### PR TITLE
feat(detection): add gp2→gp3 upgrade savings check

### DIFF
--- a/apps/cli/src/commands/analyze-waste.command.ts
+++ b/apps/cli/src/commands/analyze-waste.command.ts
@@ -12,6 +12,7 @@ import {
   Ec2InstanceWastePolicy,
   EbsSnapshotWastePolicy,
   NatGatewayWastePolicy,
+  Gp2UpgradePolicy,
 } from 'cloud-cost-domain';
 import type { WastePolicyOptions, WasteScannerPort } from 'cloud-cost-domain';
 import { AnalyzeCloudWasteUseCase } from 'cloud-cost-application';
@@ -24,6 +25,7 @@ import {
   AwsEc2InstanceScanner,
   AwsEbsSnapshotScanner,
   AwsNatGatewayScanner,
+  AwsGp2UpgradeScanner,
   StaticPriceTableAdapter,
   resolveAwsAccountId,
 } from 'cloud-cost-infrastructure-aws-adapter';
@@ -134,6 +136,7 @@ export async function analyzeWasteCommand(
       new NatGatewayWastePolicy(policyOptions),
       cloudwatchWindowHours,
     ),
+    new AwsGp2UpgradeScanner(pricing, accountId, new Gp2UpgradePolicy(policyOptions)),
   ];
 
   const useCase = new AnalyzeCloudWasteUseCase(scanners);

--- a/apps/cli/src/formatters/resource-presenters.ts
+++ b/apps/cli/src/formatters/resource-presenters.ts
@@ -98,6 +98,14 @@ export const presenters: PresenterMap = {
     recommend: (gw) =>
       `Delete idle NAT Gateway ${gw.id} in ${gw.region.code} — ${gw.wasteReason}`,
   },
