### PR TITLE
feat(pricing): 3-layer pricing — manual overrides + AWS Pricing API

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ node apps/cli/dist/main.js analyze [options]
 | `-r, --regions <regions...>` | AWS regions to scan                                                                                            | `us-east-1`        |
 | `--format <format>`          | stdout output format: `table`, `json`, or `markdown` (for CI / PR comments)                                   | `table`            |
 | `--config <path>`            | Path to a config file (defaults to `cloudrift.config.json` / `.cloudriftrc` in the cwd)                       | auto-discovered    |
+| `--live-pricing`             | Fetch current list prices from the AWS Pricing API (falls back to the static table; config prices still win)  | off (static table) |
 | `--account-id <id>`          | AWS account ID override (auto-detected via `sts:GetCallerIdentity` when omitted)                               | auto-detected      |
 | `--min-age-days <days>`      | Grace period: resources younger than this many days are not reported (overrides config)                       | `7`                |
 | `--ignore-tag <tag>`         | Resources carrying this tag are excluded from the report (overrides config)                                   | `cloudrift:ignore` |
@@ -200,6 +201,8 @@ Prices are region-aware (defined in `prices.json` in the infrastructure layer). 
 
 cloudrift reads `cloudrift.config.json` (or `.cloudriftrc`) from the current directory, or a path passed with `--config`. CLI flags take precedence over the config file, which takes precedence over the built-in defaults. All fields are optional:
 
+> **Where does the file go?** It is **your** file, not part of the npm package. Put `cloudrift.config.json` in the directory you run `cloudrift` from — typically your repo root, **committed** so it's picked up automatically in CI (after `actions/checkout`) and shared by the team. Installing globally or running via `npx` makes no difference: discovery is based on the current working directory. If the file lives elsewhere, point at it with `--config path/to/file.json`.
+
 ```json
 {
   "excludeRegions": ["us-gov-east-1"],
@@ -207,7 +210,11 @@ cloudrift reads `cloudrift.config.json` (or `.cloudriftrc`) from the current dir
   "cloudwatchWindowHours": 168,
   "minAgeDays": 14,
   "ignoreTag": "cloudrift:ignore",
-  "costAlertThresholdUsd": 500
+  "costAlertThresholdUsd": 500,
+  "prices": {
+    "eu-west-1": { "nat-gateway": 28.5, "ebs-gp3": 0.07 },
+    "default": { "elastic-ip": 3.2 }
+  }
 }
 ```
 
@@ -219,8 +226,21 @@ cloudrift reads `cloudrift.config.json` (or `.cloudriftrc`) from the current dir
 | `minAgeDays`            | Grace period in days (same as `--min-age-days`)                                                  |
 | `ignoreTag`             | Exclusion tag (same as `--ignore-tag`)                                                           |
 | `costAlertThresholdUsd` | If the monthly total exceeds this, the command **exits with code 2** (used to fail a pipeline)  |
+| `prices`                | Per-region price overrides (same shape as the built-in table): `region → { priceKey: USD }`, with `default` as fallback. Use it for your **negotiated/enterprise rates** |
 
 > A staging NAT Gateway with no weekend traffic is a classic false positive: widen `cloudwatchWindowHours` to `168` so a quiet weekend doesn't flag it.
+
+### Pricing sources
+
+Costs are resolved from three layers; the most specific wins, per `(region, priceKey)`:
+
+1. **Your `prices` overrides** (config) — your negotiated/company rates. **Highest priority.**
+2. **AWS Pricing API** (`--live-pricing`) — current public list prices, fetched at startup.
+3. **Built-in static table** (`prices.json`) — always present as the fallback.
+
+Every report shows `prices as of` (the static date, the live fetch date, or `+ custom overrides`).
+
+> **Honest caveat:** even with `--live-pricing`, AWS returns **list** prices, not *your* bill — Savings Plans, Reserved Instances and EDP discounts are not reflected. The `prices` override is the only way to make the report match what you actually pay. Anything the live API can't unambiguously resolve falls back to the static table.
 
 ### Use in CI/CD
 
@@ -281,6 +301,8 @@ The AWS principal needs the following read-only permissions:
   "Resource": "*"
 }
 ```
+
+> `--live-pricing` additionally requires `pricing:GetProducts` (the AWS Pricing API). It is **not** needed for the default static pricing.
 
 ### Development
 
@@ -482,6 +504,7 @@ node apps/cli/dist/main.js analyze [opzioni]
 | `-r, --regions <regioni...>` | Regioni AWS da scansionare                                                                                           | `us-east-1`        |
 | `--format <format>`          | Formato di stdout: `table`, `json` o `markdown` (per CI / commenti PR)                                              | `table`            |
 | `--config <path>`            | Percorso del file di config (default: `cloudrift.config.json` / `.cloudriftrc` nella cwd)                          | auto-rilevato      |
+| `--live-pricing`             | Recupera i prezzi di listino correnti dall'AWS Pricing API (fallback alla tabella statica; i prezzi del config vincono) | off (tabella statica) |
 | `--account-id <id>`          | Override dell'account ID (rilevato automaticamente via `sts:GetCallerIdentity` se omesso)                            | auto-rilevato      |
 | `--min-age-days <giorni>`    | Periodo di grazia: le risorse più giovani di N giorni non vengono segnalate (ha precedenza sul config)              | `7`                |
 | `--ignore-tag <tag>`         | Le risorse con questo tag vengono escluse dal report (ha precedenza sul config)                                     | `cloudrift:ignore` |
@@ -565,6 +588,8 @@ I prezzi sono per-regione (file `prices.json` nell'infrastruttura). Regioni supp
 
 cloudrift legge `cloudrift.config.json` (o `.cloudriftrc`) dalla directory corrente, oppure il percorso passato con `--config`. I flag CLI hanno la precedenza sul file di config, che a sua volta ha la precedenza sui default. Tutti i campi sono opzionali:
 
+> **Dove va il file?** È un file **tuo**, non fa parte del pacchetto npm. Metti `cloudrift.config.json` nella directory da cui lanci `cloudrift` — tipicamente la root del tuo repo, **committato** così viene preso automaticamente in CI (dopo `actions/checkout`) e condiviso dal team. Installazione globale o `npx` non cambia nulla: la ricerca si basa sulla working directory corrente. Se il file sta altrove, indicalo con `--config percorso/del/file.json`.
+
 ```json
 {
   "excludeRegions": ["us-gov-east-1"],
@@ -572,7 +597,11 @@ cloudrift legge `cloudrift.config.json` (o `.cloudriftrc`) dalla directory corre
   "cloudwatchWindowHours": 168,
   "minAgeDays": 14,
   "ignoreTag": "cloudrift:ignore",
-  "costAlertThresholdUsd": 500
+  "costAlertThresholdUsd": 500,
+  "prices": {
+    "eu-west-1": { "nat-gateway": 28.5, "ebs-gp3": 0.07 },
+    "default": { "elastic-ip": 3.2 }
+  }
 }
 ```
 
@@ -584,8 +613,21 @@ cloudrift legge `cloudrift.config.json` (o `.cloudriftrc`) dalla directory corre
 | `minAgeDays`            | Periodo di grazia in giorni (come `--min-age-days`)                                                      |
 | `ignoreTag`             | Tag di esclusione (come `--ignore-tag`)                                                                  |
 | `costAlertThresholdUsd` | Se il totale mensile supera questa soglia, il comando **esce con codice 2** (per far fallire la pipeline) |
+| `prices`                | Override prezzi per regione (stessa forma del listino built-in): `regione → { chiave: USD }`, con `default` come fallback. Usalo per le tue **tariffe negoziate/aziendali** |
 
 > Un NAT Gateway di staging senza traffico nel weekend è il classico falso positivo: allarga `cloudwatchWindowHours` a `168` così un weekend tranquillo non lo segnala.
+
+### Fonti dei prezzi
+
+I costi sono risolti da tre livelli; vince il più specifico, per `(regione, chiave)`:
+
+1. **I tuoi override `prices`** (config) — le tue tariffe negoziate/aziendali. **Massima priorità.**
+2. **AWS Pricing API** (`--live-pricing`) — listino pubblico corrente, recuperato all'avvio.
+3. **Tabella statica built-in** (`prices.json`) — sempre presente come fallback.
+
+Ogni report mostra `prices as of` (la data dello statico, quella del fetch live, o `+ custom overrides`).
+
+> **Nota onesta:** anche con `--live-pricing`, AWS restituisce i prezzi di **listino**, non la *tua* bolletta — Savings Plans, Reserved Instances e sconti EDP non sono riflessi. Gli override `prices` sono l'unico modo per far combaciare il report con ciò che paghi davvero. Tutto ciò che il live non riesce a risolvere in modo univoco ricade sulla tabella statica.
 
 ### Uso in CI/CD
 
@@ -646,6 +688,8 @@ Il principal AWS deve avere le seguenti permission in sola lettura:
   "Resource": "*"
 }
 ```
