### PR TITLE
Documentation-only cleanup following the v0.3.0 work (CI/CD + 3-layer pricing).

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,14 +328,7 @@ pnpm nx run-many -t typecheck
 
 ### Releasing
 
-Publishing is automated: push a `vX.Y.Z` tag whose version matches `@cloudrift/cli` and the [release workflow](.github/workflows/release.yml) lints, tests, packages and runs `npm publish` with provenance (needs the `NPM_TOKEN` repo secret). Verify the publishable artifact locally first:
-
-```sh
-pnpm nx package cli                      # builds + generates apps/cli/dist/package.json
-cd apps/cli/dist && npm pack --dry-run   # inspect the exact tarball contents
-```
-
-The published package is bundled (esbuild): workspace libraries are inlined into `main.js`, so the generated `dist/package.json` declares only the third-party runtime dependencies.
+Publishing `@cloudrift/cli` to npm is automated via a tag-triggered workflow. See [docs/en/releasing.md](./docs/en/releasing.md) for the full process (one-time npm org / `NPM_TOKEN` setup, cutting a release, local verification).
 
 ### Architecture
 
@@ -362,6 +355,7 @@ Full documentation is in the [`docs/`](./docs/) folder — English in [`docs/en/
 | [docs/en/technical-choices.md](./docs/en/technical-choices.md)  | Nx, pnpm, TypeScript, AWS SDK v3, Result pattern, jest |
 | [docs/en/how-it-works.md](./docs/en/how-it-works.md)            | End-to-end execution flow, code walkthrough            |
 | [docs/en/adding-a-resource.md](./docs/en/adding-a-resource.md)  | Step-by-step guide to adding a new resource type       |
+| [docs/en/releasing.md](./docs/en/releasing.md)                  | How `@cloudrift/cli` is built and published to npm     |
 
 ### Adding a new resource type
 
@@ -715,14 +709,7 @@ pnpm nx run-many -t typecheck
 
 ### Rilascio
 
-La pubblicazione è automatica: pusha un tag `vX.Y.Z` la cui versione combacia con `@cloudrift/cli` e il [workflow di release](.github/workflows/release.yml) esegue lint, test, packaging e `npm publish` con provenance (richiede il secret `NPM_TOKEN` del repo). Verifica prima l'artefatto pubblicabile in locale:
-
-```sh
-pnpm nx package cli                      # build + genera apps/cli/dist/package.json
-cd apps/cli/dist && npm pack --dry-run   # ispeziona il contenuto esatto del tarball
-```
-
-Il pacchetto pubblicato è bundlato (esbuild): le librerie del workspace sono inlinate in `main.js`, quindi il `dist/package.json` generato dichiara solo le dipendenze runtime di terze parti.
+La pubblicazione di `@cloudrift/cli` su npm è automatica tramite un workflow attivato dai tag. Vedi [docs/it/rilascio.md](./docs/it/rilascio.md) per il processo completo (setup una tantum org npm / `NPM_TOKEN`, come pubblicare una release, verifica in locale).
 
 ### Architettura
 
@@ -749,6 +736,7 @@ Tutta la documentazione è nella cartella [`docs/`](./docs/) — italiano in [`d
 | [docs/it/scelte-tecniche.md](./docs/it/scelte-tecniche.md)           | Nx, pnpm, TypeScript, AWS SDK v3, Result pattern, jest            |
 | [docs/it/funzionamento.md](./docs/it/funzionamento.md)               | Flusso di esecuzione end-to-end, spiegazione del codice           |
 | [docs/it/aggiungere-risorsa.md](./docs/it/aggiungere-risorsa.md)     | Guida passo per passo per aggiungere un nuovo tipo di risorsa     |
+| [docs/it/rilascio.md](./docs/it/rilascio.md)                         | Come `@cloudrift/cli` viene buildato e pubblicato su npm           |
 
 ---
 

--- a/docs/en/how-it-works.md
+++ b/docs/en/how-it-works.md
@@ -9,7 +9,7 @@ This document describes the full execution flow, from CLI invocation to the AWS 
 ## End-to-end execution flow
 
 ```
-user: cloudrift analyze -r us-east-1 eu-west-1 [--pdf] [--json] [--min-age-days 7]
+user: cloudrift analyze -r us-east-1 eu-west-1 [--format json|markdown] [--pdf] [--live-pricing]
           │
           ▼
      apps/cli/src/main.ts
@@ -17,23 +17,25 @@ user: cloudrift analyze -r us-east-1 eu-west-1 [--pdf] [--json] [--min-age-days 
           │
           ▼
      analyze-waste.command.ts  (composition root)
-     1. AwsRegion.parse() for each region (clean error on invalid input)
-     2. accountId: --account-id or STS GetCallerIdentity
-     3. Instantiates pricing, policies (config + --min-age-days / --ignore-tag) and the 8 scanners
+     1. loadConfig() — cloudrift.config.json / .cloudriftrc / --config
+     2. AwsRegion.parse() per region; config.excludeRegions filtered out
+     3. accountId: --account-id or STS GetCallerIdentity
+     4. Pricing: static table ← live API (--live-pricing) ← config.prices (wins)
+     5. Instantiates policies (config + flags) and the 8 scanners
           │
           ▼
      AnalyzeCloudWasteUseCase.execute({ regions })
      Runs the registered scanners in parallel (Promise.all),
      each scanner iterates the regions sequentially
           │
-     ┌────┬────┬────┬────┬────┬────┬────┐
-     ▼    ▼    ▼    ▼    ▼    ▼    ▼    │ (one per ResourceKind)
-   EBS  EIP  RDS  ELB  EC2  Snap  NAT   │
-  scan  scan scan scan scan scan  scan  │
-     │    │    │    │    │    │    │
-     ▼    ▼    ▼    ▼    ▼    ▼    ▼
-  EC2  EC2  RDS ELBv2 EC2* EC2** EC2+CW
-  API  API  API  API  API  API   API
+     ┌────┬────┬────┬────┬────┬────┬────┬────┐
+     ▼    ▼    ▼    ▼    ▼    ▼    ▼    ▼    │ (one per ResourceKind)
+   EBS  EIP  RDS  ELB  EC2  Snap  NAT  gp2  │
+  scan  scan scan scan scan scan scan scan  │
+     │    │    │    │    │    │    │    │
+     ▼    ▼    ▼    ▼    ▼    ▼    ▼    ▼
+  EC2  EC2  RDS ELBv2 EC2* EC2** EC2+CW EC2
+  API  API  API  API  API  API   API   API
           │        (* 2 calls; ** 3 calls; CW=CloudWatch, max 5 concurrent)
           ▼
      Each scanner applies the domain waste policy
@@ -43,10 +45,10 @@ user: cloudrift analyze -r us-east-1 eu-west-1 [--pdf] [--json] [--min-age-days 
      WastedResourcesSummary { findings: WastedResource[],
                               totalMonthlyCostUsd, scanErrors }
           │
-          ├──────────────────────────┬───────────────────────────┐
-          ▼                          ▼ (--pdf)                   ▼ (--json)
-  formatWasteReportAsTable    generateWasteReportPdf      formatWasteReportAsJson
-  (cli-table3 + chalk)        (pdfkit, with page breaks)  (WasteReportDto, JSON-safe)
+          ▼
+     --format selects stdout: table (default) | json | markdown
+     --pdf / --json [file] also write artifacts to disk
+     totalMonthlyCostUsd > config.costAlertThresholdUsd → exit code 2 (CI gate)
 ```
 
 ---
@@ -200,6 +202,34 @@ export const presenters: { [K in ResourceKind]: ResourcePresenter<ResourceKindMa
 - **Markdown** (`waste-report.markdown-formatter.ts`): a Pull-Request-ready report (totals, breakdown, collapsible `<details>` per kind, top recommendations, cost-threshold callout) for `--format markdown` in CI.
 
 `--format` (`table` | `json` | `markdown`) selects what goes to stdout; `--pdf` / `--json [filename]` write additional files. In machine-readable formats the human chrome is routed to stderr so stdout carries only the report.
+
+---
+
+## Pricing resolution
+
+Costs are resolved per `(region, priceKey)` from three layers built in the composition root, most specific winning:
+
+```
+prices.json (static, always present)
+   ← AWS Pricing API (only with --live-pricing)
+   ← config.prices (user overrides, win)
+```
+
+All three share one `PriceTable` shape (`region → { key: USD }` with a `default` fallback), so they compose with a plain `mergePriceTables`. Because the merge happens **before** the scan, the `PricingPort` getters stay synchronous and the scanners are unchanged.
+
+- **`AwsPricingApiAdapter.warmUp(regions)`** fetches list prices (`@aws-sdk/client-pricing`) and materialises a table. It accepts a price **only when the filters resolve to a single value** (ambiguous → omitted → static fills it); any failure makes the caller fall back entirely to the static table with a warning — never a crash.
+- **`config.prices`** are the user's negotiated/enterprise rates and win over both. They are the only way to make the report match the actual bill — even live prices are AWS *list* prices, not your invoice.
+- `getPricesAsOf()` reflects the layer used: the static date, the live fetch date, or `… + custom overrides`.
+
+## CI/CD integration
+
+Three pieces make the tool pipeline-native:
+
+1. **`--format markdown`** renders a Pull-Request-ready report (totals, breakdown, top recommendations, threshold callout) — pipe it to `$GITHUB_STEP_SUMMARY` or post it as a PR comment.
+2. **`config.costAlertThresholdUsd`** sets a budget: when `totalMonthlyCostUsd` exceeds it the command sets **exit code 2**, which fails the CI job. The alert goes to stderr so it never corrupts machine-readable stdout.
+3. **Clean stdout** — in `json`/`markdown` formats all human messages are routed to stderr, so `cloudrift … --format json | jq` and `… --format markdown >> "$GITHUB_STEP_SUMMARY"` are safe.
+
+The config file (`cloudrift.config.json`) is discovered from the working directory, so committing it at the repo root means CI picks it up automatically after checkout.
 
 ---
 

--- a/docs/en/releasing.md
+++ b/docs/en/releasing.md
@@ -1,0 +1,65 @@
+# Releasing `@cloudrift/cli`
+
+> 🇮🇹 [Versione italiana](../it/rilascio.md)
+
+This document describes how the npm package is built and published. It is for maintainers — users only need the [README](../../README.md#install).
+
+## What gets published
+
+The CLI is published to npm as **`@cloudrift/cli`** (the installed command is `cloudrift`). The package is **bundled**: esbuild inlines the workspace libraries (`shared-kernel`, `cloud-cost-*`) into a single `main.js`, while third-party packages (AWS SDK, pdfkit, chalk, commander, cli-table3) stay external. The published tarball therefore contains only:
+
+```
+main.js          # the bundled, executable CLI (with the #!/usr/bin/env node shebang)
+package.json     # generated: declares only the third-party runtime deps
+README.md
+LICENSE.md
+```
+
+`apps/cli/package.json` is the **development** manifest (workspace deps, nx targets, npm metadata). The **published** manifest is generated into `apps/cli/dist/package.json` by `apps/cli/scripts/make-dist-package.mjs`, which reads the actual external `require()`s from the bundle — so it self-maintains when new SDKs are added.
+
+## One-time setup
+
+1. Create the **`@cloudrift` org** on npm (the scope must exist and you must own it).
+2. Generate an npm **automation token** and add it to the GitHub repository as the secret **`NPM_TOKEN`** (Settings → Secrets and variables → Actions).
+
+The release workflow uses `--provenance`, which requires `id-token: write` (already set in [`release.yml`](../../.github/workflows/release.yml)) and a public repository.
+
+## Cutting a release
+
+1. Bump the version in `apps/cli/package.json` **and** the `.version(...)` string in `apps/cli/src/main.ts` (they must match; the workflow fails otherwise).
+2. Merge to `main`.
+3. Tag and push:
+
+   ```sh
+   git tag v0.3.0          # must equal the @cloudrift/cli version
+   git push origin v0.3.0
+   ```
+
+The [release workflow](../../.github/workflows/release.yml) then, on the `v*` tag:
+
+1. verifies the tag matches the package version,
+2. runs lint + test across the workspace,
+3. `pnpm nx package cli` (build + generate `dist/package.json`),
+4. `npm publish --provenance` from `apps/cli/dist` (using `NPM_TOKEN`),
+5. creates a GitHub Release with auto-generated notes.
+
+## Verify locally before tagging
+
+```sh
+pnpm nx package cli                      # builds + generates apps/cli/dist/package.json
+cd apps/cli/dist && npm pack --dry-run   # inspect the exact tarball contents
+```
+
+To smoke-test the published artifact end-to-end:
+
+```sh
+cd apps/cli/dist
+npm pack                                 # produces cloudrift-cli-<version>.tgz
+cd "$(mktemp -d)" && npm init -y >/dev/null
+npm install /absolute/path/to/cloudrift-cli-<version>.tgz
+npx cloudrift --version                  # must print the new version
+```
+
+## Node compatibility
+
+The package targets **Node 18+** (`engines`). The bundle is CommonJS, so every external dependency must be `require()`-able: this is why `chalk` is pinned to **v4** (v5 is ESM-only and would throw `ERR_REQUIRE_ESM` on Node < 22).

--- a/docs/it/funzionamento.md
+++ b/docs/it/funzionamento.md
@@ -9,7 +9,7 @@ Questo documento descrive il flusso completo di esecuzione, dall'invocazione CLI
 ## Flusso di esecuzione end-to-end
 
 ```
-utente: cloudrift analyze -r us-east-1 eu-west-1 [--pdf] [--json] [--min-age-days 7]
+utente: cloudrift analyze -r us-east-1 eu-west-1 [--format json|markdown] [--pdf] [--live-pricing]
           │
           ▼
      apps/cli/src/main.ts
@@ -17,23 +17,25 @@ utente: cloudrift analyze -r us-east-1 eu-west-1 [--pdf] [--json] [--min-age-day
           │
           ▼
      analyze-waste.command.ts  (composition root)
-     1. AwsRegion.parse() per ogni regione (errore pulito su input invalido)
-     2. accountId: --account-id oppure STS GetCallerIdentity
-     3. Istanzia pricing, policy (config + --min-age-days / --ignore-tag) e gli 8 scanner
+     1. loadConfig() — cloudrift.config.json / .cloudriftrc / --config
+     2. AwsRegion.parse() per regione; config.excludeRegions filtrate via
+     3. accountId: --account-id oppure STS GetCallerIdentity
+     4. Pricing: tabella statica ← live API (--live-pricing) ← config.prices (vincono)
+     5. Istanzia policy (config + flag) e gli 8 scanner
           │
           ▼
      AnalyzeCloudWasteUseCase.execute({ regions })
      Esegue gli scanner registrati in parallelo (Promise.all),
      ogni scanner itera le regioni in sequenza
           │
-     ┌────┬────┬────┬────┬────┬────┬────┐
-     ▼    ▼    ▼    ▼    ▼    ▼    ▼    │ (uno per ResourceKind)
-   EBS  EIP  RDS  ELB  EC2  Snap  NAT   │
-  scan  scan scan scan scan scan  scan  │
-     │    │    │    │    │    │    │
-     ▼    ▼    ▼    ▼    ▼    ▼    ▼
-  EC2  EC2  RDS ELBv2 EC2* EC2** EC2+CW
-  API  API  API  API  API  API   API
+     ┌────┬────┬────┬────┬────┬────┬────┬────┐
+     ▼    ▼    ▼    ▼    ▼    ▼    ▼    ▼    │ (uno per ResourceKind)
+   EBS  EIP  RDS  ELB  EC2  Snap  NAT  gp2  │
+  scan  scan scan scan scan scan scan scan  │
+     │    │    │    │    │    │    │    │
+     ▼    ▼    ▼    ▼    ▼    ▼    ▼    ▼
+  EC2  EC2  RDS ELBv2 EC2* EC2** EC2+CW EC2
+  API  API  API  API  API  API   API   API
           │        (* 2 chiamate; ** 3 chiamate; CW=CloudWatch, max 5 concorrenti)
           ▼
      Ogni scanner applica la waste policy di dominio
@@ -43,10 +45,10 @@ utente: cloudrift analyze -r us-east-1 eu-west-1 [--pdf] [--json] [--min-age-day
      WastedResourcesSummary { findings: WastedResource[],
                               totalMonthlyCostUsd, scanErrors }
           │
-          ├──────────────────────────┬───────────────────────────┐
-          ▼                          ▼ (--pdf)                   ▼ (--json)
-  formatWasteReportAsTable    generateWasteReportPdf      formatWasteReportAsJson
-  (cli-table3 + chalk)        (pdfkit, con salto pagina)  (WasteReportDto, JSON-safe)
+          ▼
+     --format sceglie lo stdout: table (default) | json | markdown
+     --pdf / --json [file] scrivono artefatti aggiuntivi su disco
+     totalMonthlyCostUsd > config.costAlertThresholdUsd → exit code 2 (gate CI)
 ```
 
 ---
@@ -200,6 +202,34 @@ export const presenters: { [K in ResourceKind]: ResourcePresenter<ResourceKindMa
 - **Markdown** (`waste-report.markdown-formatter.ts`): un report pronto per le Pull Request (totali, breakdown, `<details>` collassabile per kind, raccomandazioni principali, callout sulla soglia di costo) per `--format markdown` in CI.
 
 `--format` (`table` | `json` | `markdown`) sceglie cosa va su stdout; `--pdf` / `--json [filename]` scrivono file aggiuntivi. Nei formati machine-readable il chrome umano va su stderr, così su stdout resta solo il report.
+
+---
+
+## Risoluzione dei prezzi
+
+I costi sono risolti per `(regione, chiave)` da tre livelli costruiti nel composition root, vince il più specifico:
+
+```
+prices.json (statico, sempre presente)
+   ← AWS Pricing API (solo con --live-pricing)
+   ← config.prices (override utente, vincono)
+```
+
+Tutte e tre condividono la stessa forma `PriceTable` (`regione → { chiave: USD }` con fallback `default`), quindi si compongono con un semplice `mergePriceTables`. Poiché il merge avviene **prima** dello scan, i getter di `PricingPort` restano sincroni e gli scanner non cambiano.
+
+- **`AwsPricingApiAdapter.warmUp(regions)`** recupera i prezzi di listino (`@aws-sdk/client-pricing`) e materializza una tabella. Accetta un prezzo **solo se i filtri risolvono un valore unico** (ambiguo → omesso → lo riempie lo statico); qualunque errore fa ricadere il chiamante interamente sulla tabella statica con un warning — mai un crash.
+- **`config.prices`** sono le tariffe negoziate/aziendali dell'utente e vincono su entrambi. Sono l'unico modo per far combaciare il report con la bolletta reale — anche i prezzi live sono prezzi di *listino* AWS, non la tua fattura.
+- `getPricesAsOf()` riflette il livello usato: la data dello statico, quella del fetch live, o `… + custom overrides`.
+
+## Integrazione CI/CD
+
+Tre elementi rendono il tool nativo per le pipeline:
+
+1. **`--format markdown`** produce un report pronto per le Pull Request (totali, breakdown, raccomandazioni, callout soglia) — instradalo in `$GITHUB_STEP_SUMMARY` o pubblicalo come commento PR.
+2. **`config.costAlertThresholdUsd`** imposta un budget: quando `totalMonthlyCostUsd` lo supera, il comando imposta **exit code 2**, facendo fallire il job CI. L'alert va su stderr, così non sporca mai lo stdout machine-readable.
+3. **stdout pulito** — nei formati `json`/`markdown` tutti i messaggi umani vanno su stderr, quindi `cloudrift … --format json | jq` e `… --format markdown >> "$GITHUB_STEP_SUMMARY"` sono sicuri.
+
+Il file di config (`cloudrift.config.json`) viene cercato nella working directory: committarlo alla root del repo fa sì che la CI lo prenda automaticamente dopo il checkout.
 
 ---
 

--- a/docs/it/rilascio.md
+++ b/docs/it/rilascio.md
@@ -1,0 +1,65 @@
+# Rilascio di `@cloudrift/cli`
+
+> 🇬🇧 [English version](../en/releasing.md)
+
+Questo documento descrive come il pacchetto npm viene buildato e pubblicato. È pensato per i manutentori — agli utenti basta il [README](../../README.md#installazione).
+
+## Cosa viene pubblicato
+
+La CLI è pubblicata su npm come **`@cloudrift/cli`** (il comando installato è `cloudrift`). Il pacchetto è **bundlato**: esbuild inlina le librerie del workspace (`shared-kernel`, `cloud-cost-*`) in un unico `main.js`, mentre i pacchetti di terze parti (AWS SDK, pdfkit, chalk, commander, cli-table3) restano esterni. Il tarball pubblicato contiene quindi solo:
+
+```
+main.js          # la CLI bundlata ed eseguibile (con lo shebang #!/usr/bin/env node)
+package.json     # generato: dichiara solo le dipendenze runtime di terze parti
+README.md
+LICENSE.md
+```
+
+`apps/cli/package.json` è il manifest di **sviluppo** (dipendenze workspace, target nx, metadati npm). Il manifest **pubblicato** viene generato in `apps/cli/dist/package.json` da `apps/cli/scripts/make-dist-package.mjs`, che ricava i `require()` esterni reali dal bundle — così si auto-mantiene quando si aggiungono nuovi SDK.
+
+## Setup una tantum
+
+1. Crea l'**org `@cloudrift`** su npm (lo scope deve esistere e devi possederlo).
+2. Genera un **automation token** npm e aggiungilo come secret del repo GitHub con nome **`NPM_TOKEN`** (Settings → Secrets and variables → Actions).
+
+Il workflow di release usa `--provenance`, che richiede `id-token: write` (già impostato in [`release.yml`](../../.github/workflows/release.yml)) e un repository pubblico.
+
+## Pubblicare una release
+
+1. Aggiorna la versione in `apps/cli/package.json` **e** la stringa `.version(...)` in `apps/cli/src/main.ts` (devono combaciare; altrimenti il workflow fallisce).
+2. Mergia su `main`.
+3. Crea il tag e pusha:
+
+   ```sh
+   git tag v0.3.0          # deve essere uguale alla versione di @cloudrift/cli
+   git push origin v0.3.0
+   ```
+
+Il [workflow di release](../../.github/workflows/release.yml), sul tag `v*`:
+
+1. verifica che il tag combaci con la versione del pacchetto,
+2. esegue lint + test sul workspace,
+3. `pnpm nx package cli` (build + generazione di `dist/package.json`),
+4. `npm publish --provenance` da `apps/cli/dist` (usando `NPM_TOKEN`),
+5. crea una GitHub Release con note generate automaticamente.
+
+## Verifica in locale prima del tag
+
+```sh
+pnpm nx package cli                      # build + genera apps/cli/dist/package.json
+cd apps/cli/dist && npm pack --dry-run   # ispeziona il contenuto esatto del tarball
+```
+
+Per uno smoke test end-to-end dell'artefatto pubblicato:
+
+```sh
+cd apps/cli/dist
+npm pack                                 # produce cloudrift-cli-<versione>.tgz
+cd "$(mktemp -d)" && npm init -y >/dev/null
+npm install /percorso/assoluto/cloudrift-cli-<versione>.tgz
+npx cloudrift --version                  # deve stampare la nuova versione
+```
+
+## Compatibilità Node
+
+Il pacchetto punta a **Node 18+** (`engines`). Il bundle è CommonJS, quindi ogni dipendenza esterna deve essere `require()`-abile: per questo `chalk` è fissato a **v4** (la v5 è solo-ESM e lancerebbe `ERR_REQUIRE_ESM` su Node < 22).


### PR DESCRIPTION
- **Release notes out of the README.** The maintainer "Releasing" / "Rilascio"
  sections moved to dedicated pages — [docs/en/releasing.md](docs/en/releasing.md)
  and [docs/it/rilascio.md](docs/it/rilascio.md) — and expanded: what gets
  published (bundled tarball), one-time npm org + `NPM_TOKEN` setup, cutting a
  release (version bump in two places, `v*` tag → workflow), local verification
  + tarball smoke test, Node 18+ / chalk@4 compatibility note. The README now
  has a one-line pointer; the pages are listed in the technical-docs tables and
  cross-linked.
- **Clearer CI/CD & pricing** in how-it-works / funzionamento (EN+IT):
  - flow diagram refreshed (`--format` / `--live-pricing`, `loadConfig` +
    `excludeRegions`, the 3 pricing layers, the 8th scanner `gp2`, the
    exit-code-2 budget gate);
  - new **Pricing resolution** section (static ← live API ← `config.prices`,
    `mergePriceTables`, synchronous getters via `warmUp`, single-value safety,
    the honest "list price ≠ your bill" caveat);
  - new **CI/CD integration** section (markdown PR report, `costAlertThresholdUsd`
    → exit 2, clean stdout, config discovered from the working directory).

## Notes

- No code changes — nothing to test/build beyond the docs.
- README's user-facing "Use in CI/CD", "Configuration file" and "Pricing
  sources" sections stay (they're tool usage, not release mechanics).