### PR TITLE
wip(config-global): add config, cli test jest

### DIFF
--- a/apps/cli/jest.config.cjs
+++ b/apps/cli/jest.config.cjs
@@ -1,0 +1,25 @@
+/** @type {import('@jest/types').Config.InitialOptions} */
+module.exports = {
+  displayName: 'cli',
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      { tsconfig: '<rootDir>/tsconfig.spec.json', diagnostics: false },
+    ],
+  },
+  moduleFileExtensions: ['ts', 'js', 'json'],
+  testMatch: ['<rootDir>/src/**/*.spec.ts'],
+  moduleNameMapper: {
+    '^shared-kernel$': '<rootDir>/../../libs/shared/kernel/src/index.ts',
+    '^shared-kernel/(.*)$': '<rootDir>/../../libs/shared/kernel/src/$1',
+    '^cloud-cost-domain$': '<rootDir>/../../libs/cloud-cost/domain/src/index.ts',
+    '^cloud-cost-domain/(.*)$': '<rootDir>/../../libs/cloud-cost/domain/src/$1',
+    '^cloud-cost-application$': '<rootDir>/../../libs/cloud-cost/application/src/index.ts',
+    '^cloud-cost-application/(.*)$': '<rootDir>/../../libs/cloud-cost/application/src/$1',
+    '^cloud-cost-infrastructure-aws-adapter$': '<rootDir>/../../libs/cloud-cost/infrastructure/aws-adapter/src/index.ts',
+    '^cloud-cost-infrastructure-aws-adapter/(.*)$': '<rootDir>/../../libs/cloud-cost/infrastructure/aws-adapter/src/$1',
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
+};

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -4,6 +4,16 @@
   "private": true,
   "nx": {
     "targets": {
+      "test": {
+        "executor": "@nx/jest:jest",
+        "outputs": [
+          "{workspaceRoot}/coverage/{projectRoot}"
+        ],
+        "options": {
+          "jestConfig": "apps/cli/jest.config.cjs",
+          "passWithNoTests": true
+        }
+      },
       "build": {
         "executor": "@nx/esbuild:esbuild",
         "outputs": [

--- a/apps/cli/src/commands/analyze-waste.command.ts
+++ b/apps/cli/src/commands/analyze-waste.command.ts
@@ -3,6 +3,8 @@ import { resolve } from 'path';
 import { writeFile } from 'fs/promises';
 import {
   AwsRegion,
+  DEFAULT_IGNORE_TAG,
+  DEFAULT_MIN_AGE_DAYS,
   EbsVolumeWastePolicy,
   ElasticIpWastePolicy,
   RdsInstanceWastePolicy,
@@ -25,17 +27,21 @@ import {
   StaticPriceTableAdapter,
   resolveAwsAccountId,
 } from 'cloud-cost-infrastructure-aws-adapter';
+import { loadConfig } from '../config/cloudrift.config';
 import { formatWasteReportAsTable } from '../formatters/waste-report.table-formatter';
 import { formatWasteReportAsJson } from '../formatters/waste-report.json-formatter';
 import { generateWasteReportPdf } from '../formatters/waste-report.pdf-formatter';
 
+const DEFAULT_CLOUDWATCH_WINDOW_HOURS = 48;
+
 interface AnalyzeWasteOptions {
   regions: string[];
   accountId?: string;
+  config?: string;
   pdf?: string | boolean;
   json?: string | boolean;
-  minAgeDays: string;
-  ignoreTag: string;
+  minAgeDays?: string;
+  ignoreTag?: string;
 }
 
 function fail(message: string): void {
@@ -46,24 +52,53 @@ function fail(message: string): void {
 /**
  * Composition root: l'unico punto dove le implementazioni concrete (scanner
  * AWS, listino prezzi) vengono istanziate e iniettate nel use case.
+ *
+ * Precedenza dei parametri: flag CLI > file di config > default nel codice.
  */
 export async function analyzeWasteCommand(
   options: AnalyzeWasteOptions,
 ): Promise<void> {
+  // --json senza filename: stampa solo JSON su stdout (output machine-readable).
+  const jsonToStdout = options.json === true;
+
+  const configResult = await loadConfig(process.cwd(), options.config);
+  if (!configResult.ok) return fail(configResult.error.message);
+  const config = configResult.value;
+
+  // Periodo di grazia: CLI > config > default.
+  let minAgeDays: number;
+  if (options.minAgeDays !== undefined) {
+    minAgeDays = Number(options.minAgeDays);
+    if (!Number.isInteger(minAgeDays) || minAgeDays < 0) {
+      return fail(`--min-age-days must be a non-negative integer, got "${options.minAgeDays}".`);
+    }
+  } else {
+    minAgeDays = config.minAgeDays ?? DEFAULT_MIN_AGE_DAYS;
+  }
+
+  const ignoreTag = options.ignoreTag ?? config.ignoreTag ?? DEFAULT_IGNORE_TAG;
+  const cloudwatchWindowHours =
+    config.cloudwatchWindowHours ?? DEFAULT_CLOUDWATCH_WINDOW_HOURS;
+
+  // Regioni: parse Result-based (niente throw su input), poi esclusione da config.
+  const excluded = new Set(config.excludeRegions ?? []);
   const regions: AwsRegion[] = [];
+  const skipped: string[] = [];
   for (const code of options.regions) {
     const parsed = AwsRegion.parse(code);
     if (!parsed.ok) return fail(parsed.error.message);
+    if (excluded.has(parsed.value.code)) {
+      skipped.push(parsed.value.code);
+      continue;
+    }
     regions.push(parsed.value);
   }
 
-  const minAgeDays = Number(options.minAgeDays);
-  if (!Number.isInteger(minAgeDays) || minAgeDays < 0) {
-    return fail(`--min-age-days must be a non-negative integer, got "${options.minAgeDays}".`);
+  if (regions.length === 0) {
+    return fail(
+      'No regions left to scan: all requested regions are listed in excludeRegions.',
+    );
   }
-
-  // --json senza filename: stampa solo JSON su stdout (output machine-readable).
-  const jsonToStdout = options.json === true;
 
   const accountId = options.accountId ?? (await resolveAwsAccountId()) ?? 'unknown';
 
@@ -74,12 +109,16 @@ export async function analyzeWasteCommand(
         `\n  Scanning ${regions.map((r) => r.code).join(', ')}${accountLabel} for wasted cloud resources...\n`,
       ),
     );
+    if (skipped.length > 0) {
+      console.log(chalk.dim(`  Skipping excluded regions: ${skipped.join(', ')}\n`));
+    }
   }
 
   const pricing = new StaticPriceTableAdapter();
   const policyOptions: WastePolicyOptions = {
     minAgeDays,
-    ignoreTag: options.ignoreTag,
+    ignoreTag,
+    excludeTagValues: config.excludeTagValues,
   };
 
   const scanners: WasteScannerPort[] = [
@@ -89,7 +128,12 @@ export async function analyzeWasteCommand(
     new AwsLoadBalancerScanner(pricing, accountId, new LoadBalancerWastePolicy(policyOptions)),
     new AwsEc2InstanceScanner(pricing, accountId, new Ec2InstanceWastePolicy(policyOptions)),
     new AwsEbsSnapshotScanner(pricing, accountId, new EbsSnapshotWastePolicy(policyOptions)),
-    new AwsNatGatewayScanner(pricing, accountId, new NatGatewayWastePolicy(policyOptions)),
+    new AwsNatGatewayScanner(
+      pricing,
+      accountId,
+      new NatGatewayWastePolicy(policyOptions),
+      cloudwatchWindowHours,
+    ),
   ];
 
   const useCase = new AnalyzeCloudWasteUseCase(scanners);
@@ -126,5 +170,20 @@ export async function analyzeWasteCommand(
     process.stdout.write(chalk.bold(`  Generating PDF report...`));
     await generateWasteReportPdf(result.value, meta, outputPath);
     console.log(chalk.green(` saved to ${outputPath}\n`));
+  }
+
+  // Soglia di costo per le pipeline: exit code 2 quando il totale la supera.
+  // Il messaggio va su stderr per non sporcare l'output machine-readable su stdout.
+  if (
+    config.costAlertThresholdUsd !== undefined &&
+    result.value.totalMonthlyCostUsd > config.costAlertThresholdUsd
+  ) {
+    console.error(
+      chalk.red.bold(
+        `\n  Cost threshold exceeded: $${result.value.totalMonthlyCostUsd.toFixed(2)}/mo ` +
+          `> $${config.costAlertThresholdUsd.toFixed(2)}/mo threshold.\n`,
+      ),
+    );
+    process.exitCode = 2;
   }
 }

--- a/apps/cli/src/config/cloudrift.config.spec.ts
+++ b/apps/cli/src/config/cloudrift.config.spec.ts
@@ -1,0 +1,137 @@
+import { mkdtemp, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { loadConfig, parseConfig } from './cloudrift.config';
+
+describe('parseConfig', () => {
+  it('parses a fully valid config', () => {
+    const result = parseConfig(
+      JSON.stringify({
+        excludeRegions: ['us-east-1'],
+        excludeTagValues: { Environment: 'Production' },
+        cloudwatchWindowHours: 168,
+        minAgeDays: 14,
+        ignoreTag: 'keep',
+        costAlertThresholdUsd: 500,
+      }),
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toEqual({
+        excludeRegions: ['us-east-1'],
+        excludeTagValues: { Environment: 'Production' },
+        cloudwatchWindowHours: 168,
+        minAgeDays: 14,
+        ignoreTag: 'keep',
+        costAlertThresholdUsd: 500,
+      });
+    }
+  });
+
+  it('returns empty config for an empty object', () => {
+    const result = parseConfig('{}');
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toEqual({});
+  });
+
+  it('ignores unknown keys (forward-compatible)', () => {
+    const result = parseConfig(JSON.stringify({ minAgeDays: 3, futureKnob: true }));
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toEqual({ minAgeDays: 3 });
+  });
+
+  it('fails on invalid JSON', () => {
+    const result = parseConfig('{ not json');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toContain('not valid JSON');
+  });
+
+  it('fails when the root is not an object', () => {
+    const result = parseConfig('[1, 2, 3]');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toContain('must be a JSON object');
+  });
+
+  it('rejects a cloudwatchWindowHours above the 7-day cap', () => {
+    const result = parseConfig(JSON.stringify({ cloudwatchWindowHours: 200 }));
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toContain('cloudwatchWindowHours');
+  });
+
+  it('rejects a negative cost threshold', () => {
+    const result = parseConfig(JSON.stringify({ costAlertThresholdUsd: -1 }));
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toContain('costAlertThresholdUsd');
+  });
+
+  it('rejects excludeTagValues with non-string values', () => {
+    const result = parseConfig(JSON.stringify({ excludeTagValues: { Environment: 123 } }));
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toContain('excludeTagValues');
+  });
+
+  it('aggregates multiple validation errors', () => {
+    const result = parseConfig(
+      JSON.stringify({ minAgeDays: -1, ignoreTag: '', excludeRegions: 'us-east-1' }),
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain('minAgeDays');
+      expect(result.error.message).toContain('ignoreTag');
+      expect(result.error.message).toContain('excludeRegions');
+    }
+  });
+});
+
+describe('loadConfig', () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'cloudrift-cfg-'));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('returns empty config when no file is present', async () => {
+    const result = await loadConfig(dir);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toEqual({});
+  });
+
+  it('loads cloudrift.config.json from the cwd', async () => {
+    await writeFile(join(dir, 'cloudrift.config.json'), JSON.stringify({ minAgeDays: 30 }));
+    const result = await loadConfig(dir);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value.minAgeDays).toBe(30);
+  });
+
+  it('prefers cloudrift.config.json over .cloudriftrc', async () => {
+    await writeFile(join(dir, 'cloudrift.config.json'), JSON.stringify({ minAgeDays: 1 }));
+    await writeFile(join(dir, '.cloudriftrc'), JSON.stringify({ minAgeDays: 2 }));
+    const result = await loadConfig(dir);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value.minAgeDays).toBe(1);
+  });
+
+  it('falls back to .cloudriftrc when the primary file is absent', async () => {
+    await writeFile(join(dir, '.cloudriftrc'), JSON.stringify({ ignoreTag: 'keep' }));
+    const result = await loadConfig(dir);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value.ignoreTag).toBe('keep');
+  });
+
+  it('fails when an explicit config path does not exist', async () => {
+    const result = await loadConfig(dir, 'missing.json');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toContain('not found');
+  });
+
+  it('loads from an explicit config path', async () => {
+    await writeFile(join(dir, 'custom.json'), JSON.stringify({ costAlertThresholdUsd: 100 }));
+    const result = await loadConfig(dir, 'custom.json');
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value.costAlertThresholdUsd).toBe(100);
+  });
+});

--- a/apps/cli/src/config/cloudrift.config.ts
+++ b/apps/cli/src/config/cloudrift.config.ts
@@ -1,0 +1,168 @@
+import { readFile } from 'fs/promises';
+import { resolve } from 'path';
+import { DomainError, Result } from 'shared-kernel';
+
+/**
+ * Nomi di file cercati nel CWD, in ordine di priorità.
+ */
+const CONFIG_FILENAMES = ['cloudrift.config.json', '.cloudriftrc'] as const;
+
+/** Finestra CloudWatch massima consentita (7 giorni). */
+export const MAX_CLOUDWATCH_WINDOW_HOURS = 168;
+
+/**
+ * Configurazione opzionale letta da `cloudrift.config.json` o `.cloudriftrc`.
+ * Ogni campo è opzionale: i flag CLI hanno la precedenza, poi il file di
+ * config, poi i default nel codice.
+ */
+export interface CloudriftConfig {
+  /** Regioni da escludere dallo scan anche se passate via -r. */
+  excludeRegions?: string[];
+  /** Coppie tag=valore che escludono una risorsa (es. { "Environment": "Production" }). */
+  excludeTagValues?: Record<string, string>;
+  /** Finestra temporale (ore) per le metriche CloudWatch. Default 48, max 168. */
+  cloudwatchWindowHours?: number;
+  /** Periodo di grazia in giorni. Override di --min-age-days. */
+  minAgeDays?: number;
+  /** Tag di esclusione esplicita. Override di --ignore-tag. */
+  ignoreTag?: string;
+  /** Soglia di costo mensile: se superata, il comando esce con codice 2 (utile in CI). */
+  costAlertThresholdUsd?: number;
+}
+
+export class ConfigError extends DomainError {
+  constructor(message: string) {
+    super('INVALID_CONFIG', message);
+  }
+}
+
+/**
+ * Carica la configurazione dal CWD (o da un percorso esplicito).
+ * Nessun file trovato → config vuota (tutto da CLI/default).
+ */
+export async function loadConfig(
+  cwd: string,
+  explicitPath?: string,
+): Promise<Result<CloudriftConfig, ConfigError>> {
+  if (explicitPath) {
+    const path = resolve(cwd, explicitPath);
+    const raw = await tryRead(path);
+    if (raw === undefined) {
+      return Result.fail(new ConfigError(`Config file not found: ${path}`));
+    }
+    return parseConfig(raw, path);
+  }
+
+  for (const name of CONFIG_FILENAMES) {
+    const path = resolve(cwd, name);
+    const raw = await tryRead(path);
+    if (raw !== undefined) return parseConfig(raw, path);
+  }
+  return Result.ok({});
+}
+
+async function tryRead(path: string): Promise<string | undefined> {
+  try {
+    return await readFile(path, 'utf8');
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Validazione pura del contenuto del file (separata dall'IO per testabilità).
+ * Chiavi sconosciute vengono ignorate (forward-compatible); le chiavi note
+ * vengono validate per tipo e l'errore aggrega tutti i problemi trovati.
+ */
+export function parseConfig(
+  raw: string,
+  source = '<config>',
+): Result<CloudriftConfig, ConfigError> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return Result.fail(new ConfigError(`Config file is not valid JSON: ${source}`));
+  }
+
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    return Result.fail(new ConfigError(`Config root must be a JSON object: ${source}`));
+  }
+
+  const obj = parsed as Record<string, unknown>;
+  const config: CloudriftConfig = {};
+  const errors: string[] = [];
+
+  if (obj.excludeRegions !== undefined) {
+    if (isStringArray(obj.excludeRegions)) {
+      config.excludeRegions = obj.excludeRegions;
+    } else {
+      errors.push('excludeRegions must be an array of strings');
+    }
+  }
+
+  if (obj.excludeTagValues !== undefined) {
+    if (isStringRecord(obj.excludeTagValues)) {
+      config.excludeTagValues = obj.excludeTagValues;
+    } else {
+      errors.push(
+        'excludeTagValues must be an object with string values (e.g. { "Environment": "Production" })',
+      );
+    }
+  }
+
+  if (obj.cloudwatchWindowHours !== undefined) {
+    const n = obj.cloudwatchWindowHours;
+    if (typeof n === 'number' && Number.isFinite(n) && n > 0 && n <= MAX_CLOUDWATCH_WINDOW_HOURS) {
+      config.cloudwatchWindowHours = n;
+    } else {
+      errors.push(`cloudwatchWindowHours must be a number between 1 and ${MAX_CLOUDWATCH_WINDOW_HOURS}`);
+    }
+  }
+
+  if (obj.minAgeDays !== undefined) {
+    const n = obj.minAgeDays;
+    if (typeof n === 'number' && Number.isInteger(n) && n >= 0) {
+      config.minAgeDays = n;
+    } else {
+      errors.push('minAgeDays must be a non-negative integer');
+    }
+  }
+
+  if (obj.ignoreTag !== undefined) {
+    if (typeof obj.ignoreTag === 'string' && obj.ignoreTag.length > 0) {
+      config.ignoreTag = obj.ignoreTag;
+    } else {
+      errors.push('ignoreTag must be a non-empty string');
+    }
+  }
+
+  if (obj.costAlertThresholdUsd !== undefined) {
+    const n = obj.costAlertThresholdUsd;
+    if (typeof n === 'number' && Number.isFinite(n) && n >= 0) {
+      config.costAlertThresholdUsd = n;
+    } else {
+      errors.push('costAlertThresholdUsd must be a non-negative number');
+    }
+  }
+
+  if (errors.length > 0) {
+    return Result.fail(
+      new ConfigError(`Invalid config (${source}):\n  - ${errors.join('\n  - ')}`),
+    );
+  }
+  return Result.ok(config);
+}
+
+function isStringArray(v: unknown): v is string[] {
+  return Array.isArray(v) && v.every((item) => typeof item === 'string');
+}
+
+function isStringRecord(v: unknown): v is Record<string, string> {
+  return (
+    typeof v === 'object' &&
+    v !== null &&
+    !Array.isArray(v) &&
+    Object.values(v).every((val) => typeof val === 'string')
+  );
+}

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -20,14 +20,16 @@ program
     'AWS account ID override (auto-detected via STS when omitted)',
   )
   .option(
+    '--config <path>',
+    'path to a cloudrift config file (defaults to cloudrift.config.json / .cloudriftrc in the cwd)',
+  )
+  .option(
     '--min-age-days <days>',
-    'grace period: resources younger than this many days are not reported',
-    '7',
+    'grace period: resources younger than this many days are not reported (default 7, overrides config)',
   )
   .option(
     '--ignore-tag <tag>',
-    'resources carrying this tag are excluded from the report',
-    'cloudrift:ignore',
+    'resources carrying this tag are excluded from the report (default cloudrift:ignore, overrides config)',
   )
   .option(
     '--pdf [filename]',

--- a/apps/cli/tsconfig.app.json
+++ b/apps/cli/tsconfig.app.json
@@ -7,7 +7,7 @@
     "tsBuildInfoFile": "dist/tsconfig.app.tsbuildinfo"
   },
   "include": ["src/**/*.ts"],