+
+> `--live-pricing` richiede in più `pricing:GetProducts` (AWS Pricing API). **Non** serve per il pricing statico di default.
 
 ### Sviluppo
 

--- a/apps/cli/src/commands/analyze-waste.command.ts
+++ b/apps/cli/src/commands/analyze-waste.command.ts
@@ -27,8 +27,15 @@ import {
   AwsNatGatewayScanner,
   AwsGp2UpgradeScanner,
   StaticPriceTableAdapter,
+  TablePricingAdapter,
+  AwsPricingApiAdapter,
+  BUILTIN_PRICE_TABLE,
+  BUILTIN_PRICES_AS_OF,
+  mergePriceTables,
   resolveAwsAccountId,
 } from 'cloud-cost-infrastructure-aws-adapter';
+import type { PriceTable } from 'cloud-cost-infrastructure-aws-adapter';
+import type { PricingPort } from 'cloud-cost-domain';
 import { loadConfig } from '../config/cloudrift.config';
 import { formatWasteReportAsTable } from '../formatters/waste-report.table-formatter';
 import { formatWasteReportAsJson } from '../formatters/waste-report.json-formatter';
@@ -44,6 +51,7 @@ interface AnalyzeWasteOptions {
   accountId?: string;
   config?: string;
   format?: string;
+  livePricing?: boolean;
   pdf?: string | boolean;
   json?: string | boolean;
   minAgeDays?: string;
@@ -128,7 +136,39 @@ export async function analyzeWasteCommand(
     info(chalk.dim(`  Skipping excluded regions: ${skipped.join(', ')}`));
   }
 
-  const pricing = new StaticPriceTableAdapter();
+  // Pricing a livelli: listino statico (base) ← AWS Pricing API live (--live-pricing)
+  // ← override utente (config.prices, vincono). Gli override per regione servono
+  // per tariffe negoziate/aziendali, così il report riflette la bolletta reale.
+  let priceTable: PriceTable = BUILTIN_PRICE_TABLE;
+  let pricesAsOf = BUILTIN_PRICES_AS_OF;
+  let layered = false;
+
+  if (options.livePricing) {
+    info(chalk.dim('  Fetching current prices from the AWS Pricing API...'));
+    const live = await new AwsPricingApiAdapter().warmUp(regions);
+    if (live.ok) {
+      priceTable = mergePriceTables(priceTable, live.value);
+      pricesAsOf = new Date().toISOString().slice(0, 7); // YYYY-MM
+      layered = true;
+    } else {
+      info(
+        chalk.yellow(
+          `  Live pricing unavailable (${live.error.message}); using the static price table.`,
+        ),
+      );
+    }
+  }
+
+  if (config.prices) {
+    priceTable = mergePriceTables(priceTable, config.prices);
+    pricesAsOf = `${pricesAsOf} + custom overrides`;
+    layered = true;
+  }
+
+  const pricing: PricingPort = layered
+    ? new TablePricingAdapter(priceTable, pricesAsOf)
+    : new StaticPriceTableAdapter();
+
   const policyOptions: WastePolicyOptions = {
     minAgeDays,
     ignoreTag,

--- a/apps/cli/src/config/cloudrift.config.spec.ts
+++ b/apps/cli/src/config/cloudrift.config.spec.ts
@@ -13,6 +13,7 @@ describe('parseConfig', () => {
         minAgeDays: 14,
         ignoreTag: 'keep',
         costAlertThresholdUsd: 500,
+        prices: { 'eu-west-1': { 'nat-gateway': 28.5 }, default: { 'elastic-ip': 3.2 } },
       }),
     );
     expect(result.ok).toBe(true);
@@ -24,8 +25,23 @@ describe('parseConfig', () => {
         minAgeDays: 14,
         ignoreTag: 'keep',
         costAlertThresholdUsd: 500,
+        prices: { 'eu-west-1': { 'nat-gateway': 28.5 }, default: { 'elastic-ip': 3.2 } },
       });
     }
