### PR TITLE
feat(release): publish @cloudrift/cli to npm + CI/CD integration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,66 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write # create the GitHub Release
+  id-token: write # npm provenance
+
+jobs:
+  publish:
+    name: Publish @cloudrift/cli to npm
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: '10.33.0'
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24.x'
+          cache: 'pnpm'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Verify the tag matches the package version
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          PKG_VERSION="$(node -p "require('./apps/cli/package.json').version")"
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "::error::Tag $GITHUB_REF_NAME ($TAG_VERSION) does not match @cloudrift/cli version $PKG_VERSION"
+            exit 1
+          fi
+          echo "Releasing @cloudrift/cli@$PKG_VERSION"
+
+      - name: Lint and test
+        run: pnpm nx run-many -t lint test --all --parallel
+
+      - name: Package the CLI for npm
+        run: pnpm nx package cli
+
+      - name: Publish to npm
+        run: npm publish --provenance --access public
+        working-directory: apps/cli/dist
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create "$GITHUB_REF_NAME" --title "$GITHUB_REF_NAME" --generate-notes

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 | **EC2 Instances**  | Stopped — attached EBS volumes keep billing | Sum of attached EBS volumes                             |
 | **EBS Snapshots**  | Source volume deleted (orphan snapshots)    | $0.05/GB-month                                          |
 | **NAT Gateways**   | Zero outbound traffic in the last 48h       | ~$32.40/month fixed                                     |
+| **EBS gp2→gp3**    | In-use gp2 volume upgradeable to gp3 (savings, not waste) | Saving: gp2 − gp3 price × GB (≈ $0.02/GB-mo) |
 
 **False-positive guards (waste policies):**
 
@@ -28,11 +29,26 @@
 
 > Prices vary by region. The tool uses region-specific pricing for: `us-east-1`, `us-west-2`, `eu-west-1`, `eu-central-1`, `ap-southeast-1`, `ap-northeast-1`. Every report states the date the price table was last verified (`prices as of`).
 