-  "exclude": [],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"],
   "references": [
     {
       "path": "../../libs/shared/kernel/tsconfig.lib.json"

--- a/apps/cli/tsconfig.spec.json
+++ b/apps/cli/tsconfig.spec.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "outDir": "./dist/test",
+    "types": ["jest", "node"],
+    "strict": true,
+    "esModuleInterop": true
+  },
+  "include": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/cloudrift.config.example.json
+++ b/cloudrift.config.example.json
@@ -1,0 +1,10 @@
+{
+  "excludeRegions": ["us-gov-east-1", "us-gov-west-1"],
+  "excludeTagValues": {
+    "Environment": "Production"
+  },
+  "cloudwatchWindowHours": 168,
+  "minAgeDays": 14,
+  "ignoreTag": "cloudrift:ignore",
+  "costAlertThresholdUsd": 500
+}

--- a/libs/cloud-cost/domain/src/policies/resource-waste-policies.spec.ts
+++ b/libs/cloud-cost/domain/src/policies/resource-waste-policies.spec.ts
@@ -76,6 +76,36 @@ describe('EbsVolumeWastePolicy', () => {
   });
 });
 
+describe('WastePolicy excludeTagValues', () => {
+  it('excludes a resource whose tag matches an excluded key=value', () => {
+    const policy = new EbsVolumeWastePolicy({
+      excludeTagValues: { Environment: 'Production' },
+    });
+    const verdict = policy.evaluate(
+      makeVolume({ tags: { Environment: 'Production' } }),
+      now,
+    );
+    expect(verdict.isWaste).toBe(false);
+    expect(verdict.reason).toContain('Environment=Production');
+  });
+
+  it('does not exclude when the tag value differs', () => {
+    const policy = new EbsVolumeWastePolicy({
+      excludeTagValues: { Environment: 'Production' },
+    });
+    expect(
+      policy.evaluate(makeVolume({ tags: { Environment: 'Staging' } }), now).isWaste,
+    ).toBe(true);
+  });
+
+  it('does not exclude when the tag key is absent', () => {
+    const policy = new EbsVolumeWastePolicy({
+      excludeTagValues: { Environment: 'Production' },
+    });
+    expect(policy.evaluate(makeVolume({ tags: {} }), now).isWaste).toBe(true);
+  });
+});
+
 describe('ElasticIpWastePolicy', () => {
   const policy = new ElasticIpWastePolicy();
 

--- a/libs/cloud-cost/domain/src/policies/waste-policy.ts
+++ b/libs/cloud-cost/domain/src/policies/waste-policy.ts
@@ -10,6 +10,11 @@ export interface WastePolicyOptions {
   minAgeDays?: number;
   /** Tag che esclude esplicitamente una risorsa dal report. */
   ignoreTag?: string;
+  /**
+   * Coppie tag=valore che escludono una risorsa dal report
+   * (es. { Environment: 'Production' }). Il match è esatto, case-sensitive.
+   */
+  excludeTagValues?: Record<string, string>;
 }
 
 export const DEFAULT_MIN_AGE_DAYS = 7;
@@ -33,15 +38,22 @@ export function notWaste(reason: string): WasteVerdict {
 export abstract class WastePolicy<T extends WastedResource> {
   protected readonly minAgeDays: number;
   protected readonly ignoreTag: string;
+  protected readonly excludeTagValues: Record<string, string>;
 
   constructor(options: WastePolicyOptions = {}) {
     this.minAgeDays = options.minAgeDays ?? DEFAULT_MIN_AGE_DAYS;
     this.ignoreTag = options.ignoreTag ?? DEFAULT_IGNORE_TAG;
+    this.excludeTagValues = options.excludeTagValues ?? {};
   }
 
   evaluate(resource: T, now: Date = new Date()): WasteVerdict {
     if (this.ignoreTag in resource.tags) {
       return notWaste(`excluded by tag ${this.ignoreTag}`);
+    }
+    for (const [key, value] of Object.entries(this.excludeTagValues)) {
+      if (resource.tags[key] === value) {
+        return notWaste(`excluded by tag ${key}=${value}`);
+      }
     }
     return this.judge(resource, now);
   }

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-nat-gateway.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-nat-gateway.scanner.ts
@@ -19,7 +19,7 @@ import { AwsAdapterError } from '../errors/aws-adapter.error';
 import { paginate } from '../utils/paginate';
 import { mapWithConcurrency } from '../utils/map-with-concurrency';
 
-const LOOKBACK_HOURS = 48;
+const DEFAULT_LOOKBACK_HOURS = 48;
 // Limita le chiamate CloudWatch simultanee per non incorrere in throttling
 // su account con molti NAT Gateway.
 const CLOUDWATCH_CONCURRENCY = 5;
@@ -31,6 +31,7 @@ export class AwsNatGatewayScanner implements WasteScannerPort {
     private readonly pricing: PricingPort,
     private readonly accountId = 'unknown',
     private readonly policy = new NatGatewayWastePolicy(),
+    private readonly windowHours = DEFAULT_LOOKBACK_HOURS,
   ) {}
 
   async scan(region: AwsRegion): Promise<Result<WastedResource[]>> {
@@ -50,7 +51,7 @@ export class AwsNatGatewayScanner implements WasteScannerPort {
       if (gateways.length === 0) return Result.ok([]);
 
       const endTime = new Date();
-      const startTime = new Date(endTime.getTime() - LOOKBACK_HOURS * 60 * 60 * 1000);
+      const startTime = new Date(endTime.getTime() - this.windowHours * 60 * 60 * 1000);
       const monthlyCostUsd = this.pricing.getNatGatewayPricePerMonth(region);
 
       const bytesPerGateway = await mapWithConcurrency(
@@ -64,7 +65,7 @@ export class AwsNatGatewayScanner implements WasteScannerPort {
               Dimensions: [{ Name: 'NatGatewayId', Value: gw.NatGatewayId! }],
               StartTime: startTime,
               EndTime: endTime,
-              Period: LOOKBACK_HOURS * 3600,
+              Period: this.windowHours * 3600,
               Statistics: ['Sum'],
             }),
           );
@@ -84,7 +85,7 @@ export class AwsNatGatewayScanner implements WasteScannerPort {
               createTime: gw.CreateTime ?? new Date(0),
               detectedAt: now,
               bytesOutLastWindow: bytesPerGateway[index],
-              metricWindowHours: LOOKBACK_HOURS,
+              metricWindowHours: this.windowHours,
               tags: Object.fromEntries(
                 (gw.Tags ?? []).map((t) => [t.Key ?? '', t.Value ?? '']),
               ),


### PR DESCRIPTION
## Fase 1.1 completata ✅

**Dominio** — `WastePolicyOptions.excludeTagValues`: la base `WastePolicy.evaluate()` ora esclude le risorse il cui tag combacia con una coppia `chiave=valore` (es. `Environment=Production`), oltre all'`ignoreTag` singolo. +3 test.

**CLI** — nuovo `apps/cli/src/config/cloudrift.config.ts`:

- `loadConfig(cwd, explicitPath?)` cerca `cloudrift.config.json` poi `.cloudriftrc`; `parseConfig` puro e testabile separato dall'IO
- Validazione per-campo con errori aggregati; chiavi sconosciute ignorate (forward-compatible)
- `--config <path>` per puntare a un file esplicito

**Precedenza** CLI > config > default, cablata in `analyze-waste.command.ts`: rimossi i default Commander da `--min-age-days`/`--ignore-tag` perché altrimenti avrebbero sempre vinto sul file.

**Comportamenti config** — tutto wired e testato:

- `excludeRegions` filtra le regioni (e se le esclude tutte, errore pulito)
- `cloudwatchWindowHours` passato al NAT scanner (era `const LOOKBACK_HOURS = 48` hardcoded → ora parametrico, default 48, max 168)
- `costAlertThresholdUsd` → **exit code 2** se il totale supera la soglia (il segnale che fa fallire la pipeline), messaggio su stderr per non sporcare l'output machine-readable

**Infra di test** — la CLI non aveva setup jest: aggiunti `jest.config.cjs`, `tsconfig.spec.json`, target `test` esplicito in `package.json` (l'inferenza nx del plugin jest non crea il target per `apps/*`, solo per `libs/*/*`).

**Verifica:** typecheck ✅ · lint ✅ (0 errori) · test ✅ (domain 88, aws-adapter 74, cli 15 nuovi) · build ✅ · smoke test dei 3 path di errore (config invalida, file mancante, regioni tutte escluse) → exit 1 con messaggi puliti **prima** di toccare AWS.

Aggiunto `cloudrift.config.example.json` a documentazione dei campi.

> [!NOTE]
> L'unico ramo non testabile in locale è l'exit-2 sulla soglia (serve uno scan reale con findings), la logica c'è ed è banale; la documenterò e la mostrerò nel workflow CI alla Fase 1.4.