+  });
+
+  it('rejects a prices table with a non-number value', () => {
+    const result = parseConfig(
+      JSON.stringify({ prices: { 'eu-west-1': { 'nat-gateway': 'cheap' } } }),
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toContain('prices');
+  });
+
+  it('rejects a prices table that is not region → object', () => {
+    const result = parseConfig(JSON.stringify({ prices: { 'eu-west-1': 28.5 } }));
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toContain('prices');
   });
 
   it('returns empty config for an empty object', () => {

--- a/apps/cli/src/config/cloudrift.config.ts
+++ b/apps/cli/src/config/cloudrift.config.ts
@@ -28,6 +28,12 @@ export interface CloudriftConfig {
   ignoreTag?: string;
   /** Soglia di costo mensile: se superata, il comando esce con codice 2 (utile in CI). */
   costAlertThresholdUsd?: number;
+  /**
+   * Override prezzi per regione (tariffe speciali/aziendali). Stessa forma di
+   * `prices.json`: `regione → chiave → USD`, con `default` come fallback.
+   * Vincono su listino statico e su AWS Pricing API.
+   */
+  prices?: Record<string, Record<string, number>>;
 }
 
 export class ConfigError extends DomainError {
@@ -146,6 +152,16 @@ export function parseConfig(
     }
   }
 
+  if (obj.prices !== undefined) {
+    if (isPriceTable(obj.prices)) {
+      config.prices = obj.prices;
+    } else {
+      errors.push(
+        'prices must be an object of region → { priceKey: number } (e.g. { "eu-west-1": { "nat-gateway": 28.5 } })',
+      );
+    }
+  }
+
   if (errors.length > 0) {
     return Result.fail(
       new ConfigError(`Invalid config (${source}):\n  - ${errors.join('\n  - ')}`),
@@ -164,5 +180,20 @@ function isStringRecord(v: unknown): v is Record<string, string> {
     v !== null &&
     !Array.isArray(v) &&
     Object.values(v).every((val) => typeof val === 'string')
+  );
+}
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+function isPriceTable(v: unknown): v is Record<string, Record<string, number>> {
+  if (!isPlainObject(v)) return false;
+  return Object.values(v).every(
+    (regionPrices) =>
+      isPlainObject(regionPrices) &&
+      Object.values(regionPrices).every(
+        (price) => typeof price === 'number' && Number.isFinite(price) && price >= 0,
+      ),
   );
 }

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -24,6 +24,10 @@ program
     'path to a cloudrift config file (defaults to cloudrift.config.json / .cloudriftrc in the cwd)',
   )
   .option(
+    '--live-pricing',
+    'fetch current list prices from the AWS Pricing API (falls back to the static table; config prices still win)',
+  )
+  .option(
     '--min-age-days <days>',
     'grace period: resources younger than this many days are not reported (default 7, overrides config)',
   )

--- a/cloudrift.config.example.json
+++ b/cloudrift.config.example.json
@@ -6,5 +6,9 @@
   "cloudwatchWindowHours": 168,
   "minAgeDays": 14,
   "ignoreTag": "cloudrift:ignore",
-  "costAlertThresholdUsd": 500
+  "costAlertThresholdUsd": 500,
+  "prices": {
+    "eu-west-1": { "nat-gateway": 28.5, "ebs-gp3": 0.07 },
+    "default": { "elastic-ip": 3.2 }
+  }
 }

--- a/docs/en/technical-choices.md
+++ b/docs/en/technical-choices.md
@@ -183,4 +183,8 @@ Prices live **only** in `prices.json` (infrastructure), with per-region override
 | ALB/NLB (base) | ~$16.20/month |
 | NAT Gateway (base) | ~$32.40/month |
 
-**Maintenance:** updating prices = updating `prices.json` **and** the `pricesAsOf` field. A natural evolution is an adapter over the AWS Pricing API with a static fallback: `PricingPort` allows it without touching scanners or domain.
+**Three pricing layers (the `PricingPort` payoff).** Prices resolve per `(region, key)` from, in order: the user's `prices` overrides in the config (negotiated/company rates — highest), the **AWS Pricing API** (`--live-pricing`, `AwsPricingApiAdapter.warmUp` fetches and materialises a table), and the built-in `prices.json` (always present). All three share the same `PriceTable` shape, so they compose with a plain `mergePriceTables`; the getters stay synchronous (the live adapter warms up before the scan). Swapping/adding a source never touches the scanners or the domain — exactly what the port buys.
+
+Two safety properties: the live adapter accepts a price **only if the filters resolve to a single value** (ambiguous → fall back to static, never a wrong guess), and even live prices are AWS **list** prices, not the actual bill (Savings Plans / RI / EDP) — the `prices` override is the only way to encode real rates. `getPricesAsOf()` reflects which layer was used.
+
+**Maintenance:** updating the static fallback = updating `prices.json` **and** its `pricesAsOf` field.

--- a/docs/it/scelte-tecniche.md
+++ b/docs/it/scelte-tecniche.md
@@ -183,4 +183,8 @@ I prezzi vivono **solo** in `prices.json` (infrastruttura), con override per-reg
 | ALB/NLB (base) | ~$16.20/mese |
 | NAT Gateway (base) | ~$32.40/mese |
 
-**Manutenzione:** aggiornare i prezzi = aggiornare `prices.json` **e** il campo `pricesAsOf`. Un'evoluzione naturale è un adapter sull'AWS Pricing API con fallback sul listino statico: il `PricingPort` lo consente senza toccare scanner o domain.
+**Tre livelli di pricing (il payoff del `PricingPort`).** I prezzi si risolvono per `(regione, chiave)` da, in ordine: gli override `prices` dell'utente nel config (tariffe negoziate/aziendali — massima priorità), l'**AWS Pricing API** (`--live-pricing`, `AwsPricingApiAdapter.warmUp` recupera e materializza una tabella), e il `prices.json` built-in (sempre presente). Tutte e tre condividono la stessa forma `PriceTable`, quindi si compongono con un semplice `mergePriceTables`; i getter restano sincroni (il live fa warmUp prima dello scan). Sostituire/aggiungere una fonte non tocca mai gli scanner né il dominio — esattamente ciò che il port garantisce.
+
+Due proprietà di sicurezza: l'adapter live accetta un prezzo **solo se i filtri risolvono un valore unico** (ambiguo → fallback allo statico, mai un prezzo indovinato sbagliato), e anche i prezzi live sono prezzi di **listino** AWS, non la bolletta reale (Savings Plans / RI / EDP) — gli override `prices` sono l'unico modo per encodare le tariffe vere. `getPricesAsOf()` riflette quale livello è stato usato.
+
+**Manutenzione:** aggiornare il fallback statico = aggiornare `prices.json` **e** il suo campo `pricesAsOf`.

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/index.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/index.ts
@@ -7,5 +7,18 @@ export { AwsEbsSnapshotScanner } from './scanners/aws-ebs-snapshot.scanner';
 export { AwsNatGatewayScanner } from './scanners/aws-nat-gateway.scanner';
 export { AwsGp2UpgradeScanner } from './scanners/aws-gp2-upgrade.scanner';
 export { AwsAdapterError } from './errors/aws-adapter.error';
-export { StaticPriceTableAdapter } from './pricing/static-price-table.adapter';
+export {
+  StaticPriceTableAdapter,
+  BUILTIN_PRICE_TABLE,
+  BUILTIN_PRICES_AS_OF,
+} from './pricing/static-price-table.adapter';
+export {
+  TablePricingAdapter,
+  mergePriceTables,
+} from './pricing/table-pricing.adapter';
+export type { PriceTable, RegionPrices } from './pricing/table-pricing.adapter';
+export {
+  AwsPricingApiAdapter,
+  extractOnDemandUsd,
+} from './pricing/aws-pricing-api.adapter';
 export { resolveAwsAccountId } from './account/aws-account-id.resolver';

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/pricing/aws-pricing-api.adapter.spec.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/pricing/aws-pricing-api.adapter.spec.ts
@@ -1,0 +1,113 @@
+import { PricingClient, GetProductsCommand } from '@aws-sdk/client-pricing';
+import { AwsRegion } from 'cloud-cost-domain';
+import { AwsPricingApiAdapter, extractOnDemandUsd } from './aws-pricing-api.adapter';
+
+// Mock only the client; keep GetProductsCommand real so `cmd.input` is populated.
+jest.mock('@aws-sdk/client-pricing', () => {
+  const actual = jest.requireActual('@aws-sdk/client-pricing');
+  return { ...actual, PricingClient: jest.fn() };
+});
+
+const mockSend = jest.fn();
+const mockDestroy = jest.fn();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (PricingClient as jest.Mock).mockImplementation(() => ({
+    send: mockSend,
+    destroy: mockDestroy,
+  }));
+});
+
+const euWest1 = AwsRegion.create('eu-west-1');
+const unknownRegion = AwsRegion.create('mx-central-1'); // not in REGION_TO_LOCATION
+
+/** Builds a PriceList JSON string with a single OnDemand USD price. */
+function priceListItem(usd: string): string {
+  return JSON.stringify({
+    terms: {
+      OnDemand: {
+        offer1: {
+          priceDimensions: {
+            dim1: { pricePerUnit: { USD: usd } },
+          },
+        },
+      },
+    },
+  });
+}
+
+describe('extractOnDemandUsd', () => {
+  it('extracts a positive USD price from a JSON string', () => {
+    expect(extractOnDemandUsd(priceListItem('0.0880000000'))).toEqual([0.088]);
+  });
+
+  it('extracts from an already-parsed object', () => {
+    expect(extractOnDemandUsd(JSON.parse(priceListItem('0.045')))).toEqual([0.045]);
+  });
+
+  it('ignores zero-priced dimensions (free tiers)', () => {
+    expect(extractOnDemandUsd(priceListItem('0.0000000000'))).toEqual([]);
+  });
+
+  it('returns [] for malformed input', () => {
+    expect(extractOnDemandUsd('{ not json')).toEqual([]);
+    expect(extractOnDemandUsd({})).toEqual([]);
+  });
+});
+
+describe('AwsPricingApiAdapter.warmUp', () => {
+  it('builds a PriceTable from unambiguous prices and converts hourly to monthly', async () => {
+    // Every GetProducts call returns one product; NAT (hourly) → ×730.
+    mockSend.mockImplementation((cmd: GetProductsCommand) => {
+      const filters = cmd.input.Filters ?? [];
+      const isNat = filters.some((f) => f.Value === 'NAT Gateway');
+      const usd = isNat ? '0.0450000000' : '0.0880000000';
+      return Promise.resolve({ PriceList: [priceListItem(usd)] });
+    });
+
+    const adapter = new AwsPricingApiAdapter();
+    const result = await adapter.warmUp([euWest1]);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const prices = result.value['eu-west-1'];
+    expect(prices['ebs-gp3']).toBe(0.088);
+    expect(prices['nat-gateway']).toBe(+(0.045 * 730).toFixed(4)); // 32.85
+    expect(mockDestroy).toHaveBeenCalledTimes(1);
+  });
+
+  it('omits a key when the filter is ambiguous (multiple distinct prices)', async () => {
+    mockSend.mockResolvedValue({
+      PriceList: [priceListItem('0.10'), priceListItem('0.20')],
+    });
+
+    const adapter = new AwsPricingApiAdapter();
+    const result = await adapter.warmUp([euWest1]);
+
+    expect(result.ok).toBe(true);
+    // Every spec is ambiguous → no prices resolved → region omitted entirely.
+    if (result.ok) expect(result.value['eu-west-1']).toBeUndefined();
+  });
+
+  it('skips regions with no known location mapping', async () => {
+    mockSend.mockResolvedValue({ PriceList: [priceListItem('0.08')] });
+
+    const adapter = new AwsPricingApiAdapter();
+    const result = await adapter.warmUp([unknownRegion]);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toEqual({});
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  it('returns Result.fail (so the caller falls back to static) on SDK error', async () => {
+    mockSend.mockRejectedValue(new Error('AccessDenied: pricing:GetProducts'));
+
+    const adapter = new AwsPricingApiAdapter();
+    const result = await adapter.warmUp([euWest1]);
+
+    expect(result.ok).toBe(false);
+    expect(mockDestroy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/pricing/aws-pricing-api.adapter.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/pricing/aws-pricing-api.adapter.ts
@@ -1,0 +1,198 @@
+import {
+  PricingClient,
+  GetProductsCommand,
+  type Filter,
+} from '@aws-sdk/client-pricing';
+import { Result } from 'shared-kernel';
+import type { AwsRegion } from 'cloud-cost-domain';
+import { AwsAdapterError } from '../errors/aws-adapter.error';
+import { mapWithConcurrency } from '../utils/map-with-concurrency';
+import type { PriceTable, RegionPrices } from './table-pricing.adapter';
+
+/** Il Pricing API risiede solo in alcune regioni; us-east-1 è sempre valida. */
+const PRICING_API_REGION = 'us-east-1';
+/** Convenzione AWS per convertire i prezzi orari in mensili. */
+const HOURS_PER_MONTH = 730;
+/** Chiamate Pricing simultanee per regione (l'API ha rate limit bassi). */
+const PRICING_CONCURRENCY = 5;
+
+/**
+ * Mappa codice regione → "location" leggibile usata dal Pricing API.
+ * Le regioni non presenti vengono lasciate al listino statico.
+ */
+const REGION_TO_LOCATION: Record<string, string> = {
+  'us-east-1': 'US East (N. Virginia)',
+  'us-east-2': 'US East (Ohio)',
+  'us-west-1': 'US West (N. California)',
+  'us-west-2': 'US West (Oregon)',
+  'ca-central-1': 'Canada (Central)',
+  'eu-west-1': 'EU (Ireland)',
+  'eu-west-2': 'EU (London)',
+  'eu-west-3': 'EU (Paris)',
+  'eu-central-1': 'EU (Frankfurt)',
+  'eu-north-1': 'EU (Stockholm)',
+  'eu-south-1': 'EU (Milan)',
+  'ap-east-1': 'Asia Pacific (Hong Kong)',
+  'ap-south-1': 'Asia Pacific (Mumbai)',
+  'ap-southeast-1': 'Asia Pacific (Singapore)',
+  'ap-southeast-2': 'Asia Pacific (Sydney)',
+  'ap-northeast-1': 'Asia Pacific (Tokyo)',
+  'ap-northeast-2': 'Asia Pacific (Seoul)',
+  'ap-northeast-3': 'Asia Pacific (Osaka)',
+  'sa-east-1': 'South America (Sao Paulo)',
+  'me-south-1': 'Middle East (Bahrain)',
+  'af-south-1': 'Africa (Cape Town)',
+};
+
+type PriceUnit = 'gb-month' | 'hourly';
+
+interface PriceSpec {
+  /** Chiave nella PriceTable (deve combaciare con quelle di prices.json). */
+  key: string;
+  serviceCode: string;
+  /** Filtri TERM_MATCH oltre a `location` (aggiunto automaticamente). */
+  filters: Array<{ Field: string; Value: string }>;
+  unit: PriceUnit;
+}
+
+/**
+ * Specifiche di prezzo recuperate dal Pricing API. Ogni voce mappa una chiave
+ * della PriceTable a un prodotto AWS tramite ServiceCode + filtri. La routine
+ * di fetch è generica e accetta un prezzo solo se i filtri identificano un
+ * unico valore (vedi `fetchPrice`): filtri ambigui ⇒ fallback allo statico.
+ */
+const PRICE_SPECS: readonly PriceSpec[] = [
+  ...(['gp3', 'gp2', 'io1', 'io2', 'st1', 'sc1', 'standard'] as const).map(
+    (vol): PriceSpec => ({
+      key: `ebs-${vol}`,
+      serviceCode: 'AmazonEC2',
+      filters: [
+        { Field: 'productFamily', Value: 'Storage' },
+        { Field: 'volumeApiName', Value: vol },
+      ],
+      unit: 'gb-month',
+    }),
+  ),
+  {
+    key: 'ebs-snapshot',
+    serviceCode: 'AmazonEC2',
+    filters: [{ Field: 'productFamily', Value: 'Storage Snapshot' }],
+    unit: 'gb-month',
+  },
+  {
+    key: 'nat-gateway',
+    serviceCode: 'AmazonEC2',
+    filters: [{ Field: 'productFamily', Value: 'NAT Gateway' }],
+    unit: 'hourly',
+  },
+  {
+    key: 'elastic-ip',
+    serviceCode: 'AmazonEC2',
+    filters: [
+      { Field: 'productFamily', Value: 'IP Address' },
+      { Field: 'group', Value: 'ElasticIP:IdleAddress' },
+    ],
+    unit: 'hourly',
+  },
+];
+
+/**
+ * Adapter che recupera i prezzi dall'AWS Pricing API. Non implementa
+ * direttamente `PricingPort`: produce una `PriceTable` via `warmUp` che il
+ * composition root fonde con il listino statico e gli override dell'utente.
+ */
+export class AwsPricingApiAdapter {
+  constructor(
+    private readonly client = new PricingClient({ region: PRICING_API_REGION }),
+  ) {}
+
+  /**
+   * Recupera i prezzi per le regioni richieste e ne costruisce una PriceTable.
+   * Una chiave assente (regione sconosciuta, filtro ambiguo, prodotto non
+   * trovato) viene semplicemente omessa: il merge la lascia allo statico.
+   */
+  async warmUp(regions: readonly AwsRegion[]): Promise<Result<PriceTable>> {
+    try {
+      const table: PriceTable = {};
+      for (const region of regions) {
+        const location = REGION_TO_LOCATION[region.code];
+        if (!location) continue;
+
+        const prices = await mapWithConcurrency(
+          PRICE_SPECS,
+          PRICING_CONCURRENCY,
+          async (spec) => ({ key: spec.key, value: await this.fetchPrice(spec, location) }),
+        );
+
+        const regionPrices: RegionPrices = {};
+        for (const { key, value } of prices) {
+          if (value !== undefined) regionPrices[key] = value;
+        }
+        if (Object.keys(regionPrices).length > 0) table[region.code] = regionPrices;
+      }
+      return Result.ok(table);
+    } catch (err) {
+      return Result.fail(new AwsAdapterError('Pricing', err as Error));
+    } finally {
+      this.client.destroy();
+    }
+  }
+
+  /**
+   * Restituisce il prezzo per una spec **solo se i prodotti restituiti
+   * concordano su un unico valore**. Filtri ambigui (più valori distinti) ⇒
+   * `undefined`, per non rischiare un prezzo sbagliato (peggio del listino).
+   */
+  private async fetchPrice(spec: PriceSpec, location: string): Promise<number | undefined> {
+    const filters: Filter[] = [
+      { Type: 'TERM_MATCH', Field: 'location', Value: location },
+      ...spec.filters.map((f) => ({ Type: 'TERM_MATCH' as const, Field: f.Field, Value: f.Value })),
+    ];
+
+    const response = await this.client.send(
+      new GetProductsCommand({ ServiceCode: spec.serviceCode, Filters: filters, MaxResults: 100 }),
+    );
+
+    const distinct = new Set<number>();
+    for (const item of response.PriceList ?? []) {
+      for (const usd of extractOnDemandUsd(item)) distinct.add(usd);
+    }
+    if (distinct.size !== 1) return undefined;
+
+    const [usd] = [...distinct];
+    const monthly = spec.unit === 'hourly' ? usd * HOURS_PER_MONTH : usd;
+    return +monthly.toFixed(4);
+  }
+}
+
+/**
+ * Estrae i prezzi OnDemand (USD, > 0) da una voce PriceList. La voce è una
+ * stringa JSON (o già un oggetto, a seconda della versione SDK).
+ */
+export function extractOnDemandUsd(item: unknown): number[] {
+  let product: unknown;
+  if (typeof item === 'string') {
+    try {
+      product = JSON.parse(item);
+    } catch {
+      return [];
+    }
+  } else {
+    product = item;
+  }
+
+  const onDemand = (product as { terms?: { OnDemand?: Record<string, unknown> } })?.terms?.OnDemand;
+  if (!onDemand || typeof onDemand !== 'object') return [];
+
+  const prices: number[] = [];
+  for (const offer of Object.values(onDemand)) {
+    const dimensions = (offer as { priceDimensions?: Record<string, unknown> })?.priceDimensions;
+    if (!dimensions) continue;
+    for (const dimension of Object.values(dimensions)) {
+      const usd = (dimension as { pricePerUnit?: { USD?: string } })?.pricePerUnit?.USD;
+      const value = usd !== undefined ? Number(usd) : NaN;
+      if (Number.isFinite(value) && value > 0) prices.push(value);
+    }
+  }
+  return prices;
+}

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/pricing/static-price-table.adapter.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/pricing/static-price-table.adapter.ts
@@ -1,41 +1,30 @@
-import type { PricingPort, AwsRegion } from 'cloud-cost-domain';
 import priceTable from './prices.json';
+import {
+  TablePricingAdapter,
+  type PriceTable,
+  type RegionPrices,
+} from './table-pricing.adapter';
 
-type PriceKey = keyof typeof priceTable.default;
-type RegionTable = Record<string, number>;
+/**
+ * La tabella prezzi built-in, estratta da `prices.json` scartando i campi di
+ * metadati (`_comment`, `pricesAsOf`) e tenendo solo le tabelle per regione.
+ * Esportata per poterla comporre con le altre fonti (live API, override utente).
+ */
+export const BUILTIN_PRICE_TABLE: PriceTable = Object.fromEntries(
+  Object.entries(priceTable as Record<string, unknown>).filter(
+    ([, value]) => typeof value === 'object' && value !== null,
+  ) as Array<[string, RegionPrices]>,
+);
 
-function lookup(region: AwsRegion, key: PriceKey): number {
-  const regionTable = (priceTable as unknown as Record<string, RegionTable>)[region.code];
-  if (regionTable?.[key] !== undefined) return regionTable[key];
-  return priceTable.default[key];
-}
+/** Data (YYYY-MM) di ultima verifica del listino built-in. */
+export const BUILTIN_PRICES_AS_OF: string = priceTable.pricesAsOf;
 
-export class StaticPriceTableAdapter implements PricingPort {
-  getEbsVolumePricePerGbMonth(region: AwsRegion, volumeType: string): number {
-    return lookup(region, `ebs-${volumeType}` as PriceKey) ?? priceTable.default['ebs-gp3'];
-  }
-
-  getEbsSnapshotPricePerGbMonth(region: AwsRegion): number {
-    return lookup(region, 'ebs-snapshot');
-  }
-
-  getElasticIpPricePerMonth(region: AwsRegion): number {
-    return lookup(region, 'elastic-ip');
-  }
-
-  getRdsStoragePricePerGbMonth(region: AwsRegion, storageType: string): number {
-    return lookup(region, `rds-${storageType}` as PriceKey) ?? priceTable.default['rds-gp2'];
-  }
-
-  getLoadBalancerPricePerMonth(region: AwsRegion): number {
-    return lookup(region, 'load-balancer');
-  }
-
-  getNatGatewayPricePerMonth(region: AwsRegion): number {
-    return lookup(region, 'nat-gateway');
-  }
-
-  getPricesAsOf(): string {
-    return priceTable.pricesAsOf;
+/**
+ * Adapter di pricing basato sul listino statico `prices.json`. È il fallback
+ * sempre disponibile quando non sono configurati prezzi live o manuali.
+ */
+export class StaticPriceTableAdapter extends TablePricingAdapter {
+  constructor() {
+    super(BUILTIN_PRICE_TABLE, BUILTIN_PRICES_AS_OF);
   }
 }

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/pricing/table-pricing.adapter.spec.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/pricing/table-pricing.adapter.spec.ts
@@ -1,0 +1,72 @@
+import { AwsRegion } from 'cloud-cost-domain';
+import {
+  TablePricingAdapter,
+  mergePriceTables,
+  type PriceTable,
+} from './table-pricing.adapter';
+
+const usEast1 = AwsRegion.create('us-east-1');
+const euWest1 = AwsRegion.create('eu-west-1');
+const unlisted = AwsRegion.create('ca-central-1');
+
+const table: PriceTable = {
+  default: { 'ebs-gp3': 0.08, 'ebs-gp2': 0.1, 'nat-gateway': 32.4, 'elastic-ip': 3.6, 'rds-gp2': 0.115 },
+  'eu-west-1': { 'nat-gateway': 36.72, 'ebs-gp3': 0.088 },
+};
+
+describe('TablePricingAdapter', () => {
+  const adapter = new TablePricingAdapter(table, '2025-06');
+
+  it('returns the region-specific price when present', () => {
+    expect(adapter.getNatGatewayPricePerMonth(euWest1)).toBe(36.72);
+    expect(adapter.getEbsVolumePricePerGbMonth(euWest1, 'gp3')).toBe(0.088);
+  });
+
+  it('falls back to default for an unlisted region', () => {
+    expect(adapter.getNatGatewayPricePerMonth(unlisted)).toBe(32.4);
+    expect(adapter.getEbsVolumePricePerGbMonth(usEast1, 'gp3')).toBe(0.08);
+  });
+
+  it('falls back to gp3 default for an unknown EBS volume type', () => {
+    expect(adapter.getEbsVolumePricePerGbMonth(usEast1, 'unknown')).toBe(0.08);
+  });
+
+  it('falls back to rds-gp2 default for an unknown RDS storage type', () => {
+    expect(adapter.getRdsStoragePricePerGbMonth(usEast1, 'nvme')).toBe(0.115);
+  });
+
+  it('exposes the pricesAsOf passed in', () => {
+    expect(adapter.getPricesAsOf()).toBe('2025-06');
+  });
+});
+
+describe('mergePriceTables', () => {
+  it('overlays per (region, key), with the overlay winning', () => {
+    const base: PriceTable = {
+      default: { 'nat-gateway': 32.4, 'elastic-ip': 3.6 },
+      'eu-west-1': { 'nat-gateway': 36.72 },
+    };
+    const overlay: PriceTable = {
+      'eu-west-1': { 'nat-gateway': 28.5 }, // user's negotiated rate
+      default: { 'ebs-gp3': 0.07 }, // a key only in overlay
+    };
+
+    const merged = mergePriceTables(base, overlay);
+
+    // overlay wins for eu-west-1 nat-gateway
+    expect(merged['eu-west-1']['nat-gateway']).toBe(28.5);
+    // base keys preserved where not overridden
+    expect(merged.default['nat-gateway']).toBe(32.4);
+    expect(merged.default['elastic-ip']).toBe(3.6);
+    // overlay-only key added
+    expect(merged.default['ebs-gp3']).toBe(0.07);
+  });
+
+  it('user overrides take effect through the adapter', () => {
+    const merged = mergePriceTables(table, { 'eu-west-1': { 'nat-gateway': 20 } });
+    const adapter = new TablePricingAdapter(merged, '2025-06 + custom overrides');
+    expect(adapter.getNatGatewayPricePerMonth(euWest1)).toBe(20);
+    // unrelated region untouched
+    expect(adapter.getNatGatewayPricePerMonth(unlisted)).toBe(32.4);
+  });
+});

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/pricing/table-pricing.adapter.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/pricing/table-pricing.adapter.ts
@@ -1,0 +1,69 @@
+import type { PricingPort, AwsRegion } from 'cloud-cost-domain';
+
+/** Prezzi di una singola regione: chiave (es. "ebs-gp3", "nat-gateway") → USD. */
+export type RegionPrices = Record<string, number>;
+
+/**
+ * Tabella prezzi: `regione → prezzi`, con una chiave speciale `default` usata
+ * come fallback per le regioni non elencate. È la forma condivisa da tutte le
+ * fonti di prezzo (listino statico, AWS Pricing API, override dell'utente),
+ * così le sorgenti si compongono con un semplice merge.
+ */
+export type PriceTable = Record<string, RegionPrices>;
+
+/**
+ * Fonde due tabelle prezzi a livello di (regione, chiave): i valori di
+ * `overlay` vincono su quelli di `base`. Usato per stratificare le fonti:
+ * statico (base) ← live API ← override dell'utente (vince).
+ */
+export function mergePriceTables(base: PriceTable, overlay: PriceTable): PriceTable {
+  const result: PriceTable = {};
+  for (const region of new Set([...Object.keys(base), ...Object.keys(overlay)])) {
+    result[region] = { ...base[region], ...overlay[region] };
+  }
+  return result;
+}
+
+/**
+ * Adapter di pricing che legge da una `PriceTable` in memoria. I getter sono
+ * sincroni: qualunque fonte asincrona (AWS Pricing API) deve prima
+ * materializzare la propria tabella, poi comporla qui.
+ */
+export class TablePricingAdapter implements PricingPort {
+  constructor(
+    private readonly table: PriceTable,
+    private readonly pricesAsOf: string,
+  ) {}
+
+  private lookup(region: AwsRegion, key: string): number | undefined {
+    return this.table[region.code]?.[key] ?? this.table.default?.[key];
+  }
+
+  getEbsVolumePricePerGbMonth(region: AwsRegion, volumeType: string): number {
+    return this.lookup(region, `ebs-${volumeType}`) ?? this.table.default?.['ebs-gp3'] ?? 0;
+  }
+
+  getEbsSnapshotPricePerGbMonth(region: AwsRegion): number {
+    return this.lookup(region, 'ebs-snapshot') ?? 0;
+  }
+
+  getElasticIpPricePerMonth(region: AwsRegion): number {
+    return this.lookup(region, 'elastic-ip') ?? 0;
+  }
+
+  getRdsStoragePricePerGbMonth(region: AwsRegion, storageType: string): number {
+    return this.lookup(region, `rds-${storageType}`) ?? this.table.default?.['rds-gp2'] ?? 0;
+  }
+
+  getLoadBalancerPricePerMonth(region: AwsRegion): number {
+    return this.lookup(region, 'load-balancer') ?? 0;
+  }
+
+  getNatGatewayPricePerMonth(region: AwsRegion): number {
+    return this.lookup(region, 'nat-gateway') ?? 0;
+  }
+
+  getPricesAsOf(): string {
+    return this.pricesAsOf;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@aws-sdk/client-cloudwatch": "^3.741.0",
     "@aws-sdk/client-ec2": "^3.741.0",
     "@aws-sdk/client-elastic-load-balancing-v2": "^3.741.0",
+    "@aws-sdk/client-pricing": "^3.1070.0",
     "@aws-sdk/client-rds": "^3.741.0",
     "@aws-sdk/client-sts": "^3.1068.0",
     "chalk": "^4.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@aws-sdk/client-elastic-load-balancing-v2':
         specifier: ^3.741.0
         version: 3.1064.0
+      '@aws-sdk/client-pricing':
+        specifier: ^3.1070.0
+        version: 3.1070.0
       '@aws-sdk/client-rds':
         specifier: ^3.741.0
         version: 3.1064.0
@@ -194,6 +197,10 @@ packages:
     resolution: {integrity: sha512-OEq9iZYL4QVsHf+kP4Aws5jM6SVPLJ9FZ70MCOr3I/m4XQRhZ+i9uCDqpJPz4sm+iQZQ3MkYTfIyXtCungeHmQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/client-pricing@3.1070.0':
+    resolution: {integrity: sha512-rzRAoJu67pSMVdpAg+ToYdZyGK/AyXecOnuNZb+aADH2gZGVnUY9/GlhR5lyH+fKIz5OJjh+Qv3iiercxwTR4A==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/client-rds@3.1064.0':
     resolution: {integrity: sha512-rrdpDGsPPK4hLmXb8e698Y/AXxFFkJI21FY9euSBwcTAs8SCUCcHhJDWiSslb8GkzyVfo56296hTFoZxMr5qGw==}
     engines: {node: '>=20.0.0'}
@@ -210,12 +217,20 @@ packages:
     resolution: {integrity: sha512-7sDi2B2N3mc3nf1nz6FyEx/FCrJ1N1QnBmraHHQNabFaeAh2IaOOLml48/rHOD1bICHgTRkbBgNTvUzEr5Z35g==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/core@3.974.21':
+    resolution: {integrity: sha512-P5JAHvn4dTi96UsAGS67LVOqqpUNNRhnfFXqzCYtdBIGZtqBue4CXvRr9YenOO7PALj/Pn8uuyw53FBCiCYw8w==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-env@3.972.45':
     resolution: {integrity: sha512-ZPsnLyrpDRmojKrBbJykASyLLVFkjyD+fWATeSuYgaqablijGOzxPxEKyrwUvNg+bgSQ7PkW2FTu65Xco19Gag==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-env@3.972.46':
     resolution: {integrity: sha512-+GPXVS2srMOlH74S+SmC1gVuP2TvUZ0siuC0onKO93q+udP+M72dmY8wJfVQ5CX9z/9X5A1HHwz5yRIGBtskvQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.47':
+    resolution: {integrity: sha512-3YoPwJczcc+MtX2xxXaYaOOWO6xKUJr1ZIIDIFuninr51BYONVVcF/CP8K2xfVRC/PztJjqKWxNGFH7BWQAw1Q==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-http@3.972.47':
@@ -226,12 +241,20 @@ packages:
     resolution: {integrity: sha512-fA5loSdlocacRxyUXtpoHSMuk5rsIKRDzQYVMnMxjcmFeZshaJlJ8lymy/hYKji6sne/UmNGj5pxuEs6kq/Qcg==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-http@3.972.49':
+    resolution: {integrity: sha512-2UtGUPy+x3lqyceHrtC1uEuVxBZbDalPF6KAFqBwYgm4edWdBrZKNnCqzDs7KynWUvEC6mrR+ojRk+ZgQz9C2w==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-ini@3.972.51':
     resolution: {integrity: sha512-f8sRTVyM+9BbzQKPlUP9dVVpgNEu65jFckNAAGzRfCrlaSi5AWUbCKEHIMcIYokv8pWblSKEqHkqKYZtwINnhw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-ini@3.972.53':
     resolution: {integrity: sha512-ZfdhIOR41q8TcWEnUac+gCOb+O2LBWdHLmjedXpXz4IEFW2ppNuFcm6p0sMTavpM+zD5TYfpH5Gp7guRyqSgsQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.972.54':
+    resolution: {integrity: sha512-Hx4gO4YRjFwitf3MVl3cDwYe1aryJthC4txVl9b+JAURovA50M2ywf9r8j1E/Q6SCTPT4qQpjOAbKYIC9CG+Vw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-login@3.972.50':
@@ -242,12 +265,20 @@ packages:
     resolution: {integrity: sha512-9hu2oR0qH7Fst5Tzdx+UWxm+w5zCXtErTLtOOW5hwwQc170CLwOeniRxyFY6s9mHfGEfC5zFukNBdKBwJR8mhQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-login@3.972.53':
+    resolution: {integrity: sha512-+71sluhkgPqdhbbD3UDwUpj24GCkng9HQx6z7qoBFb8dwkF4ktpOcVKDeHpgg8PvBgLYwAnUYLTEGRC/PniCiQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-node@3.972.53':
     resolution: {integrity: sha512-z/JJ8Qvf2GiTn4bw+x8k7wQjxmPpNsiwZ7ls/h1cZHikrSpS0+65lB+lafnXZlxv1lqH4k6rQwh+2UsycC662g==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-node@3.972.55':
     resolution: {integrity: sha512-zMGLa/dhESVqmCD7mmIFFKSwSFrJGScvCXcjvBZEVOOMauFS5JRQvLTMukFpMEFWiV6dTAlsen2ATDBulLPtbg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.56':
+    resolution: {integrity: sha512-iI+4o0dvQQ4NHel4FMDiFy5q2gaU/ryLK3niOsoPccAt9WLFRkV4XTYPWRr9XvmBUqEzXG73S4p/8gm0Lu/W3A==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-process@3.972.45':
@@ -258,6 +289,10 @@ packages:
     resolution: {integrity: sha512-VUoNFBIjWrUN8NbFiQiuxQEgFjvziAlBRPK+ddh27aj65gk0BYu6bLZnrdrNZwpW6vAihtSUtEMQ1PUJ32QRPA==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-process@3.972.47':
+    resolution: {integrity: sha512-tAizPm9IFo/PHn06c+LQJlzfY2AGOlyF0CUljFejrU6LcZBjnk8pmbZK3/xoIDdnIzjEdbClfvY3mXfr818ZEg==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-sso@3.972.50':
     resolution: {integrity: sha512-pQ9ww4G53gwHlon1NMz25JhaBo13E9Jv+VVgjh39C/yzvby+xhSnEOb+VDYShKNCh1TbttMF/5CFCHkZrIqOcA==}
     engines: {node: '>=20.0.0'}
@@ -266,12 +301,20 @@ packages:
     resolution: {integrity: sha512-nb2/n4o/HQf+FVpVbZe9vCTFngmuDoIsltMgLAtjixaKzvzhB4J8WSDFyWgnErgLHk55ctWH+I4PU+LIHhyffg==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-sso@3.972.53':
+    resolution: {integrity: sha512-pUXE3fu4tfEDV8BksIgf4dXvuIH10FhwHMl/wu8rBD5T1sMpryQWFVitH3kdPS90wlgrGYJQ/meQTSPacyZfeg==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-web-identity@3.972.50':
     resolution: {integrity: sha512-9DbaPaT2aMbz18wtSpq9HVBErjBQwxykqTFgG6n8Bn05GN68mITz+G1869ekYx0mVT/BDjETj5czz/3cPgLwxA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-web-identity@3.972.52':
     resolution: {integrity: sha512-lKj6aRSGbqLmpYmM24bY7a1Xmfcq2vkE3hv8CSPYfc1yCu0BPu/XEJ1L4Fm61MsU6ULLNSG8UGsffNoFUBjESA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.53':
+    resolution: {integrity: sha512-JmMGlhVvSj8uSG9CpeDkJAXT35H89tc6v84iMgEIE75q4yp1MKVVKvopv6Gg28HJIR7hMNkojRF8H2m5W44wyg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/middleware-sdk-ec2@3.972.33':
@@ -290,12 +333,20 @@ packages:
     resolution: {integrity: sha512-IYJuLpXp2DEILVQpQOy0PMpkftv0AHEOCn52o0atyOaumA0CdWQ3klPyXdViGYLbNpESsVFMVybvHUeZAuiGxA==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/nested-clients@3.997.21':
+    resolution: {integrity: sha512-eC7Vl7Qom/BGhZjG9GEqPwdQ/fk45hg1t5LP4EUxG5d1fdshLbaxCiwh/tszUzDX/4mW40mu2QsbeJJRPBbqUw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/signature-v4-multi-region@3.996.33':
     resolution: {integrity: sha512-Hn0RThJEbyOZWV2PV9Z4YD3nitGPxybmyU17dSe9b61WOBcKnqS0WTtM3c1zyZq9WnGiyrfi/i+UBPUk7cM8Ug==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/signature-v4-multi-region@3.996.34':
     resolution: {integrity: sha512-mx1L5qlumSOt/nKM3BFaHE2HVkWwz0i4Bw0pyYO42FfX/FeLlo8YI6csC0gSPprEk6fTIqI+CZN9RwUwKd5krQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.35':
+    resolution: {integrity: sha512-6L/VWs+Wch2stHemCGTmUNqKLMzURxQDK5boNG3Jn3kAOp71meDUuS5sbObpEvFxHDq0uWeSLFDNSYsjNt+Dlg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/token-providers@3.1064.0':
@@ -306,8 +357,16 @@ packages:
     resolution: {integrity: sha512-UqEUJq7dqa44hneLDUcX7UJy95cg8YqEWyakRpvIPnrNS3Mq+UlQHgCDGu5pvwAPtlIW4qcYbvW6reG6++FyvA==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/token-providers@3.1069.0':
+    resolution: {integrity: sha512-ks4X+kngC3PA5howV7Qu1TgG4bfC4jPykKdvw3nmBSXR9yZxRJouBholFSNQ5kY3L+Fgwyw+LCjzQmNi+KR91g==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/types@3.973.12':
     resolution: {integrity: sha512-43ajd1NF0RMgX5k0hxCNUyEdrtFUsb2aHT2QvpktSC/2Eyb2Jr/JPVqdp0XIoaHWikZJq5tNWSLO6kB5q2eMCA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.973.13':
+    resolution: {integrity: sha512-pEHZqRkAlHfnfAU9tK+WpKv/gBNjGJrHMgA3A0iYRGyswBS2t0pfez+lWlwktb3Bqa0ovh7w/QJTFwp3fDxLNg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/util-locate-window@3.965.7':
@@ -316,6 +375,10 @@ packages:
 
   '@aws-sdk/xml-builder@3.972.29':
     resolution: {integrity: sha512-fk0niuGFxfi8yIJuMVM4mhwObkiQSuwZFj3tAPrLVx64Pk3BkrEIpqjzHKY4hKoEBUD6Jg/S74Zj9jy+5F3DnQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.30':
+    resolution: {integrity: sha512-StElZPEoBquWwNqw1AcfpzEyZqJvFxouG+mpDNYlcH6ZOrqd2CuIryv+8LV8gNHZUOyKyJF3Dq9vxaXEmDR9TQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws/lambda-invoke-store@0.2.4':
@@ -4019,7 +4082,7 @@ snapshots:
       '@aws-crypto/sha256-js': 5.2.0
       '@aws-crypto/supports-web-crypto': 5.2.0
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.12
+      '@aws-sdk/types': 3.973.13
       '@aws-sdk/util-locate-window': 3.965.7
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
@@ -4027,7 +4090,7 @@ snapshots:
   '@aws-crypto/sha256-js@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.12
+      '@aws-sdk/types': 3.973.13
       tslib: 2.8.1
 
   '@aws-crypto/supports-web-crypto@5.2.0':
@@ -4075,6 +4138,19 @@ snapshots:
       '@aws-sdk/core': 3.974.19
       '@aws-sdk/credential-provider-node': 3.972.53
       '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.24.6
+      '@smithy/fetch-http-handler': 5.4.6
+      '@smithy/node-http-handler': 4.7.7
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/client-pricing@3.1070.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.21
+      '@aws-sdk/credential-provider-node': 3.972.56
+      '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.24.6
       '@smithy/fetch-http-handler': 5.4.6
       '@smithy/node-http-handler': 4.7.7
@@ -4131,6 +4207,17 @@ snapshots:
       bowser: 2.14.1
       tslib: 2.8.1
 
+  '@aws-sdk/core@3.974.21':
+    dependencies:
+      '@aws-sdk/types': 3.973.13
+      '@aws-sdk/xml-builder': 3.972.30
+      '@aws/lambda-invoke-store': 0.2.4
+      '@smithy/core': 3.24.6
+      '@smithy/signature-v4': 5.4.6
+      '@smithy/types': 4.14.3
+      bowser: 2.14.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-env@3.972.45':
     dependencies:
       '@aws-sdk/core': 3.974.19
@@ -4143,6 +4230,14 @@ snapshots:
     dependencies:
       '@aws-sdk/core': 3.974.20
       '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.24.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.47':
+    dependencies:
+      '@aws-sdk/core': 3.974.21
+      '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.24.6
       '@smithy/types': 4.14.3
       tslib: 2.8.1
@@ -4161,6 +4256,16 @@ snapshots:
     dependencies:
       '@aws-sdk/core': 3.974.20
       '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.24.6
+      '@smithy/fetch-http-handler': 5.4.6
+      '@smithy/node-http-handler': 4.7.7
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.49':
+    dependencies:
+      '@aws-sdk/core': 3.974.21
+      '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.24.6
       '@smithy/fetch-http-handler': 5.4.6
       '@smithy/node-http-handler': 4.7.7
@@ -4199,6 +4304,22 @@ snapshots:
       '@smithy/types': 4.14.3
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-ini@3.972.54':
+    dependencies:
+      '@aws-sdk/core': 3.974.21
+      '@aws-sdk/credential-provider-env': 3.972.47
+      '@aws-sdk/credential-provider-http': 3.972.49
+      '@aws-sdk/credential-provider-login': 3.972.53
+      '@aws-sdk/credential-provider-process': 3.972.47
+      '@aws-sdk/credential-provider-sso': 3.972.53
+      '@aws-sdk/credential-provider-web-identity': 3.972.53
+      '@aws-sdk/nested-clients': 3.997.21
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.24.6
+      '@smithy/credential-provider-imds': 4.3.8
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-login@3.972.50':
     dependencies:
       '@aws-sdk/core': 3.974.19
@@ -4213,6 +4334,15 @@ snapshots:
       '@aws-sdk/core': 3.974.20
       '@aws-sdk/nested-clients': 3.997.20
       '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.24.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.53':
+    dependencies:
+      '@aws-sdk/core': 3.974.21
+      '@aws-sdk/nested-clients': 3.997.21
+      '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.24.6
       '@smithy/types': 4.14.3
       tslib: 2.8.1
@@ -4245,6 +4375,20 @@ snapshots:
       '@smithy/types': 4.14.3
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-node@3.972.56':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.47
+      '@aws-sdk/credential-provider-http': 3.972.49
+      '@aws-sdk/credential-provider-ini': 3.972.54
+      '@aws-sdk/credential-provider-process': 3.972.47
+      '@aws-sdk/credential-provider-sso': 3.972.53
+      '@aws-sdk/credential-provider-web-identity': 3.972.53
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.24.6
+      '@smithy/credential-provider-imds': 4.3.8
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-process@3.972.45':
     dependencies:
       '@aws-sdk/core': 3.974.19
@@ -4257,6 +4401,14 @@ snapshots:
     dependencies:
       '@aws-sdk/core': 3.974.20
       '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.24.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.47':
+    dependencies:
+      '@aws-sdk/core': 3.974.21
+      '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.24.6
       '@smithy/types': 4.14.3
       tslib: 2.8.1
@@ -4281,6 +4433,16 @@ snapshots:
       '@smithy/types': 4.14.3
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-sso@3.972.53':
+    dependencies:
+      '@aws-sdk/core': 3.974.21
+      '@aws-sdk/nested-clients': 3.997.21
+      '@aws-sdk/token-providers': 3.1069.0
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.24.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-web-identity@3.972.50':
     dependencies:
       '@aws-sdk/core': 3.974.19
@@ -4295,6 +4457,15 @@ snapshots:
       '@aws-sdk/core': 3.974.20
       '@aws-sdk/nested-clients': 3.997.20
       '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.24.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.53':
+    dependencies:
+      '@aws-sdk/core': 3.974.21
+      '@aws-sdk/nested-clients': 3.997.21
+      '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.24.6
       '@smithy/types': 4.14.3
       tslib: 2.8.1
@@ -4343,6 +4514,19 @@ snapshots:
       '@smithy/types': 4.14.3
       tslib: 2.8.1
 
+  '@aws-sdk/nested-clients@3.997.21':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.21
+      '@aws-sdk/signature-v4-multi-region': 3.996.35
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.24.6
+      '@smithy/fetch-http-handler': 5.4.6
+      '@smithy/node-http-handler': 4.7.7
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
   '@aws-sdk/signature-v4-multi-region@3.996.33':
     dependencies:
       '@aws-sdk/types': 3.973.12
@@ -4353,6 +4537,13 @@ snapshots:
   '@aws-sdk/signature-v4-multi-region@3.996.34':
     dependencies:
       '@aws-sdk/types': 3.973.12
+      '@smithy/signature-v4': 5.4.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.35':
+    dependencies:
+      '@aws-sdk/types': 3.973.13
       '@smithy/signature-v4': 5.4.6
       '@smithy/types': 4.14.3
       tslib: 2.8.1
@@ -4375,7 +4566,21 @@ snapshots:
       '@smithy/types': 4.14.3
       tslib: 2.8.1
 
+  '@aws-sdk/token-providers@3.1069.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.21
+      '@aws-sdk/nested-clients': 3.997.21
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.24.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
   '@aws-sdk/types@3.973.12':
+    dependencies:
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.973.13':
     dependencies:
       '@smithy/types': 4.14.3
       tslib: 2.8.1
@@ -4385,6 +4590,12 @@ snapshots:
       tslib: 2.8.1
 
   '@aws-sdk/xml-builder@3.972.29':
+    dependencies:
+      '@smithy/types': 4.14.3
+      fast-xml-parser: 5.7.3
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.30':
     dependencies:
       '@smithy/types': 4.14.3
       fast-xml-parser: 5.7.3


### PR DESCRIPTION
## What

Replaces the single static price table with a 3-layer pricing model. The
direct fix for "a paid report with stale prices is a complaint" — and, via
manual overrides, the only way to make the report match a company's *actual*
bill rather than public list prices.

Phase 2 of the v0.3.0 plan.

## Pricing resolution (per `region, key`, most specific wins)

1. **User `prices` overrides** (config) — negotiated/enterprise rates. Highest.
2. **AWS Pricing API** (`--live-pricing`) — current public list prices.
3. **Built-in static table** (`prices.json`) — always present as fallback.

All three share one `PriceTable` shape, so they compose with a plain
`mergePriceTables`. The live adapter `warmUp`s before the scan, so
`PricingPort` getters stay **synchronous** — neither the 8 scanners nor the
domain change. This is the architectural payoff of the port.

## Design & safety

- `TablePricingAdapter(table, pricesAsOf)` generalises the static adapter;
  `StaticPriceTableAdapter` now extends it (its spec passes unchanged).
- **Single-value rule:** the live adapter accepts a price only when the
  filters resolve to one distinct USD value. Ambiguous filters → fall back to
  static, never a wrong guess (a wrong price would be worse than the static
  table — the whole point).
- **Total fallback:** if the Pricing API fails (no creds / no permission), the
  command logs a warning to stderr and serves entirely from the static table —
  no crash, stdout stays clean.
- **Honest caveat (documented):** even live prices are AWS *list* prices, not
  your bill (Savings Plans / RI / EDP). The `prices` override is the only way
  to encode real rates.

## Config file location (for package users)

Documented explicitly: the config is the **user's** file, discovered from the
current working directory (or `--config <path>`), not bundled in the package.
Committing `cloudrift.config.json` at the repo root makes CI pick it up after
`actions/checkout`. Global install vs `npx` makes no difference.

## Dependency & IAM

- New runtime dep: `@aws-sdk/client-pricing`
- `pricing:GetProducts` required **only** with `--live-pricing`