+### Install
+
+The published package is **[`@cloudrift/cli`](https://www.npmjs.com/package/@cloudrift/cli)**; the installed command is `cloudrift`.
+
+```sh
+# One-off (ideal in CI)
+npx @cloudrift/cli@latest analyze -r us-east-1
+
+# Or install globally
+npm install -g @cloudrift/cli
+cloudrift analyze -r us-east-1
+```
+
+Prefer building from source for development? See [Quick Start](#quick-start) below. All examples in this README use `cloudrift …`; when running from source replace it with `node apps/cli/dist/main.js …`.
+
 ### Prerequisites
 
-- **Node.js 20+** — check with `node --version`
-- **pnpm** — install with `npm install -g pnpm`, check with `pnpm --version`
+- **Node.js 18+** — check with `node --version`
 - **AWS credentials** with read-only permissions (see [Required IAM permissions](#required-iam-permissions) below)
+- **pnpm** — only needed when building from source (`npm install -g pnpm`)
 
 ---
 
@@ -114,33 +130,37 @@ node apps/cli/dist/main.js analyze [options]
 | Option                       | Description                                                                                                    | Default            |
 | ---------------------------- | -------------------------------------------------------------------------------------------------------------- | ------------------ |
 | `-r, --regions <regions...>` | AWS regions to scan                                                                                            | `us-east-1`        |
+| `--format <format>`          | stdout output format: `table`, `json`, or `markdown` (for CI / PR comments)                                   | `table`            |
+| `--config <path>`            | Path to a config file (defaults to `cloudrift.config.json` / `.cloudriftrc` in the cwd)                       | auto-discovered    |
 | `--account-id <id>`          | AWS account ID override (auto-detected via `sts:GetCallerIdentity` when omitted)                               | auto-detected      |
-| `--min-age-days <days>`      | Grace period: resources younger than this many days are not reported                                           | `7`                |
-| `--ignore-tag <tag>`         | Resources carrying this tag are excluded from the report                                                       | `cloudrift:ignore` |
-| `--pdf [filename]`           | Export a PDF report; if no filename is given, saves `cloudrift-report-YYYY-MM-DD.pdf` in the current directory | —                  |
-| `--json [filename]`          | Output the report as JSON; with no filename, prints JSON to stdout (suppresses the table output)               | —                  |
+| `--min-age-days <days>`      | Grace period: resources younger than this many days are not reported (overrides config)                       | `7`                |
+| `--ignore-tag <tag>`         | Resources carrying this tag are excluded from the report (overrides config)                                   | `cloudrift:ignore` |
+| `--pdf [filename]`           | Also write a PDF report to disk (defaults to `cloudrift-report-YYYY-MM-DD.pdf`)                                | —                  |
+| `--json [filename]`          | Also write a JSON report to disk (defaults to `cloudrift-report-YYYY-MM-DD.json`)                              | —                  |
 | `-h, --help`                 | Show help                                                                                                      | —                  |
+
+> **stdout vs. file artifacts:** `--format` controls what goes to **stdout** (the report itself). `--json` / `--pdf` write **additional files** to disk and are independent of `--format`. In machine-readable formats (`json`, `markdown`) all human messages are routed to stderr, so stdout carries only the report — ideal for piping.
 
 **Examples:**
 
 ```sh
 # Scan the default region (us-east-1)
-node apps/cli/dist/main.js analyze
+cloudrift analyze
 
 # Scan multiple regions at once
-node apps/cli/dist/main.js analyze -r us-east-1 eu-west-1 ap-southeast-1
+cloudrift analyze -r us-east-1 eu-west-1 ap-southeast-1
 
 # Disable the grace period (report resources of any age)
-node apps/cli/dist/main.js analyze --min-age-days 0
+cloudrift analyze --min-age-days 0
 
 # Export a PDF report with auto-generated filename (cloudrift-report-YYYY-MM-DD.pdf)
-node apps/cli/dist/main.js analyze --pdf
+cloudrift analyze --pdf
 
 # Machine-readable output (e.g. to feed a dashboard or CI check)
-node apps/cli/dist/main.js analyze --json | jq '.totalMonthlyCostUsd'
+cloudrift analyze --format json | jq '.totalMonthlyCostUsd'
 
-# Save the JSON report to a file alongside the console output
-node apps/cli/dist/main.js analyze --json report.json
+# Markdown report (e.g. a GitHub Actions PR comment / step summary)
+cloudrift analyze --format markdown >> "$GITHUB_STEP_SUMMARY"
 ```
 
 **PDF report:**
@@ -175,6 +195,67 @@ If scanning a resource type fails (e.g. missing CloudWatch permissions for NAT G
 **Per-region pricing:**
 
 Prices are region-aware (defined in `prices.json` in the infrastructure layer). Regions with explicit pricing: `us-east-1`, `us-west-2`, `eu-west-1`, `eu-central-1`, `ap-southeast-1`, `ap-northeast-1`. All other regions fall back to us-east-1 defaults.
+
+### Configuration file
+
+cloudrift reads `cloudrift.config.json` (or `.cloudriftrc`) from the current directory, or a path passed with `--config`. CLI flags take precedence over the config file, which takes precedence over the built-in defaults. All fields are optional:
+
+```json
+{
+  "excludeRegions": ["us-gov-east-1"],
+  "excludeTagValues": { "Environment": "Production" },
+  "cloudwatchWindowHours": 168,
+  "minAgeDays": 14,
+  "ignoreTag": "cloudrift:ignore",
+  "costAlertThresholdUsd": 500
+}
+```
+
+| Field                   | Meaning                                                                                          |
+| ----------------------- | ------------------------------------------------------------------------------------------------ |
+| `excludeRegions`        | Regions skipped even if passed via `-r`                                                          |
+| `excludeTagValues`      | Exclude any resource carrying an exact `key: value` tag (e.g. don't touch `Environment: Production`) |
+| `cloudwatchWindowHours` | CloudWatch lookback window for traffic-based checks (default 48, max 168 = 7 days)               |
+| `minAgeDays`            | Grace period in days (same as `--min-age-days`)                                                  |
+| `ignoreTag`             | Exclusion tag (same as `--ignore-tag`)                                                           |
+| `costAlertThresholdUsd` | If the monthly total exceeds this, the command **exits with code 2** (used to fail a pipeline)  |
+
+> A staging NAT Gateway with no weekend traffic is a classic false positive: widen `cloudwatchWindowHours` to `168` so a quiet weekend doesn't flag it.
+
+### Use in CI/CD
+
+cloudrift is built to run inside pipelines, not just a terminal. Two ingredients make it CI-friendly:
+
+1. `--format markdown` produces a Pull-Request-ready comment (totals, breakdown, top recommendations).
+2. `costAlertThresholdUsd` in the config makes the command **exit 2** when waste exceeds the budget, which fails the job.
+
+**GitHub Actions** — comment the waste report on the step summary and fail over budget:
+
+```yaml
+name: Cloud cost check
+on: [pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  cloudrift:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # OIDC or static keys — here static, from repo secrets
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      # Posts the markdown report to the job summary; exits 2 if over costAlertThresholdUsd
+      - run: npx @cloudrift/cli@latest analyze -r us-east-1 eu-west-1 --format markdown >> "$GITHUB_STEP_SUMMARY"
+```
+
+With a `cloudrift.config.json` committed (`{"costAlertThresholdUsd": 500}`), the `run` step's exit code 2 fails the check automatically — the pipeline blocks when newly created resources push waste over the threshold.
 
 ### Required IAM permissions
 
@@ -222,6 +303,17 @@ pnpm nx run-many -t lint
 # Type check
 pnpm nx run-many -t typecheck
 ```
+
+### Releasing
+
+Publishing is automated: push a `vX.Y.Z` tag whose version matches `@cloudrift/cli` and the [release workflow](.github/workflows/release.yml) lints, tests, packages and runs `npm publish` with provenance (needs the `NPM_TOKEN` repo secret). Verify the publishable artifact locally first:
+
+```sh
+pnpm nx package cli                      # builds + generates apps/cli/dist/package.json
+cd apps/cli/dist && npm pack --dry-run   # inspect the exact tarball contents
+```
+
+The published package is bundled (esbuild): workspace libraries are inlined into `main.js`, so the generated `dist/package.json` declares only the third-party runtime dependencies.
 
 ### Architecture
 
@@ -277,6 +369,7 @@ No changes to `AnalyzeCloudWasteUseCase`, the summary, or the report DTO are nee
 | **EC2 Instances**  | Ferme (`stopped`), i volumi EBS attaccati continuano a essere fatturati | Somma dei volumi EBS attaccati                                |
 | **EBS Snapshots**  | Volume sorgente cancellato (snapshot orfani)                            | $0,05/GB-mese                                                 |
 | **NAT Gateways**   | Zero traffico in uscita nelle ultime 48h                                | ~$32,40/mese fisso                                            |
+| **EBS gp2→gp3**    | Volume gp2 in uso aggiornabile a gp3 (risparmio, non spreco)            | Risparmio: prezzo gp2 − gp3 × GB (≈ $0,02/GB-mese)           |
 
 **Protezioni contro i falsi positivi (waste policies):**
 
@@ -286,11 +379,26 @@ No changes to `AnalyzeCloudWasteUseCase`, the summary, or the report DTO are nee
 
 > I prezzi variano per regione. Il tool usa prezzi specifici per: `us-east-1`, `us-west-2`, `eu-west-1`, `eu-central-1`, `ap-southeast-1`, `ap-northeast-1`. Ogni report indica la data di ultima verifica del listino (`prices as of`).
 
+### Installazione
+
+Il pacchetto pubblicato è **[`@cloudrift/cli`](https://www.npmjs.com/package/@cloudrift/cli)**; il comando installato è `cloudrift`.
+
+```sh
+# Esecuzione singola (ideale in CI)
+npx @cloudrift/cli@latest analyze -r us-east-1
+
+# Oppure installazione globale
+npm install -g @cloudrift/cli
+cloudrift analyze -r us-east-1
+```
+
+Preferisci compilare dai sorgenti per lo sviluppo? Vedi [Guida rapida](#guida-rapida) qui sotto. Tutti gli esempi di questo README usano `cloudrift …`; eseguendo dai sorgenti sostituiscilo con `node apps/cli/dist/main.js …`.
+
 ### Prerequisiti
 
-- **Node.js 20+** — verifica con `node --version`
-- **pnpm** — installa con `npm install -g pnpm`, poi verifica con `pnpm --version`
+- **Node.js 18+** — verifica con `node --version`
 - **Credenziali AWS** con permessi in sola lettura (vedi sezione [Permessi IAM](#permessi-iam-necessari) qui sotto)
+- **pnpm** — serve solo per compilare dai sorgenti (`npm install -g pnpm`)
 
 ---
 
@@ -372,33 +480,37 @@ node apps/cli/dist/main.js analyze [opzioni]
 | Opzione                      | Descrizione                                                                                                          | Default            |
 | ---------------------------- | -------------------------------------------------------------------------------------------------------------------- | ------------------ |
 | `-r, --regions <regioni...>` | Regioni AWS da scansionare                                                                                           | `us-east-1`        |
+| `--format <format>`          | Formato di stdout: `table`, `json` o `markdown` (per CI / commenti PR)                                              | `table`            |
+| `--config <path>`            | Percorso del file di config (default: `cloudrift.config.json` / `.cloudriftrc` nella cwd)                          | auto-rilevato      |
 | `--account-id <id>`          | Override dell'account ID (rilevato automaticamente via `sts:GetCallerIdentity` se omesso)                            | auto-rilevato      |
-| `--min-age-days <giorni>`    | Periodo di grazia: le risorse più giovani di N giorni non vengono segnalate                                          | `7`                |
-| `--ignore-tag <tag>`         | Le risorse con questo tag vengono escluse dal report                                                                 | `cloudrift:ignore` |
-| `--pdf [filename]`           | Esporta un report PDF; se non si specifica un nome, salva `cloudrift-report-YYYY-MM-DD.pdf` nella directory corrente | —                  |
-| `--json [filename]`          | Output del report in JSON; senza filename stampa il JSON su stdout (sopprime l'output tabellare)                     | —                  |
+| `--min-age-days <giorni>`    | Periodo di grazia: le risorse più giovani di N giorni non vengono segnalate (ha precedenza sul config)              | `7`                |
+| `--ignore-tag <tag>`         | Le risorse con questo tag vengono escluse dal report (ha precedenza sul config)                                     | `cloudrift:ignore` |
+| `--pdf [filename]`           | Scrive anche un report PDF su disco (default `cloudrift-report-YYYY-MM-DD.pdf`)                                      | —                  |
+| `--json [filename]`          | Scrive anche un report JSON su disco (default `cloudrift-report-YYYY-MM-DD.json`)                                   | —                  |
 | `-h, --help`                 | Mostra l'help                                                                                                        | —                  |
+
+> **stdout vs. file:** `--format` controlla cosa va su **stdout** (il report). `--json` / `--pdf` scrivono **file aggiuntivi** su disco, indipendenti da `--format`. Nei formati machine-readable (`json`, `markdown`) tutti i messaggi umani vanno su stderr, così su stdout resta solo il report — ideale per il piping.
 
 **Esempi:**
 
 ```sh
 # Scansione nella regione di default (us-east-1)
-node apps/cli/dist/main.js analyze
+cloudrift analyze
 
 # Più regioni contemporaneamente
-node apps/cli/dist/main.js analyze -r us-east-1 eu-west-1 ap-southeast-1
+cloudrift analyze -r us-east-1 eu-west-1 ap-southeast-1
 
 # Disattiva il periodo di grazia (segnala risorse di qualsiasi età)
-node apps/cli/dist/main.js analyze --min-age-days 0
+cloudrift analyze --min-age-days 0
 
 # Esporta un report PDF con nome automatico (cloudrift-report-YYYY-MM-DD.pdf)
-node apps/cli/dist/main.js analyze --pdf
+cloudrift analyze --pdf
 
 # Output machine-readable (es. per una dashboard o un check CI)
-node apps/cli/dist/main.js analyze --json | jq '.totalMonthlyCostUsd'
+cloudrift analyze --format json | jq '.totalMonthlyCostUsd'
 
-# Salva il report JSON su file mantenendo l'output console
-node apps/cli/dist/main.js analyze --json report.json
+# Report Markdown (es. commento PR / step summary su GitHub Actions)
+cloudrift analyze --format markdown >> "$GITHUB_STEP_SUMMARY"
 ```
 
 **Report PDF:**
@@ -449,6 +561,67 @@ Se la scansione di un tipo di risorsa fallisce (es. permessi mancanti su CloudWa
 
 I prezzi sono per-regione (file `prices.json` nell'infrastruttura). Regioni supportate con prezzi specifici: `us-east-1`, `us-west-2`, `eu-west-1`, `eu-central-1`, `ap-southeast-1`, `ap-northeast-1`. Per le altre regioni viene usato il prezzo di default (us-east-1).
 
+### File di configurazione
+
+cloudrift legge `cloudrift.config.json` (o `.cloudriftrc`) dalla directory corrente, oppure il percorso passato con `--config`. I flag CLI hanno la precedenza sul file di config, che a sua volta ha la precedenza sui default. Tutti i campi sono opzionali:
+
+```json
+{
+  "excludeRegions": ["us-gov-east-1"],
+  "excludeTagValues": { "Environment": "Production" },
+  "cloudwatchWindowHours": 168,
+  "minAgeDays": 14,
+  "ignoreTag": "cloudrift:ignore",
+  "costAlertThresholdUsd": 500
+}
+```
+
+| Campo                   | Significato                                                                                              |
+| ----------------------- | -------------------------------------------------------------------------------------------------------- |
+| `excludeRegions`        | Regioni saltate anche se passate con `-r`                                                                |
+| `excludeTagValues`      | Esclude le risorse con un tag `chiave: valore` esatto (es. non toccare `Environment: Production`)        |
+| `cloudwatchWindowHours` | Finestra CloudWatch per i check sul traffico (default 48, max 168 = 7 giorni)                            |
+| `minAgeDays`            | Periodo di grazia in giorni (come `--min-age-days`)                                                      |
+| `ignoreTag`             | Tag di esclusione (come `--ignore-tag`)                                                                  |
+| `costAlertThresholdUsd` | Se il totale mensile supera questa soglia, il comando **esce con codice 2** (per far fallire la pipeline) |
+
+> Un NAT Gateway di staging senza traffico nel weekend è il classico falso positivo: allarga `cloudwatchWindowHours` a `168` così un weekend tranquillo non lo segnala.
+
+### Uso in CI/CD
+
+cloudrift è pensato per girare dentro le pipeline, non solo nel terminale. Due ingredienti lo rendono CI-friendly:
+
+1. `--format markdown` produce un commento pronto per le Pull Request (totali, breakdown, raccomandazioni principali).
+2. `costAlertThresholdUsd` nel config fa **uscire con codice 2** quando lo spreco supera il budget, facendo fallire il job.
+
+**GitHub Actions** — commenta il report sullo step summary e fallisci se oltre budget:
+
+```yaml
+name: Cloud cost check
+on: [pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  cloudrift:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # OIDC o chiavi statiche — qui statiche, dai secret del repo
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      # Pubblica il report markdown nel job summary; esce 2 se oltre costAlertThresholdUsd
+      - run: npx @cloudrift/cli@latest analyze -r us-east-1 eu-west-1 --format markdown >> "$GITHUB_STEP_SUMMARY"
+```
+
+Con un `cloudrift.config.json` committato (`{"costAlertThresholdUsd": 500}`), l'exit code 2 dello step `run` fa fallire il check automaticamente — la pipeline si blocca quando nuove risorse spingono lo spreco oltre la soglia.
+
 ### Permessi IAM necessari
 
 Il principal AWS deve avere le seguenti permission in sola lettura:
@@ -495,6 +668,17 @@ pnpm nx run-many -t lint
 # Type check
 pnpm nx run-many -t typecheck
 ```
+
+### Rilascio
+
+La pubblicazione è automatica: pusha un tag `vX.Y.Z` la cui versione combacia con `@cloudrift/cli` e il [workflow di release](.github/workflows/release.yml) esegue lint, test, packaging e `npm publish` con provenance (richiede il secret `NPM_TOKEN` del repo). Verifica prima l'artefatto pubblicabile in locale:
+
+```sh
+pnpm nx package cli                      # build + genera apps/cli/dist/package.json
+cd apps/cli/dist && npm pack --dry-run   # ispeziona il contenuto esatto del tarball
+```
+
+Il pacchetto pubblicato è bundlato (esbuild): le librerie del workspace sono inlinate in `main.js`, quindi il `dist/package.json` generato dichiara solo le dipendenze runtime di terze parti.
 
 ### Architettura
 

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,44 @@
 {
-  "name": "cli",
-  "version": "0.0.1",
-  "private": true,
+  "name": "@cloudrift/cli",
+  "version": "0.3.0",
+  "description": "Detect and report wasted AWS cloud resources — built to run in CI/CD and fail pipelines over a cost threshold.",
+  "keywords": [
+    "aws",
+    "cost",
+    "finops",
+    "cloud",
+    "waste",
+    "cost-optimization",
+    "cli",
+    "ci",
+    "ec2",
+    "ebs",
+    "rds",
+    "nat-gateway"
+  ],
+  "license": "EL-2.0",
+  "homepage": "https://github.com/elleVas/cloudrift#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/elleVas/cloudrift.git",
+    "directory": "apps/cli"
+  },
+  "bugs": {
+    "url": "https://github.com/elleVas/cloudrift/issues"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "main": "./main.js",
+  "bin": {
+    "cloudrift": "./main.js"
+  },
+  "files": [
+    "main.js"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
   "nx": {
     "targets": {
       "test": {
@@ -12,6 +49,19 @@
         "options": {
           "jestConfig": "apps/cli/jest.config.cjs",
           "passWithNoTests": true
+        }
+      },
+      "package": {
+        "dependsOn": [
+          "build"
+        ],
+        "cache": true,
+        "outputs": [
+          "{projectRoot}/dist/package.json"
+        ],
+        "executor": "nx:run-commands",
+        "options": {
+          "command": "node apps/cli/scripts/make-dist-package.mjs"
         }
       },
       "build": {
@@ -31,7 +81,17 @@
           "main": "apps/cli/src/main.ts",
           "tsConfig": "apps/cli/tsconfig.app.json",
           "assets": [
-            "apps/cli/src/assets"
+            "apps/cli/src/assets",
+            {
+              "input": ".",
+              "glob": "README.md",
+              "output": "."
+            },
+            {
+              "input": ".",
+              "glob": "LICENSE.md",
+              "output": "."
+            }
           ],
           "esbuildOptions": {
             "sourcemap": true,
@@ -51,40 +111,6 @@
             }
           }
         }
-      },
-      "prune-lockfile": {
-        "dependsOn": [
-          "build"
-        ],
-        "cache": true,
-        "executor": "@nx/js:prune-lockfile",
-        "outputs": [
-          "{workspaceRoot}/apps/cli/dist/package.json",
-          "{workspaceRoot}/apps/cli/dist/pnpm-lock.yaml"
-        ],
-        "options": {
-          "buildTarget": "build"
-        }
-      },
-      "copy-workspace-modules": {
-        "dependsOn": [
-          "build"
-        ],
-        "cache": true,
-        "outputs": [
-          "{workspaceRoot}/apps/cli/dist/workspace_modules"
-        ],
-        "executor": "@nx/js:copy-workspace-modules",
-        "options": {
-          "buildTarget": "build"
-        }
-      },
-      "prune": {
-        "dependsOn": [
-          "prune-lockfile",
-          "copy-workspace-modules"
-        ],
-        "executor": "nx:noop"
       },
       "serve": {
         "continuous": true,

--- a/apps/cli/project.json
+++ b/apps/cli/project.json
@@ -1,0 +1,4 @@
+{
+  "name": "cli",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json"
+}

--- a/apps/cli/scripts/make-dist-package.mjs
+++ b/apps/cli/scripts/make-dist-package.mjs
@@ -1,0 +1,93 @@
+// Genera apps/cli/dist/package.json per la pubblicazione npm.
+//
+// La CLI è bundlata (esbuild bundle:true): le lib del workspace sono già
+// inlinate in main.js, mentre i pacchetti di terze parti restano `require()`
+// esterni. Il manifest di pubblicazione deve quindi dichiarare SOLO quei
+// pacchetti esterni — non le dipendenze workspace:* del manifest di sviluppo.
+//
+// Gli esterni vengono ricavati dal bundle reale (i `require("...")`), così lo
+// script si auto-mantiene se in futuro si aggiungono nuovi SDK.
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { isBuiltin } from 'node:module';
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const appDir = resolve(scriptDir, '..');
+const workspaceRoot = resolve(appDir, '..', '..');
+const distDir = resolve(appDir, 'dist');
+
+const appPkg = readJson(resolve(appDir, 'package.json'));
+const rootPkg = readJson(resolve(workspaceRoot, 'package.json'));
+const bundle = readFileSync(resolve(distDir, 'main.js'), 'utf8');
+
+// 1. Estrai i nomi dei pacchetti esterni dai require() del bundle.
+const externals = new Set();
+for (const match of bundle.matchAll(/require\(["']([^"']+)["']\)/g)) {
+  const spec = match[1];
+  if (spec.startsWith('.') || spec.startsWith('/') || isBuiltin(spec)) continue;
+  externals.add(packageNameOf(spec));
+}
+
+// 2. Risolvi la versione di ciascun esterno (app → root → versione installata).
+const dependencies = {};
+for (const name of [...externals].sort()) {
+  dependencies[name] = resolveVersion(name);
+}
+
+// 3. Comporre il manifest di pubblicazione dai metadati del manifest di sviluppo.
+const publishManifest = {
+  name: appPkg.name,
+  version: appPkg.version,
+  description: appPkg.description,
+  keywords: appPkg.keywords,
+  license: appPkg.license,
+  homepage: appPkg.homepage,
+  repository: appPkg.repository,
+  bugs: appPkg.bugs,
+  engines: appPkg.engines,
+  type: 'commonjs',
+  main: './main.js',
+  bin: appPkg.bin,
+  files: appPkg.files,
+  publishConfig: appPkg.publishConfig,
+  dependencies,
+};
+
+writeFileSync(
+  resolve(distDir, 'package.json'),
+  JSON.stringify(publishManifest, null, 2) + '\n',
+);
+
+console.log(`Wrote ${appPkg.name}@${appPkg.version} dist/package.json with ${Object.keys(dependencies).length} runtime dependencies:`);
+for (const [name, version] of Object.entries(dependencies)) {
+  console.log(`  ${name}@${version}`);
+}
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+function packageNameOf(spec) {
+  const parts = spec.split('/');
+  return spec.startsWith('@') ? `${parts[0]}/${parts[1]}` : parts[0];
+}
+
+function resolveVersion(name) {
+  const fromApp = appPkg.dependencies?.[name];
+  if (fromApp && !fromApp.startsWith('workspace:')) return fromApp;
+
+  const fromRoot = rootPkg.dependencies?.[name] ?? rootPkg.devDependencies?.[name];
+  if (fromRoot) return fromRoot;
+
+  try {
+    const installed = readJson(resolve(workspaceRoot, 'node_modules', name, 'package.json'));
+    return `^${installed.version}`;
+  } catch {
+    throw new Error(
+      `Cannot resolve a version for external dependency "${name}". ` +
+        `Add it to the root or apps/cli package.json.`,
+    );
+  }
+}

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -5,7 +5,7 @@ import { analyzeWasteCommand } from './commands/analyze-waste.command';
 program
   .name('cloudrift')
   .description('Detect and report wasted AWS cloud resources')
-  .version('0.2.0');
+  .version('0.3.0');
 
 program
   .command('analyze')

--- a/docs/en/architecture.md
+++ b/docs/en/architecture.md
@@ -34,7 +34,7 @@ What it does **not** buy on its own is multi-cloud: see [Towards multi-cloud](#t
 │   entities, policies,   │   │   Result, DomainError)    │
 │   ports)                │   └───────────────────────────┘
 └──────▲──────────────────┘
-       │ implements WasteScannerPort (×7)
+       │ implements WasteScannerPort (×8)
 ┌──────┴──────────────────────────────────────────────────┐
 │        libs/cloud-cost/infrastructure/aws-adapter       │
 │   (AWS SDK v3 scanners, pricing, STS account resolver)  │
@@ -95,7 +95,8 @@ export type ResourceKind =
   | 'load-balancer'
   | 'ec2-instance'
   | 'ebs-snapshot'
-  | 'nat-gateway';
+  | 'nat-gateway'
+  | 'ebs-gp2-upgrade';
 
 export interface WastedResource {
   readonly id: string;
@@ -113,7 +114,7 @@ export interface WastedResource {
 
 #### Entities
 
-The 7 entities (`EbsVolume`, `ElasticIp`, `RdsInstance`, `LoadBalancer`, `Ec2Instance`, `EbsSnapshot`, `NatGateway`) implement `WastedResource` and carry the observed **facts** the decisions need: `LoadBalancer.registeredTargetCount`, `NatGateway.bytesOutLastWindow`, `EbsSnapshot.sourceVolumeExists` / `boundToAmiId`, `Ec2Instance.stoppedSince`.
+The 8 entities (`EbsVolume`, `ElasticIp`, `RdsInstance`, `LoadBalancer`, `Ec2Instance`, `EbsSnapshot`, `NatGateway`, `Gp2Volume`) implement `WastedResource` and carry the observed **facts** the decisions need: `LoadBalancer.registeredTargetCount`, `NatGateway.bytesOutLastWindow`, `EbsSnapshot.sourceVolumeExists` / `boundToAmiId`, `Ec2Instance.stoppedSince`. `Gp2Volume` is a savings opportunity rather than deletable waste: its `costEstimate` carries the gp2→gp3 monthly *saving*.
 
 #### Waste Policies — where the business knowledge lives
 
@@ -133,6 +134,7 @@ Each concrete policy adds the type-specific criterion:
 | `Ec2InstanceWastePolicy`  | `state === 'stopped'`                     | grace on `stoppedSince` (from `StateTransitionReason`), fallback `launchTime`   |
 | `EbsSnapshotWastePolicy`  | source volume deleted                     | snapshots referenced by AMIs excluded (not deletable); grace on `startTime`     |
 | `NatGatewayWastePolicy`   | zero outbound bytes in the window (48h)   | grace on `createTime` (freshly created environments)                            |
+| `Gp2UpgradePolicy`        | in-use gp2 volume (savings, not waste)    | only `status=in-use` (unattached gp2 stays with `ebs-volume`); grace on `createTime` |
 
 Policies are pure domain logic: tested without AWS, with their parameters coming from the CLI (`--min-age-days`, `--ignore-tag`).
 
@@ -175,7 +177,7 @@ Specifics:
 
 ### 5. `apps/cli` — Entry point and composition root
 
-`analyze-waste.command.ts` is the only place where concrete implementations are instantiated: it builds the price table, the policies (with the CLI parameters) and the 7 scanners, injects them into the use case and hands the result to the formatters. The three formatters (console table, PDF, JSON) share the `resource-presenters.ts` registry, typed `Record<ResourceKind, …>` with `satisfies`: forgetting the presenter for a new kind is a compile error.
+`analyze-waste.command.ts` is the only place where concrete implementations are instantiated: it loads the config file, builds the price table, the policies (with config + CLI parameters) and the 8 scanners, injects them into the use case and hands the result to the formatters. The four formatters (console table, PDF, JSON, Markdown) share the `resource-presenters.ts` registry, typed `Record<ResourceKind, …>` with `satisfies`: forgetting the presenter for a new kind is a compile error. The output format is selected by `--format` (`table` | `json` | `markdown`); `markdown` targets CI / PR comments.
 
 ---
 

--- a/docs/en/how-it-works.md
+++ b/docs/en/how-it-works.md
@@ -19,7 +19,7 @@ user: cloudrift analyze -r us-east-1 eu-west-1 [--pdf] [--json] [--min-age-days 
      analyze-waste.command.ts  (composition root)
      1. AwsRegion.parse() for each region (clean error on invalid input)
      2. accountId: --account-id or STS GetCallerIdentity
-     3. Instantiates pricing, policies (--min-age-days / --ignore-tag) and the 7 scanners
+     3. Instantiates pricing, policies (config + --min-age-days / --ignore-tag) and the 8 scanners
           │
           ▼
      AnalyzeCloudWasteUseCase.execute({ regions })
@@ -197,6 +197,9 @@ export const presenters: { [K in ResourceKind]: ResourcePresenter<ResourceKindMa
 - **Console table** (`waste-report.table-formatter.ts`): iterates `RESOURCE_KINDS`, uses `groupByKind(findings)` and the presenter for headers and rows. At the end: warnings per (kind, region), total and a disclaimer with the price table date.
 - **PDF** (`waste-report.pdf-formatter.ts`): executive summary page (totals, breakdown, top 8 recommendations from `presenter.recommend`) + one page per kind. `drawTable` handles **page breaks**: when a table exceeds the bottom margin, it closes the border, opens a new page and redraws the header.
 - **JSON** (`waste-report.json-formatter.ts`): serializes `toWasteReportDto(summary, meta)` — the data contract for dashboards, CI or a future frontend.
+- **Markdown** (`waste-report.markdown-formatter.ts`): a Pull-Request-ready report (totals, breakdown, collapsible `<details>` per kind, top recommendations, cost-threshold callout) for `--format markdown` in CI.
+
+`--format` (`table` | `json` | `markdown`) selects what goes to stdout; `--pdf` / `--json [filename]` write additional files. In machine-readable formats the human chrome is routed to stderr so stdout carries only the report.
 
 ---
 

--- a/docs/it/architettura.md
+++ b/docs/it/architettura.md
@@ -33,7 +33,7 @@ Ciò che **non** compra da sola è il multi-cloud: vedi la sezione [Verso il mul
 │  (WastedResource, entità│   │  (Entity, ValueObject,    │
 │   waste policies, ports)│   │   Result, DomainError)    │
 └──────▲──────────────────┘   └───────────────────────────┘
-       │ implementa WasteScannerPort (×7)
+       │ implementa WasteScannerPort (×8)
 ┌──────┴──────────────────────────────────────────────────┐
 │        libs/cloud-cost/infrastructure/aws-adapter       │
 │   (scanner AWS SDK v3, pricing, STS account resolver)   │
@@ -94,7 +94,8 @@ export type ResourceKind =
   | 'load-balancer'
   | 'ec2-instance'
   | 'ebs-snapshot'
-  | 'nat-gateway';
+  | 'nat-gateway'
+  | 'ebs-gp2-upgrade';
 
 export interface WastedResource {
   readonly id: string;
@@ -112,7 +113,7 @@ export interface WastedResource {
 
 #### Entità
 
-Le 7 entità (`EbsVolume`, `ElasticIp`, `RdsInstance`, `LoadBalancer`, `Ec2Instance`, `EbsSnapshot`, `NatGateway`) implementano `WastedResource` e portano i **fatti** osservati necessari alle decisioni: `LoadBalancer.registeredTargetCount`, `NatGateway.bytesOutLastWindow`, `EbsSnapshot.sourceVolumeExists` / `boundToAmiId`, `Ec2Instance.stoppedSince`.
+Le 8 entità (`EbsVolume`, `ElasticIp`, `RdsInstance`, `LoadBalancer`, `Ec2Instance`, `EbsSnapshot`, `NatGateway`, `Gp2Volume`) implementano `WastedResource` e portano i **fatti** osservati necessari alle decisioni: `LoadBalancer.registeredTargetCount`, `NatGateway.bytesOutLastWindow`, `EbsSnapshot.sourceVolumeExists` / `boundToAmiId`, `Ec2Instance.stoppedSince`. `Gp2Volume` è un'opportunità di risparmio più che spreco da cancellare: il suo `costEstimate` porta il *risparmio* mensile gp2→gp3.
 
 #### Waste Policies — dove vive la conoscenza di business
 
@@ -132,6 +133,7 @@ Ogni policy concreta aggiunge il criterio specifico del tipo:
 | `Ec2InstanceWastePolicy`  | `state === 'stopped'`                     | grace su `stoppedSince` (da `StateTransitionReason`), fallback `launchTime`    |
 | `EbsSnapshotWastePolicy`  | volume sorgente cancellato                | esclusi snapshot referenziati da AMI (non cancellabili); grace su `startTime`  |
 | `NatGatewayWastePolicy`   | zero bytes in uscita nella finestra (48h) | grace su `createTime` (ambienti appena creati)                                 |
+| `Gp2UpgradePolicy`        | volume gp2 in uso (risparmio, non spreco) | solo `status=in-use` (i gp2 staccati restano a `ebs-volume`); grace su `createTime` |
 
 Le policy sono pura logica di dominio: si testano senza AWS, e i loro parametri arrivano dalla CLI (`--min-age-days`, `--ignore-tag`).
 
@@ -174,7 +176,7 @@ Particolarità:
 
 ### 5. `apps/cli` — Entry point e composition root
 
-`analyze-waste.command.ts` è l'unico punto in cui le implementazioni concrete vengono istanziate: costruisce il listino prezzi, le policy (con i parametri da CLI) e i 7 scanner, li inietta nel use case e passa il risultato ai formatter. I tre formatter (tabella console, PDF, JSON) condividono il registry `resource-presenters.ts`, tipizzato `Record<ResourceKind, …>` con `satisfies`: dimenticare il presenter di un nuovo kind è un errore di compilazione.
+`analyze-waste.command.ts` è l'unico punto in cui le implementazioni concrete vengono istanziate: carica il file di config, costruisce il listino prezzi, le policy (con i parametri da config + CLI) e gli 8 scanner, li inietta nel use case e passa il risultato ai formatter. I quattro formatter (tabella console, PDF, JSON, Markdown) condividono il registry `resource-presenters.ts`, tipizzato `Record<ResourceKind, …>` con `satisfies`: dimenticare il presenter di un nuovo kind è un errore di compilazione. Il formato di output si sceglie con `--format` (`table` | `json` | `markdown`); `markdown` è pensato per CI / commenti PR.
 
 ---
 

--- a/docs/it/funzionamento.md
+++ b/docs/it/funzionamento.md
@@ -19,7 +19,7 @@ utente: cloudrift analyze -r us-east-1 eu-west-1 [--pdf] [--json] [--min-age-day
      analyze-waste.command.ts  (composition root)
      1. AwsRegion.parse() per ogni regione (errore pulito su input invalido)
      2. accountId: --account-id oppure STS GetCallerIdentity
-     3. Istanzia pricing, policy (con --min-age-days / --ignore-tag) e i 7 scanner
+     3. Istanzia pricing, policy (config + --min-age-days / --ignore-tag) e gli 8 scanner
           │
           ▼
      AnalyzeCloudWasteUseCase.execute({ regions })
@@ -197,6 +197,9 @@ export const presenters: { [K in ResourceKind]: ResourcePresenter<ResourceKindMa
 - **Tabella console** (`waste-report.table-formatter.ts`): itera `RESOURCE_KINDS`, usa `groupByKind(findings)` e il presenter per intestazioni e righe. In coda: warning per (kind, regione), totale e disclaimer con la data del listino prezzi.
 - **PDF** (`waste-report.pdf-formatter.ts`): pagina executive summary (totali, breakdown, top 8 raccomandazioni da `presenter.recommend`) + una pagina per kind. `drawTable` gestisce il **salto pagina**: quando una tabella supera il margine inferiore, chiude il bordo, apre una nuova pagina e ridisegna l'header.
 - **JSON** (`waste-report.json-formatter.ts`): serializza `toWasteReportDto(summary, meta)` — il contratto dati per dashboard, CI o un futuro frontend.
+- **Markdown** (`waste-report.markdown-formatter.ts`): un report pronto per le Pull Request (totali, breakdown, `<details>` collassabile per kind, raccomandazioni principali, callout sulla soglia di costo) per `--format markdown` in CI.
+
+`--format` (`table` | `json` | `markdown`) sceglie cosa va su stdout; `--pdf` / `--json [filename]` scrivono file aggiuntivi. Nei formati machine-readable il chrome umano va su stderr, così su stdout resta solo il report.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@aws-sdk/client-elastic-load-balancing-v2": "^3.741.0",
     "@aws-sdk/client-rds": "^3.741.0",
     "@aws-sdk/client-sts": "^3.1068.0",
-    "chalk": "^5.4.1",
+    "chalk": "^4.1.2",
     "cli-table3": "^0.6.5",
     "commander": "^13.1.0"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ^3.1068.0
         version: 3.1068.0
       chalk:
-        specifier: ^5.4.1
-        version: 5.6.2
+        specifier: ^4.1.2
+        version: 4.1.2
       cli-table3:
         specifier: ^0.6.5
         version: 0.6.5
@@ -2243,10 +2243,6 @@ packages:
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
-
-  chalk@5.6.2:
-    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
-    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
   char-regex@1.0.2:
     resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}
@@ -6725,8 +6721,6 @@ snapshots:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
-
-  chalk@5.6.2: {}
 
   char-regex@1.0.2: {}
 


### PR DESCRIPTION
## What

Makes cloudrift installable from npm and runnable inside CI/CD pipelines.
This is the strategic payoff of v0.3.0: the tool moves from "something you run
in a terminal and read" to "something that lives in the pipeline and blocks a
merge over budget".

Phase 1.4 (final) of the v0.3.0 plan.

## Package: `@cloudrift/cli`

Published as scoped **`@cloudrift/cli`**; the installed command is `cloudrift`.
Scoped (not bare `cloudrift`) on purpose: no global-name gamble, no rename of
the private workspace root, and room for `@cloudrift/core` / `@cloudrift/action`
later.

- The nx project name is pinned to `cli` via `project.json`, so `nx … cli`
  keeps working even though the package name is `@cloudrift/cli`.
- `apps/cli/scripts/make-dist-package.mjs` (nx `package` target) generates
  `dist/package.json` by reading the **actual external `require()`s from the
  bundle**, so it self-maintains when future phases add SDKs. Workspace libs
  are bundled into `main.js`, so the manifest lists only third-party deps.
- Tarball verified with `npm pack`: 4 files (`main.js`, `package.json`,
  `README.md`, `LICENSE.md`), ~23 kB. Installed it into a temp project and ran
  the `cloudrift` bin end-to-end.

## Portability fix — chalk 5 → 4

`chalk@5` is ESM-only, but the bundle is CJS and `require()`d it. That only
works on Node ≥22 (`require(esm)`); on Node 18/20 — the common GitHub Actions
runners — it throws `ERR_REQUIRE_ESM`. Downgraded to `chalk@4` (CJS, identical
API for our usage). All remaining externals (commander, cli-table3, pdfkit,
AWS SDK) are already CJS.

## Release automation

`.github/workflows/release.yml` on a `v*` tag: verifies the tag matches the
package version, runs lint + test, packages, `npm publish --provenance`, and
creates a GitHub Release. Needs the `NPM_TOKEN` repo secret.

## Docs (EN + IT)

- **README**: `Install` (npx / global), `Configuration file` (all fields +
  precedence), `Use in CI/CD` with a full GitHub Actions example (markdown to
  `$GITHUB_STEP_SUMMARY` + exit-2 budget gate), `Releasing`; `--format` /
  `--config` in the options table; gp2→gp3 resource row; Node 18+.
- **architecture / how-it-works** (EN+IT): `ResourceKind` union (8 kinds),
  ×8 counts, `Gp2UpgradePolicy` row, the Markdown formatter.


## To actually publish (manual, outward-facing)

1. Create the `@cloudrift` org on npm.
2. Add the `NPM_TOKEN` secret to the GitHub repo.
3. Merge, then `git tag v0.3.0 && git push --tags` — the workflow publishes.