### PR TITLE
feat(cli): add --format table|json|markdown for CI pipelines

### DIFF
--- a/apps/cli/src/commands/analyze-waste.command.ts
+++ b/apps/cli/src/commands/analyze-waste.command.ts
@@ -32,14 +32,18 @@ import {
 import { loadConfig } from '../config/cloudrift.config';
 import { formatWasteReportAsTable } from '../formatters/waste-report.table-formatter';
 import { formatWasteReportAsJson } from '../formatters/waste-report.json-formatter';
+import { formatWasteReportAsMarkdown } from '../formatters/waste-report.markdown-formatter';
 import { generateWasteReportPdf } from '../formatters/waste-report.pdf-formatter';
 
 const DEFAULT_CLOUDWATCH_WINDOW_HOURS = 48;
+const OUTPUT_FORMATS = ['table', 'json', 'markdown'] as const;
+type OutputFormat = (typeof OUTPUT_FORMATS)[number];
 
 interface AnalyzeWasteOptions {
   regions: string[];
   accountId?: string;
   config?: string;
+  format?: string;
   pdf?: string | boolean;
   json?: string | boolean;
   minAgeDays?: string;
@@ -60,8 +64,16 @@ function fail(message: string): void {
 export async function analyzeWasteCommand(
   options: AnalyzeWasteOptions,
 ): Promise<void> {
-  // --json senza filename: stampa solo JSON su stdout (output machine-readable).
-  const jsonToStdout = options.json === true;
+  const format = (options.format ?? 'table') as OutputFormat;
+  if (!OUTPUT_FORMATS.includes(format)) {
+    return fail(`--format must be one of: ${OUTPUT_FORMATS.join(', ')}. Got "${options.format}".`);
+  }
+  // In modalità machine-readable lo stdout deve contenere SOLO il report:
+  // il chrome umano (banner, conferme) viene instradato su stderr.
+  const quietStdout = format !== 'table';
+  const info = quietStdout
+    ? (msg: string) => console.error(msg)
+    : (msg: string) => console.log(msg);
 
   const configResult = await loadConfig(process.cwd(), options.config);
   if (!configResult.ok) return fail(configResult.error.message);
@@ -104,16 +116,16 @@ export async function analyzeWasteCommand(
 
   const accountId = options.accountId ?? (await resolveAwsAccountId()) ?? 'unknown';
 
-  if (!jsonToStdout) {
+  if (!quietStdout) {
     const accountLabel = accountId !== 'unknown' ? ` (account ${accountId})` : '';
     console.log(
       chalk.bold.blue(
         `\n  Scanning ${regions.map((r) => r.code).join(', ')}${accountLabel} for wasted cloud resources...\n`,
       ),
     );
-    if (skipped.length > 0) {
-      console.log(chalk.dim(`  Skipping excluded regions: ${skipped.join(', ')}\n`));
-    }
+  }
+  if (skipped.length > 0) {
+    info(chalk.dim(`  Skipping excluded regions: ${skipped.join(', ')}`));
   }
 
   const pricing = new StaticPriceTableAdapter();
@@ -151,28 +163,39 @@ export async function analyzeWasteCommand(
     pricesAsOf: pricing.getPricesAsOf(),
   };
 
-  if (jsonToStdout) {
-    console.log(formatWasteReportAsJson(result.value, meta));
+  // Il report scelto va SEMPRE su stdout (così è componibile in pipeline:
+  // `--format json | jq`, `--format markdown >> $GITHUB_STEP_SUMMARY`).
+  let rendered: string;
+  if (format === 'json') {
+    rendered = formatWasteReportAsJson(result.value, meta);
+  } else if (format === 'markdown') {
+    rendered = formatWasteReportAsMarkdown(result.value, meta, {
+      costAlertThresholdUsd: config.costAlertThresholdUsd,
+    });
   } else {
-    console.log(formatWasteReportAsTable(result.value, meta));
+    rendered = formatWasteReportAsTable(result.value, meta);
   }
+  console.log(rendered);
 
-  if (typeof options.json === 'string') {
-    const jsonPath = resolve(process.cwd(), options.json);
+  const day = meta.generatedAt.toISOString().split('T')[0];
+
+  // --json / --pdf sono artefatti su file, indipendenti dal formato di stdout.
+  if (options.json !== undefined && options.json !== false) {
+    const filename =
+      typeof options.json === 'string' ? options.json : `cloudrift-report-${day}.json`;
+    const jsonPath = resolve(process.cwd(), filename);
     await writeFile(jsonPath, formatWasteReportAsJson(result.value, meta));
-    console.log(chalk.green(`  JSON report saved to ${jsonPath}\n`));
+    info(chalk.green(`  JSON report saved to ${jsonPath}`));
   }
 
   if (options.pdf !== undefined && options.pdf !== false) {
     const filename =
-      typeof options.pdf === 'string'
-        ? options.pdf
-        : `cloudrift-report-${new Date().toISOString().split('T')[0]}.pdf`;
+      typeof options.pdf === 'string' ? options.pdf : `cloudrift-report-${day}.pdf`;
     const outputPath = resolve(process.cwd(), filename);
 
-    process.stdout.write(chalk.bold(`  Generating PDF report...`));
+    info(chalk.bold('  Generating PDF report...'));
     await generateWasteReportPdf(result.value, meta, outputPath);
-    console.log(chalk.green(` saved to ${outputPath}\n`));
+    info(chalk.green(`  PDF report saved to ${outputPath}`));
   }
 
   // Soglia di costo per le pipeline: exit code 2 quando il totale la supera.

--- a/apps/cli/src/formatters/waste-report.markdown-formatter.spec.ts
+++ b/apps/cli/src/formatters/waste-report.markdown-formatter.spec.ts
@@ -1,0 +1,111 @@
+import { AwsRegion, EbsVolume } from 'cloud-cost-domain';
+import type { WastedResourcesSummary } from 'cloud-cost-domain';
+import type { WasteReportMeta } from 'cloud-cost-application';
+import { formatWasteReportAsMarkdown } from './waste-report.markdown-formatter';
+
+const region = AwsRegion.create('us-east-1');
+
+const meta: WasteReportMeta = {
+  accountId: '123456789012',
+  regions: ['us-east-1', 'eu-west-1'],
+  generatedAt: new Date('2026-06-16T10:00:00Z'),
+  pricesAsOf: '2025-06',
+};
+
+function makeVolume(id: string, monthlyCostUsd: number): EbsVolume {
+  return new EbsVolume({
+    volumeId: id,
+    region,
+    accountId: '123456789012',
+    sizeGb: 100,
+    volumeType: 'gp3',
+    state: 'available',
+    createTime: new Date('2025-01-01'),
+    detectedAt: meta.generatedAt,
+    tags: {},
+    monthlyCostUsd,
+  });
+}
+
+describe('formatWasteReportAsMarkdown', () => {
+  it('renders the empty case', () => {
+    const summary: WastedResourcesSummary = {
+      findings: [],
+      totalMonthlyCostUsd: 0,
+      scanErrors: [],
+    };
+
+    const md = formatWasteReportAsMarkdown(summary, meta);
+
+    expect(md).toContain('No wasted resources found');
+    expect(md).toContain('prices as of 2025-06');
+  });
+
+  it('renders headline, breakdown, details and recommendations', () => {
+    const summary: WastedResourcesSummary = {
+      findings: [makeVolume('vol-aaa', 8), makeVolume('vol-bbb', 4)],
+      totalMonthlyCostUsd: 12,
+      scanErrors: [],
+    };
+
+    const md = formatWasteReportAsMarkdown(summary, meta);
+
+    // headline + annualized
+    expect(md).toContain('$12.00/month');
+    expect(md).toContain('$144.00/year');
+    expect(md).toContain('across 2 resource(s)');
+    // account + regions context
+    expect(md).toContain('account `123456789012`');
+    expect(md).toContain('us-east-1, eu-west-1');
+    // breakdown total row
+    expect(md).toContain('| **Total** | **2** | **$12.00** |');
+    // collapsible details + per-finding row
+    expect(md).toContain('<details>');
+    expect(md).toContain('vol-aaa');
+    // recommendation present, sorted by cost (vol-aaa first)
+    const recIndexAaa = md.indexOf('Delete unattached EBS vol-aaa');
+    const recIndexBbb = md.indexOf('Delete unattached EBS vol-bbb');
+    expect(recIndexAaa).toBeGreaterThan(-1);
+    expect(recIndexAaa).toBeLessThan(recIndexBbb);
+  });
+
+  it('flags when the total is over the configured threshold', () => {
+    const summary: WastedResourcesSummary = {
+      findings: [makeVolume('vol-aaa', 600)],
+      totalMonthlyCostUsd: 600,
+      scanErrors: [],
+    };
+
+    const md = formatWasteReportAsMarkdown(summary, meta, { costAlertThresholdUsd: 500 });
+
+    expect(md).toContain('Over the $500.00/mo threshold');
+    expect(md).toContain('pipeline should fail');
+  });
+
+  it('shows "under threshold" when the total is within budget', () => {
+    const summary: WastedResourcesSummary = {
+      findings: [makeVolume('vol-aaa', 100)],
+      totalMonthlyCostUsd: 100,
+      scanErrors: [],
+    };
+
+    const md = formatWasteReportAsMarkdown(summary, meta, { costAlertThresholdUsd: 500 });
+
+    expect(md).toContain('Under the $500.00/mo threshold');
+  });
+
+  it('reports scan errors as partial results', () => {
+    const summary: WastedResourcesSummary = {
+      findings: [],
+      totalMonthlyCostUsd: 0,
+      scanErrors: [
+        { kind: 'rds-instance', region: 'eu-west-1', error: new Error('AccessDenied') },
+      ],
+    };
+
+    const md = formatWasteReportAsMarkdown(summary, meta);
+
+    expect(md).toContain('Partial results');
+    expect(md).toContain('RDS Instances in eu-west-1: AccessDenied');
+  });
+});

--- a/apps/cli/src/formatters/waste-report.markdown-formatter.ts
+++ b/apps/cli/src/formatters/waste-report.markdown-formatter.ts
@@ -1,0 +1,146 @@
+import {
+  RESOURCE_KINDS,
+  RESOURCE_KIND_LABELS,
+  groupByKind,
+} from 'cloud-cost-domain';
+import type { WastedResourcesSummary } from 'cloud-cost-domain';
+import type { WasteReportMeta } from 'cloud-cost-application';
+import { presenterFor } from './resource-presenters';
+
+export interface MarkdownReportOptions {
+  /** Se valorizzata, il report mostra se il totale supera la soglia (CI). */
+  costAlertThresholdUsd?: number;
+}
+
+const MAX_RECOMMENDATIONS = 10;
+
+function money(n: number): string {
+  return `$${n.toFixed(2)}`;
+}
+
+/** Neutralizza i caratteri che romperebbero una cella di tabella markdown. */
+function esc(cell: string): string {
+  return cell.replace(/\|/g, '\\|').replace(/\r?\n/g, ' ');
+}
+
+function footer(meta: WasteReportMeta): string {
+  return `---\n<sub>Estimates use AWS list prices as of ${meta.pricesAsOf}; actual billing may differ.</sub>`;
+}
+
+/**
+ * Render Markdown pensato per i commenti automatici sulle Pull Request
+ * (GitHub Actions / GitLab CI). Usa `<details>` per restare compatto e mette
+ * il totale e l'eventuale sforamento di soglia ben in vista.
+ */
+export function formatWasteReportAsMarkdown(
+  summary: WastedResourcesSummary,
+  meta: WasteReportMeta,
+  options: MarkdownReportOptions = {},
+): string {
+  const lines: string[] = [];
+  const grouped = groupByKind(summary.findings);
+  const total = summary.totalMonthlyCostUsd;
+  const day = meta.generatedAt.toISOString().split('T')[0];
+
+  lines.push('## ☁️ cloudrift — Cloud waste report');
+  lines.push('');
+  const accountLabel =
+    meta.accountId !== 'unknown' ? `account \`${meta.accountId}\` · ` : '';
+  lines.push(`> ${accountLabel}regions \`${meta.regions.join(', ')}\` · ${day}`);
+  lines.push('');
+
+  if (summary.findings.length === 0 && summary.scanErrors.length === 0) {
+    lines.push('✅ **No wasted resources found.**');
+    lines.push('');
+    lines.push(footer(meta));
+    return lines.join('\n');
+  }
+
+  // Headline
+  lines.push(
+    `**💸 ${money(total)}/month** potential savings ` +
+      `(**${money(total * 12)}/year**) across ${summary.findings.length} resource(s).`,
+  );
+  if (options.costAlertThresholdUsd !== undefined) {
+    lines.push('');
+    lines.push(
+      total > options.costAlertThresholdUsd
+        ? `> ⚠️ **Over the ${money(options.costAlertThresholdUsd)}/mo threshold** — this pipeline should fail.`
+        : `> ✅ Under the ${money(options.costAlertThresholdUsd)}/mo threshold.`,
+    );
+  }
+  lines.push('');
+
+  // Breakdown table
+  lines.push('### Breakdown');
+  lines.push('');
+  lines.push('| Resource type | Count | $/month |');
+  lines.push('|---|---:|---:|');
+  for (const kind of RESOURCE_KINDS) {
+    const findings = grouped[kind];
+    if (findings.length === 0) continue;
+    const subtotal = findings.reduce((s, r) => s + r.costEstimate.monthlyCostUsd, 0);
+    lines.push(`| ${RESOURCE_KIND_LABELS[kind]} | ${findings.length} | ${money(subtotal)} |`);
+  }
+  lines.push(`| **Total** | **${summary.findings.length}** | **${money(total)}** |`);
+  lines.push('');
+
+  // Dettaglio per tipo (collassabile per mantenere il commento PR compatto)
+  for (const kind of RESOURCE_KINDS) {
+    const findings = grouped[kind];
+    if (findings.length === 0) continue;
+    const presenter = presenterFor(kind);
+    const subtotal = findings.reduce((s, r) => s + r.costEstimate.monthlyCostUsd, 0);
+
+    lines.push('<details>');
+    lines.push(
+      `<summary>${esc(presenter.title)} (${findings.length}) · ${money(subtotal)}/mo</summary>`,
+    );
+    lines.push('');
+    const header = [...presenter.head, '$/mo'];
+    lines.push(`| ${header.join(' | ')} |`);
+    lines.push(`|${header.map(() => '---').join('|')}|`);
+    for (const finding of findings) {
+      const cells = [
+        ...presenter.row(finding).map(esc),
+        money(finding.costEstimate.monthlyCostUsd),
+      ];
+      lines.push(`| ${cells.join(' | ')} |`);
+    }
+    lines.push('');
+    lines.push('</details>');
+    lines.push('');
+  }
+
+  // Raccomandazioni principali (ordinate per costo decrescente)
+  const recommendations = RESOURCE_KINDS.flatMap((kind) =>
+    grouped[kind].map((finding) => ({
+      text: presenterFor(kind).recommend(finding),
+      cost: finding.costEstimate.monthlyCostUsd,
+    })),
+  ).sort((a, b) => b.cost - a.cost);
+
+  if (recommendations.length > 0) {
+    lines.push('### Top recommendations');
+    lines.push('');
+    for (const { text } of recommendations.slice(0, MAX_RECOMMENDATIONS)) {
+      lines.push(`- ${esc(text)}`);
+    }
+    if (recommendations.length > MAX_RECOMMENDATIONS) {
+      lines.push(`- …and ${recommendations.length - MAX_RECOMMENDATIONS} more`);
+    }
+    lines.push('');
+  }
+
+  // Errori di scan: risultati parziali
+  if (summary.scanErrors.length > 0) {
+    lines.push('> ⚠️ **Partial results** — some scans could not complete:');
+    for (const { kind, region, error } of summary.scanErrors) {
+      lines.push(`> - ${RESOURCE_KIND_LABELS[kind]} in ${region}: ${esc(error.message)}`);
+    }
+    lines.push('');
+  }
+
+  lines.push(footer(meta));
+  return lines.join('\n');
+}

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -32,12 +32,17 @@ program
     'resources carrying this tag are excluded from the report (default cloudrift:ignore, overrides config)',
   )
   .option(
+    '--format <format>',
+    'stdout output format: table (default), json, or markdown (for CI / PR comments)',
+    'table',
+  )
+  .option(
     '--pdf [filename]',
-    'Export a PDF report (optional filename, defaults to cloudrift-report-YYYY-MM-DD.pdf)',
+    'Also write a PDF report to disk (optional filename, defaults to cloudrift-report-YYYY-MM-DD.pdf)',
   )
   .option(
     '--json [filename]',
-    'Output the report as JSON (to stdout when no filename is given)',
+    'Also write a JSON report to disk (optional filename, defaults to cloudrift-report-YYYY-MM-DD.json)',
   )
   .action(analyzeWasteCommand);
 


### PR DESCRIPTION
## What

Adds `--format table|json|markdown` to control stdout. The **markdown**
format is built for automated Pull Request comments in CI — a developer can
pipe it to `$GITHUB_STEP_SUMMARY` or post it as a PR comment, so the cost of
newly created resources is visible at review time.

Phase 1.3 of the v0.3.0 plan.

## Output model

- `--format` controls **stdout**: `table` (default, human), `json`
  (machine), `markdown` (CI / PR comments).
- `--json` / `--pdf [filename]` are now **file artifacts**, independent of
  the stdout format. With no filename they default to
  `cloudrift-report-YYYY-MM-DD.{json,pdf}`.
- For `json` and `markdown`, all human chrome (banner, "saved to…", skipped
  regions) is routed to **stderr**, so stdout carries only the report:
  ```sh
  cloudrift analyze --format json | jq '.totalMonthlyCostUsd'
  cloudrift analyze --format markdown >> "$GITHUB_STEP_SUMMARY"