+  'ebs-gp2-upgrade': {
+    title: 'EBS Volumes — gp2→gp3 upgrade (savings opportunity, not deletable waste)',
+    head: ['Volume ID', 'Region', 'Size', 'Created'],
+    colWidths: [170, 90, 60, 96, 80],
+    row: (v) => [v.id, v.region.code, `${v.sizeGb} GB`, day(v.createTime)],
+    recommend: (v) =>
+      `Modify EBS ${v.id} (${v.sizeGb} GB gp2) in ${v.region.code} to gp3 — saves ${v.costEstimate.format()}, no downtime`,
+  },
 };
 
 export function presenterFor(kind: ResourceKind): ResourcePresenter {

--- a/libs/cloud-cost/domain/src/entities/gp2-volume.entity.ts
+++ b/libs/cloud-cost/domain/src/entities/gp2-volume.entity.ts
@@ -1,0 +1,56 @@
+import { Entity } from 'shared-kernel';
+import { AwsRegion } from '../value-objects/aws-region.value-object';
+import { CostEstimate } from '../value-objects/cost-estimate.value-object';
+import type { WastedResource } from '../wasted-resource';
+
+/**
+ * Volume EBS gp2 *attaccato e in uso*, candidato all'upgrade a gp3.
+ * Non è spreco da cancellare: è un'ottimizzazione a costo zero (gp3 ha lo
+ * stesso baseline di performance ma costa meno). `monthlyCostUsd` qui
+ * rappresenta il *risparmio* mensile, non il costo della risorsa.
+ *
+ * I volumi gp2 *non* attaccati (state=available) sono gestiti come spreco
+ * dal flusso `ebs-volume`, quindi non vengono mai conteggiati due volte.
+ */
+export interface Gp2VolumeProps {
+  volumeId: string;
+  region: AwsRegion;
+  accountId: string;
+  sizeGb: number;
+  createTime: Date;
+  detectedAt: Date;
+  tags: Record<string, string>;
+  /** Risparmio mensile stimato passando da gp2 a gp3, in USD. */
+  monthlyCostUsd: number;
+}
+
+export class Gp2Volume extends Entity<string> implements WastedResource {
+  private readonly props: Readonly<Gp2VolumeProps>;
+
+  constructor(props: Gp2VolumeProps) {
+    super(props.volumeId);
+    this.props = Object.freeze({ ...props });
+  }
+
+  get region(): AwsRegion { return this.props.region; }
+  get accountId(): string { return this.props.accountId; }
+  get sizeGb(): number { return this.props.sizeGb; }
+  get createTime(): Date { return this.props.createTime; }
+  get detectedAt(): Date { return this.props.detectedAt; }
+  get tags(): Record<string, string> { return this.props.tags; }
+
+  get kind(): 'ebs-gp2-upgrade' { return 'ebs-gp2-upgrade'; }
+
+  get wasteReason(): string {
+    return `gp2 → gp3 saves $${this.props.monthlyCostUsd.toFixed(2)}/mo (same baseline performance)`;
+  }
+
+  get monthlySavingUsd(): number { return this.props.monthlyCostUsd; }
+
+  get costEstimate(): CostEstimate {
+    return CostEstimate.of(
+      this.props.monthlyCostUsd,
+      `${this.props.sizeGb} GB gp2 → gp3 saving`,
+    );
+  }
+}

--- a/libs/cloud-cost/domain/src/group-by-kind.ts
+++ b/libs/cloud-cost/domain/src/group-by-kind.ts
@@ -6,6 +6,7 @@ import type { LoadBalancer } from './entities/load-balancer.entity';
 import type { Ec2Instance } from './entities/ec2-instance.entity';
 import type { EbsSnapshot } from './entities/ebs-snapshot.entity';
 import type { NatGateway } from './entities/nat-gateway.entity';
+import type { Gp2Volume } from './entities/gp2-volume.entity';
 
 /**
  * Mappa kind → entità concreta. Permette ai consumer (formatter, frontend)
@@ -19,6 +20,7 @@ export interface ResourceKindMap {
   'ec2-instance': Ec2Instance;
   'ebs-snapshot': EbsSnapshot;
   'nat-gateway': NatGateway;
+  'ebs-gp2-upgrade': Gp2Volume;
 }
 
 export type FindingsByKind = {

--- a/libs/cloud-cost/domain/src/index.ts
+++ b/libs/cloud-cost/domain/src/index.ts
@@ -19,6 +19,8 @@ export { EbsSnapshot } from './entities/ebs-snapshot.entity';
 export type { EbsSnapshotProps } from './entities/ebs-snapshot.entity';
 export { NatGateway } from './entities/nat-gateway.entity';
 export type { NatGatewayProps } from './entities/nat-gateway.entity';
+export { Gp2Volume } from './entities/gp2-volume.entity';
+export type { Gp2VolumeProps } from './entities/gp2-volume.entity';
 
 // Value Objects
 export { AwsRegion, InvalidAwsRegionError } from './value-objects/aws-region.value-object';
@@ -41,6 +43,7 @@ export {
   Ec2InstanceWastePolicy,
   EbsSnapshotWastePolicy,
   NatGatewayWastePolicy,
+  Gp2UpgradePolicy,
 } from './policies/resource-waste-policies';
 
 // Outbound Ports

--- a/libs/cloud-cost/domain/src/policies/resource-waste-policies.spec.ts
+++ b/libs/cloud-cost/domain/src/policies/resource-waste-policies.spec.ts
@@ -6,6 +6,7 @@ import {
   Ec2InstanceWastePolicy,
   EbsSnapshotWastePolicy,
   NatGatewayWastePolicy,
+  Gp2UpgradePolicy,
 } from './resource-waste-policies';
 import { DEFAULT_IGNORE_TAG } from './waste-policy';
 import { EbsVolume } from '../entities/ebs-volume.entity';
@@ -15,6 +16,7 @@ import { LoadBalancer } from '../entities/load-balancer.entity';
 import { Ec2Instance } from '../entities/ec2-instance.entity';
 import { EbsSnapshot } from '../entities/ebs-snapshot.entity';
 import { NatGateway } from '../entities/nat-gateway.entity';
+import { Gp2Volume } from '../entities/gp2-volume.entity';
 import type { EbsSnapshotProps } from '../entities/ebs-snapshot.entity';
 import type { Ec2InstanceProps } from '../entities/ec2-instance.entity';
 import { AwsRegion } from '../value-objects/aws-region.value-object';
@@ -305,5 +307,44 @@ describe('NatGatewayWastePolicy', () => {
 
   it('does not flag a freshly created gateway (grace period)', () => {
     expect(policy.evaluate(makeGateway(0, yesterday), now).isWaste).toBe(false);
+  });
+});
+
+describe('Gp2UpgradePolicy', () => {
+  const policy = new Gp2UpgradePolicy();
+
+  function makeGp2Volume(
+    overrides: { createTime?: Date; tags?: Record<string, string> } = {},
+  ): Gp2Volume {
+    return new Gp2Volume({
+      volumeId: 'vol-gp2',
+      region,
+      accountId: '123456789012',
+      sizeGb: 200,
+      createTime: overrides.createTime ?? oldDate,
+      detectedAt: now,
+      tags: overrides.tags ?? {},
+      monthlyCostUsd: 4, // (0.10 - 0.08) * 200
+    });
+  }
+
+  it('flags an old gp2 volume as an upgrade opportunity', () => {
+    expect(policy.evaluate(makeGp2Volume(), now).isWaste).toBe(true);
+  });
+
+  it('does not flag a freshly created gp2 volume (grace period)', () => {
+    expect(policy.evaluate(makeGp2Volume({ createTime: yesterday }), now).isWaste).toBe(false);
+  });
+
+  it('does not flag a gp2 volume carrying the ignore tag', () => {
+    const verdict = policy.evaluate(
+      makeGp2Volume({ tags: { [DEFAULT_IGNORE_TAG]: 'true' } }),
+      now,
+    );
+    expect(verdict.isWaste).toBe(false);
+  });
+
+  it('reports the saving in the wasteReason', () => {
+    expect(makeGp2Volume().wasteReason).toContain('saves $4.00/mo');
   });
 });

--- a/libs/cloud-cost/domain/src/policies/resource-waste-policies.ts
+++ b/libs/cloud-cost/domain/src/policies/resource-waste-policies.ts
@@ -6,6 +6,7 @@ import type { LoadBalancer } from '../entities/load-balancer.entity';
 import type { Ec2Instance } from '../entities/ec2-instance.entity';
 import type { EbsSnapshot } from '../entities/ebs-snapshot.entity';
 import type { NatGateway } from '../entities/nat-gateway.entity';
+import type { Gp2Volume } from '../entities/gp2-volume.entity';
 
 export class EbsVolumeWastePolicy extends WastePolicy<EbsVolume> {
   protected judge(volume: EbsVolume, now: Date): WasteVerdict {
@@ -79,5 +80,17 @@ export class NatGatewayWastePolicy extends WastePolicy<NatGateway> {
       return notWaste(`created less than ${this.minAgeDays}d ago`);
     }
     return waste(`zero traffic in last ${gateway.metricWindowHours}h`);
+  }
+}
+
+export class Gp2UpgradePolicy extends WastePolicy<Gp2Volume> {
+  protected judge(volume: Gp2Volume, now: Date): WasteVerdict {
+    // Il prefiltro server-side garantisce già volume-type=gp2 in-use;
+    // applichiamo solo il periodo di grazia per non segnalare risorse
+    // appena create (infrastruttura ancora in fase di setup).
+    if (this.isWithinGracePeriod(volume.createTime, now)) {
+      return notWaste(`created less than ${this.minAgeDays}d ago`);
+    }
+    return waste('gp2 volume upgradeable to gp3');
   }
 }

--- a/libs/cloud-cost/domain/src/wasted-resource.ts
+++ b/libs/cloud-cost/domain/src/wasted-resource.ts
@@ -9,6 +9,7 @@ export const RESOURCE_KINDS = [
   'ec2-instance',
   'ebs-snapshot',
   'nat-gateway',
+  'ebs-gp2-upgrade',
 ] as const;
 
 export type ResourceKind = (typeof RESOURCE_KINDS)[number];
@@ -21,6 +22,7 @@ export const RESOURCE_KIND_LABELS: Record<ResourceKind, string> = {
   'ec2-instance': 'EC2 Instances',
   'ebs-snapshot': 'EBS Snapshots',
   'nat-gateway': 'NAT Gateways',
+  'ebs-gp2-upgrade': 'EBS gp2→gp3 Upgrades',
 };
 
 /**

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/index.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/index.ts
@@ -5,6 +5,7 @@ export { AwsLoadBalancerScanner } from './scanners/aws-load-balancer.scanner';
 export { AwsEc2InstanceScanner } from './scanners/aws-ec2-instance.scanner';
 export { AwsEbsSnapshotScanner } from './scanners/aws-ebs-snapshot.scanner';
 export { AwsNatGatewayScanner } from './scanners/aws-nat-gateway.scanner';
+export { AwsGp2UpgradeScanner } from './scanners/aws-gp2-upgrade.scanner';
 export { AwsAdapterError } from './errors/aws-adapter.error';
 export { StaticPriceTableAdapter } from './pricing/static-price-table.adapter';
 export { resolveAwsAccountId } from './account/aws-account-id.resolver';

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-gp2-upgrade.scanner.spec.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-gp2-upgrade.scanner.spec.ts
@@ -1,0 +1,139 @@
+import { EC2Client, DescribeVolumesCommand } from '@aws-sdk/client-ec2';
+import { AwsGp2UpgradeScanner } from './aws-gp2-upgrade.scanner';
+import { AwsRegion, type Gp2Volume } from 'cloud-cost-domain';
+import { AwsAdapterError } from '../errors/aws-adapter.error';
+import { mockPricing } from '../testing/mock-pricing';
+
+jest.mock('@aws-sdk/client-ec2');
+
+const mockSend = jest.fn();
+const mockDestroy = jest.fn();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (EC2Client as jest.Mock).mockImplementation(() => ({
+    send: mockSend,
+    destroy: mockDestroy,
+  }));
+});
+
+const region = AwsRegion.create('us-east-1');
+const scanner = new AwsGp2UpgradeScanner(mockPricing);
+const OLD_DATE = new Date('2025-01-01');
+
+describe('AwsGp2UpgradeScanner', () => {
+  it('exposes its resource kind', () => {
+    expect(scanner.kind).toBe('ebs-gp2-upgrade');
+  });
+
+  it('maps gp2 volumes and computes the gp2→gp3 monthly saving', async () => {
+    mockSend.mockResolvedValueOnce({
+      Volumes: [
+        {
+          VolumeId: 'vol-gp2a',
+          Size: 200,
+          VolumeType: 'gp2',
+          State: 'in-use',
+          CreateTime: OLD_DATE,
+          Tags: [{ Key: 'Name', Value: 'data' }],
+        },
+      ],
+    });
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value).toHaveLength(1);
+
+    const vol = result.value[0] as Gp2Volume;
+    expect(vol.id).toBe('vol-gp2a');
+    expect(vol.kind).toBe('ebs-gp2-upgrade');
+    // (0.10 - 0.08) * 200 = 4.00
+    expect(vol.costEstimate.monthlyCostUsd).toBeCloseTo(4, 2);
+    expect(vol.wasteReason).toContain('saves $4.00/mo');
+  });
+
+  it('filters server-side on volume-type=gp2 AND status=in-use (no double counting)', async () => {
+    mockSend.mockResolvedValueOnce({ Volumes: [] });
+
+    await scanner.scan(region);
+
+    const args = (DescribeVolumesCommand as unknown as jest.Mock).mock.calls[0][0];
+    expect(args.Filters).toEqual([
+      { Name: 'volume-type', Values: ['gp2'] },
+      { Name: 'status', Values: ['in-use'] },
+    ]);
+  });
+
+  it('applies the grace period: a freshly created gp2 volume is not reported', async () => {
+    mockSend.mockResolvedValueOnce({
+      Volumes: [
+        { VolumeId: 'vol-new', Size: 100, VolumeType: 'gp2', State: 'in-use', CreateTime: new Date() },
+      ],
+    });
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toHaveLength(0);
+  });
+
+  it('excludes a gp2 volume tagged cloudrift:ignore', async () => {
+    mockSend.mockResolvedValueOnce({
+      Volumes: [
+        {
+          VolumeId: 'vol-keep',
+          Size: 100,
+          VolumeType: 'gp2',
+          State: 'in-use',
+          CreateTime: OLD_DATE,
+          Tags: [{ Key: 'cloudrift:ignore', Value: 'true' }],
+        },
+      ],
+    });
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toHaveLength(0);
+  });
+
+  it('follows NextToken across pages', async () => {
+    mockSend
+      .mockResolvedValueOnce({
+        Volumes: [{ VolumeId: 'vol-p1', Size: 50, VolumeType: 'gp2', State: 'in-use', CreateTime: OLD_DATE }],
+        NextToken: 'cursor-2',
+      })
+      .mockResolvedValueOnce({
+        Volumes: [{ VolumeId: 'vol-p2', Size: 50, VolumeType: 'gp2', State: 'in-use', CreateTime: OLD_DATE }],
+      });
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.map((v) => v.id)).toEqual(['vol-p1', 'vol-p2']);
+    expect(mockSend).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns Result.fail wrapping AwsAdapterError on SDK error', async () => {
+    mockSend.mockRejectedValueOnce(new Error('Network error'));
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBeInstanceOf(AwsAdapterError);
+      expect((result.error as AwsAdapterError).service).toBe('EBS');
+    }
+  });
+
+  it('destroys the EC2Client after the call', async () => {
+    mockSend.mockResolvedValueOnce({ Volumes: [] });
+
+    await scanner.scan(region);
+
+    expect(mockDestroy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-gp2-upgrade.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-gp2-upgrade.scanner.ts
@@ -1,0 +1,80 @@
+import {
+  EC2Client,
+  DescribeVolumesCommand,
+  type Volume,
+} from '@aws-sdk/client-ec2';
+import { Result } from 'shared-kernel';
+import type {
+  AwsRegion,
+  PricingPort,
+  WasteScannerPort,
+  WastedResource,
+} from 'cloud-cost-domain';
+import { Gp2Volume, Gp2UpgradePolicy } from 'cloud-cost-domain';
+import { AwsAdapterError } from '../errors/aws-adapter.error';
+import { paginate } from '../utils/paginate';
+
+/**
+ * Rileva i volumi gp2 *attaccati e in uso* aggiornabili a gp3: stesso baseline
+ * di performance, costo inferiore. Non è spreco da cancellare, è un risparmio.
+ *
+ * Prefiltro server-side: `volume-type=gp2` AND `status=in-use`. I gp2 *non*
+ * attaccati (available) sono già gestiti dal flusso `ebs-volume`, quindi non
+ * c'è doppio conteggio.
+ */
+export class AwsGp2UpgradeScanner implements WasteScannerPort {
+  readonly kind = 'ebs-gp2-upgrade' as const;
+
+  constructor(
+    private readonly pricing: PricingPort,
+    private readonly accountId = 'unknown',
+    private readonly policy = new Gp2UpgradePolicy(),
+  ) {}
+
+  async scan(region: AwsRegion): Promise<Result<WastedResource[]>> {
+    const client = new EC2Client({ region: region.code });
+    try {
+      const rawVolumes = await paginate<Volume>(async (cursor) => {
+        const r = await client.send(
+          new DescribeVolumesCommand({
+            Filters: [
+              { Name: 'volume-type', Values: ['gp2'] },
+              { Name: 'status', Values: ['in-use'] },
+            ],
+            NextToken: cursor,
+          }),
+        );
+        return { items: r.Volumes ?? [], cursor: r.NextToken };
+      });
+
+      const gp2PricePerGb = this.pricing.getEbsVolumePricePerGbMonth(region, 'gp2');
+      const gp3PricePerGb = this.pricing.getEbsVolumePricePerGbMonth(region, 'gp3');
+      const savingPerGb = Math.max(0, gp2PricePerGb - gp3PricePerGb);
+      const now = new Date();
+
+      const volumes = rawVolumes
+        .map((v: Volume) => {
+          const sizeGb = v.Size ?? 0;
+          return new Gp2Volume({
+            volumeId: v.VolumeId!,
+            region,
+            accountId: this.accountId,
+            sizeGb,
+            createTime: v.CreateTime ?? new Date(),
+            detectedAt: now,
+            tags: Object.fromEntries(
+              (v.Tags ?? []).map((t) => [t.Key ?? '', t.Value ?? '']),
+            ),
+            monthlyCostUsd: +(savingPerGb * sizeGb).toFixed(4),
+          });
+        })
+        .filter((volume) => this.policy.evaluate(volume, now).isWaste);
+
+      return Result.ok(volumes);
+    } catch (err) {
+      return Result.fail(new AwsAdapterError('EBS', err as Error));
+    } finally {
+      client.destroy();
+    }
+  }
+}

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/testing/mock-pricing.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/testing/mock-pricing.ts
@@ -1,7 +1,8 @@
 import type { PricingPort } from 'cloud-cost-domain';
 
 export const mockPricing: PricingPort = {
-  getEbsVolumePricePerGbMonth: () => 0.08,
+  getEbsVolumePricePerGbMonth: (_region, volumeType) =>
+    volumeType === 'gp2' ? 0.1 : 0.08,
   getEbsSnapshotPricePerGbMonth: () => 0.05,
   getElasticIpPricePerMonth: () => 3.6,
   getRdsStoragePricePerGbMonth: () => 0.115,


### PR DESCRIPTION
New ResourceKind `ebs-gp2-upgrade`: flags attached (in-use) gp2 volumes
that can be upgraded to gp3 — same baseline performance, lower price.
Reports the monthly saving, not a deletion target.

- Domain: Gp2Volume entity + Gp2UpgradePolicy (grace period + ignore tag
  inherited from the base policy); wired into the ResourceKind union,
  RESOURCE_KIND_LABELS and ResourceKindMap
- Infra: AwsGp2UpgradeScanner filters server-side on volume-type=gp2 AND
  status=in-use, so unattached gp2 volumes stay owned by the ebs-volume
  waste flow (no double counting); saving = max(0, gp2-gp3 price) * GB
- CLI: presenter labelled "savings opportunity, not deletable waste";
  scanner registered in the composition root
- Tests: policy cases + scanner spec (mapping, saving, dual filter, grace
  period, ignore tag, pagination, errors, destroy); mock pricing now
  differentiates gp2 (0.10) from gp3 (0.08)

No new IAM permission (ec2:DescribeVolumes already required).
Coordinator, summary, DTO and formatters untouched.