### PR TITLE
feat(cli): waste/optimization split + CLI test seam & e2e tests (v0.4…

### DIFF
--- a/apps/cli/src/commands/analyze-waste.command.spec.ts
+++ b/apps/cli/src/commands/analyze-waste.command.spec.ts
@@ -1,0 +1,162 @@
+import { readFile, mkdtemp, rm } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { Result } from 'shared-kernel';
+import { AwsRegion, EbsVolume } from 'cloud-cost-domain';
+import type { WastedResource, WastedResourcesSummary } from 'cloud-cost-domain';
+import { ConfigError, type CloudriftConfig } from '../config/cloudrift.config';
+import {
+  analyzeWasteCommand,
+  type AnalyzeDeps,
+  type AnalyzeWasteOptions,
+} from './analyze-waste.command';
+
+const region = AwsRegion.create('us-east-1');
+
+function wasteVolume(id: string, monthlyCostUsd: number): EbsVolume {
+  return new EbsVolume({
+    volumeId: id,
+    region,
+    accountId: '123456789012',
+    sizeGb: 100,
+    volumeType: 'gp3',
+    state: 'available',
+    createTime: new Date('2025-01-01'),
+    detectedAt: new Date('2026-06-16'),
+    tags: {},
+    monthlyCostUsd,
+  });
+}
+
+function summaryOf(
+  findings: WastedResource[],
+  totalWasteMonthlyUsd: number,
+): WastedResourcesSummary {
+  return { findings, totalWasteMonthlyUsd, totalOptimizationMonthlyUsd: 0, scanErrors: [] };
+}
+
+/** Fake deps: no AWS. Lets us drive config + canned findings into the command. */
+function makeDeps(opts: {
+  config?: CloudriftConfig;
+  summary?: WastedResourcesSummary;
+} = {}): AnalyzeDeps {
+  return {
+    loadConfig: async () => Result.ok(opts.config ?? {}),
+    resolveAccountId: async () => undefined,
+    createAnalysis: async () => ({
+      useCase: { execute: async () => Result.ok(opts.summary ?? summaryOf([], 0)) },
+      pricesAsOf: '2025-06',
+    }),
+  };
+}
+
+let stdout: string;
+let stderr: string;
+
+beforeEach(() => {
+  stdout = '';
+  stderr = '';
+  jest.spyOn(console, 'log').mockImplementation((...args) => {
+    stdout += args.join(' ') + '\n';
+  });
+  jest.spyOn(console, 'error').mockImplementation((...args) => {
+    stderr += args.join(' ') + '\n';
+  });
+  process.exitCode = undefined;
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+  process.exitCode = undefined; // don't leak a non-zero exit to the jest process
+});
+
+function run(options: Partial<AnalyzeWasteOptions>, deps: AnalyzeDeps): Promise<void> {
+  return analyzeWasteCommand({ regions: ['us-east-1'], ...options }, deps);
+}
+
+describe('analyzeWasteCommand (CLI end-to-end)', () => {
+  it('rejects an invalid --format before doing any work (exit 1)', async () => {
+    await run({ format: 'xml' }, makeDeps());
+    expect(process.exitCode).toBe(1);
+    expect(stderr).toContain('--format must be one of');
+  });
+
+  it('table format: banner and report go to stdout', async () => {
+    await run({ format: 'table' }, makeDeps({
+      summary: summaryOf([wasteVolume('vol-1', 8)], 8),
+    }));
+    expect(stdout).toContain('Scanning us-east-1');
+    expect(stdout).toContain('Total waste:');
+    expect(stdout).toContain('$8.00/month');
+  });
+
+  it('json format: stdout is pure parseable JSON, no human chrome', async () => {
+    await run({ format: 'json' }, makeDeps({
+      summary: summaryOf([wasteVolume('vol-1', 8)], 8),
+    }));
+    expect(stdout).not.toContain('Scanning'); // banner suppressed
+    const parsed = JSON.parse(stdout.trim());
+    expect(parsed.totalWasteMonthlyUsd).toBe(8);
+    expect(parsed.findings).toHaveLength(1);
+  });
+
+  it('markdown format: stdout is the markdown report', async () => {
+    await run({ format: 'markdown' }, makeDeps({
+      summary: summaryOf([wasteVolume('vol-1', 8)], 8),
+    }));
+    expect(stdout).toContain('## ☁️ cloudrift');
+    expect(stdout).not.toContain('Scanning');
+  });
+
+  it('exits 2 when waste exceeds the configured threshold', async () => {
+    await run({ format: 'json' }, makeDeps({
+      config: { costAlertThresholdUsd: 5 },
+      summary: summaryOf([wasteVolume('vol-1', 8)], 8),
+    }));
+    expect(process.exitCode).toBe(2);
+    // stdout stays clean JSON; the alert goes to stderr
+    expect(() => JSON.parse(stdout.trim())).not.toThrow();
+    expect(stderr).toContain('Waste threshold exceeded');
+  });
+
+  it('does not exit 2 when waste is under the threshold', async () => {
+    await run({ format: 'json' }, makeDeps({
+      config: { costAlertThresholdUsd: 100 },
+      summary: summaryOf([wasteVolume('vol-1', 8)], 8),
+    }));
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it('fails (exit 1) when the config is invalid', async () => {
+    const deps: AnalyzeDeps = {
+      ...makeDeps(),
+      loadConfig: async () => Result.fail(new ConfigError('Invalid config: bad')),
+    };
+    await run({}, deps);
+    expect(process.exitCode).toBe(1);
+    expect(stderr).toContain('Invalid config');
+  });
+
+  it('fails (exit 1) when all regions are excluded by config', async () => {
+    await run({ regions: ['us-east-1'] }, makeDeps({
+      config: { excludeRegions: ['us-east-1'] },
+    }));
+    expect(process.exitCode).toBe(1);
+    expect(stderr).toContain('No regions left to scan');
+  });
+
+  it('writes a JSON artifact to disk with --json <file>', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'cloudrift-cli-'));
+    const file = join(dir, 'out.json');
+    try {
+      await run({ format: 'table', json: file }, makeDeps({
+        summary: summaryOf([wasteVolume('vol-1', 8)], 8),
+      }));
+      const written = JSON.parse(await readFile(file, 'utf8'));
+      expect(written.totalWasteMonthlyUsd).toBe(8);
+      expect(written.findings[0].id).toBe('vol-1');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/cli/src/commands/analyze-waste.command.ts
+++ b/apps/cli/src/commands/analyze-waste.command.ts
@@ -1,6 +1,7 @@
 import chalk from 'chalk';
 import { resolve } from 'path';
 import { writeFile } from 'fs/promises';
+import type { Result } from 'shared-kernel';
 import {
   AwsRegion,
   DEFAULT_IGNORE_TAG,
@@ -14,7 +15,12 @@ import {
   NatGatewayWastePolicy,
   Gp2UpgradePolicy,
 } from 'cloud-cost-domain';
-import type { WastePolicyOptions, WasteScannerPort } from 'cloud-cost-domain';
+import type {
+  FindWastedResourcesUseCasePort,
+  PricingPort,
+  WastePolicyOptions,
+  WasteScannerPort,
+} from 'cloud-cost-domain';
 import { AnalyzeCloudWasteUseCase } from 'cloud-cost-application';
 import type { WasteReportMeta } from 'cloud-cost-application';
 import {
@@ -35,8 +41,7 @@ import {
   resolveAwsAccountId,
 } from 'cloud-cost-infrastructure-aws-adapter';
 import type { PriceTable } from 'cloud-cost-infrastructure-aws-adapter';
-import type { PricingPort } from 'cloud-cost-domain';
-import { loadConfig } from '../config/cloudrift.config';
+import { loadConfig, type CloudriftConfig, type ConfigError } from '../config/cloudrift.config';
 import { formatWasteReportAsTable } from '../formatters/waste-report.table-formatter';
 import { formatWasteReportAsJson } from '../formatters/waste-report.json-formatter';
 import { formatWasteReportAsMarkdown } from '../formatters/waste-report.markdown-formatter';
@@ -46,7 +51,7 @@ const DEFAULT_CLOUDWATCH_WINDOW_HOURS = 48;
 const OUTPUT_FORMATS = ['table', 'json', 'markdown'] as const;
 type OutputFormat = (typeof OUTPUT_FORMATS)[number];
 
-interface AnalyzeWasteOptions {
+export interface AnalyzeWasteOptions {
   regions: string[];
   accountId?: string;
   config?: string;
@@ -58,19 +63,108 @@ interface AnalyzeWasteOptions {
   ignoreTag?: string;
 }
 
+/** Contesto risolto passato a `createAnalysis` per costruire pricing + scanner. */
+export interface AnalysisContext {
+  regions: AwsRegion[];
+  config: CloudriftConfig;
+  accountId: string;
+  livePricing: boolean;
+  policyOptions: WastePolicyOptions;
+  cloudwatchWindowHours: number;
+  info: (msg: string) => void;
+}
+
+export interface Analysis {
+  useCase: FindWastedResourcesUseCasePort;
+  pricesAsOf: string;
+}
+
+/**
+ * Seam di injection: tutto ciò che tocca AWS passa da qui. Il default compone
+ * gli scanner reali; i test CLI iniettano fake per verificare formato, exit
+ * code e routing dello stdout senza credenziali AWS.
+ */
+export interface AnalyzeDeps {
+  loadConfig(cwd: string, explicitPath?: string): Promise<Result<CloudriftConfig, ConfigError>>;
+  resolveAccountId(): Promise<string | undefined>;
+  createAnalysis(ctx: AnalysisContext): Promise<Analysis>;
+}
+
+/** Composizione reale: pricing a livelli + 8 scanner AWS + use case generico. */
+async function defaultCreateAnalysis(ctx: AnalysisContext): Promise<Analysis> {
+  // Pricing a livelli: listino statico (base) ← AWS Pricing API live (--live-pricing)
+  // ← override utente (config.prices, vincono).
+  let priceTable: PriceTable = BUILTIN_PRICE_TABLE;
+  let pricesAsOf = BUILTIN_PRICES_AS_OF;
+  let layered = false;
+
+  if (ctx.livePricing) {
+    ctx.info(chalk.dim('  Fetching current prices from the AWS Pricing API...'));
+    const live = await new AwsPricingApiAdapter().warmUp(ctx.regions);
+    if (live.ok) {
+      priceTable = mergePriceTables(priceTable, live.value);
+      pricesAsOf = new Date().toISOString().slice(0, 7); // YYYY-MM
+      layered = true;
+    } else {
+      ctx.info(
+        chalk.yellow(
+          `  Live pricing unavailable (${live.error.message}); using the static price table.`,
+        ),
+      );
+    }
+  }
+
+  if (ctx.config.prices) {
+    priceTable = mergePriceTables(priceTable, ctx.config.prices);
+    pricesAsOf = `${pricesAsOf} + custom overrides`;
+    layered = true;
+  }
+
+  const pricing: PricingPort = layered
+    ? new TablePricingAdapter(priceTable, pricesAsOf)
+    : new StaticPriceTableAdapter();
+
+  const { policyOptions, accountId, cloudwatchWindowHours } = ctx;
+  const scanners: WasteScannerPort[] = [
+    new AwsEbsVolumeScanner(pricing, accountId, new EbsVolumeWastePolicy(policyOptions)),
+    new AwsElasticIpScanner(pricing, accountId, new ElasticIpWastePolicy(policyOptions)),
+    new AwsRdsInstanceScanner(pricing, accountId, new RdsInstanceWastePolicy(policyOptions)),
+    new AwsLoadBalancerScanner(pricing, accountId, new LoadBalancerWastePolicy(policyOptions)),
+    new AwsEc2InstanceScanner(pricing, accountId, new Ec2InstanceWastePolicy(policyOptions)),
+    new AwsEbsSnapshotScanner(pricing, accountId, new EbsSnapshotWastePolicy(policyOptions)),
+    new AwsNatGatewayScanner(
+      pricing,
+      accountId,
+      new NatGatewayWastePolicy(policyOptions),
+      cloudwatchWindowHours,
+    ),
+    new AwsGp2UpgradeScanner(pricing, accountId, new Gp2UpgradePolicy(policyOptions)),
+  ];
+
+  return { useCase: new AnalyzeCloudWasteUseCase(scanners), pricesAsOf: pricing.getPricesAsOf() };
+}
+
+export const defaultAnalyzeDeps: AnalyzeDeps = {
+  loadConfig,
+  resolveAccountId: resolveAwsAccountId,
+  createAnalysis: defaultCreateAnalysis,
+};
+
 function fail(message: string): void {
   console.error(chalk.red(`\n  Error: ${message}\n`));
   process.exitCode = 1;
 }
 
 /**
- * Composition root: l'unico punto dove le implementazioni concrete (scanner
- * AWS, listino prezzi) vengono istanziate e iniettate nel use case.
+ * Composition root del comando `analyze`. Risolve opzioni e config, delega a
+ * `deps.createAnalysis` la costruzione di pricing + scanner (l'unico punto che
+ * tocca AWS), poi renderizza, scrive gli artefatti e applica il gate di soglia.
  *
  * Precedenza dei parametri: flag CLI > file di config > default nel codice.
  */
 export async function analyzeWasteCommand(
   options: AnalyzeWasteOptions,
+  deps: AnalyzeDeps = defaultAnalyzeDeps,
 ): Promise<void> {
   const format = (options.format ?? 'table') as OutputFormat;
   if (!OUTPUT_FORMATS.includes(format)) {
@@ -83,7 +177,7 @@ export async function analyzeWasteCommand(
     ? (msg: string) => console.error(msg)
     : (msg: string) => console.log(msg);
 
-  const configResult = await loadConfig(process.cwd(), options.config);
+  const configResult = await deps.loadConfig(process.cwd(), options.config);
   if (!configResult.ok) return fail(configResult.error.message);
   const config = configResult.value;
 
@@ -122,7 +216,7 @@ export async function analyzeWasteCommand(
     );
   }
 
-  const accountId = options.accountId ?? (await resolveAwsAccountId()) ?? 'unknown';
+  const accountId = options.accountId ?? (await deps.resolveAccountId()) ?? 'unknown';
 
   if (!quietStdout) {
     const accountLabel = accountId !== 'unknown' ? ` (account ${accountId})` : '';
@@ -136,71 +230,30 @@ export async function analyzeWasteCommand(
     info(chalk.dim(`  Skipping excluded regions: ${skipped.join(', ')}`));
   }
 
-  // Pricing a livelli: listino statico (base) ← AWS Pricing API live (--live-pricing)
-  // ← override utente (config.prices, vincono). Gli override per regione servono
-  // per tariffe negoziate/aziendali, così il report riflette la bolletta reale.
-  let priceTable: PriceTable = BUILTIN_PRICE_TABLE;
-  let pricesAsOf = BUILTIN_PRICES_AS_OF;
-  let layered = false;
-
-  if (options.livePricing) {
-    info(chalk.dim('  Fetching current prices from the AWS Pricing API...'));
-    const live = await new AwsPricingApiAdapter().warmUp(regions);
-    if (live.ok) {
-      priceTable = mergePriceTables(priceTable, live.value);
-      pricesAsOf = new Date().toISOString().slice(0, 7); // YYYY-MM
-      layered = true;
-    } else {
-      info(
-        chalk.yellow(
-          `  Live pricing unavailable (${live.error.message}); using the static price table.`,
-        ),
-      );
-    }
-  }
-
-  if (config.prices) {
-    priceTable = mergePriceTables(priceTable, config.prices);
-    pricesAsOf = `${pricesAsOf} + custom overrides`;
-    layered = true;
-  }
-
-  const pricing: PricingPort = layered
-    ? new TablePricingAdapter(priceTable, pricesAsOf)
-    : new StaticPriceTableAdapter();
-
   const policyOptions: WastePolicyOptions = {
     minAgeDays,
     ignoreTag,
     excludeTagValues: config.excludeTagValues,
   };
 
-  const scanners: WasteScannerPort[] = [
-    new AwsEbsVolumeScanner(pricing, accountId, new EbsVolumeWastePolicy(policyOptions)),
-    new AwsElasticIpScanner(pricing, accountId, new ElasticIpWastePolicy(policyOptions)),
-    new AwsRdsInstanceScanner(pricing, accountId, new RdsInstanceWastePolicy(policyOptions)),
-    new AwsLoadBalancerScanner(pricing, accountId, new LoadBalancerWastePolicy(policyOptions)),
-    new AwsEc2InstanceScanner(pricing, accountId, new Ec2InstanceWastePolicy(policyOptions)),
-    new AwsEbsSnapshotScanner(pricing, accountId, new EbsSnapshotWastePolicy(policyOptions)),
-    new AwsNatGatewayScanner(
-      pricing,
-      accountId,
-      new NatGatewayWastePolicy(policyOptions),
-      cloudwatchWindowHours,
-    ),
-    new AwsGp2UpgradeScanner(pricing, accountId, new Gp2UpgradePolicy(policyOptions)),
-  ];
+  const { useCase, pricesAsOf } = await deps.createAnalysis({
+    regions,
+    config,
+    accountId,
+    livePricing: options.livePricing === true,
+    policyOptions,
+    cloudwatchWindowHours,
+    info,
+  });
 
-  const useCase = new AnalyzeCloudWasteUseCase(scanners);
   const result = await useCase.execute({ regions });
-
   if (!result.ok) return fail(result.error.message);
 
   const meta: WasteReportMeta = {
     accountId,
     regions: regions.map((r) => r.code),
     generatedAt: new Date(),
-    pricesAsOf: pricing.getPricesAsOf(),
+    pricesAsOf,
   };
 
   // Il report scelto va SEMPRE su stdout (così è componibile in pipeline:
@@ -238,15 +291,16 @@ export async function analyzeWasteCommand(
     info(chalk.green(`  PDF report saved to ${outputPath}`));
   }
 
-  // Soglia di costo per le pipeline: exit code 2 quando il totale la supera.
+  // Soglia di costo per le pipeline: exit code 2 quando il totale WASTE la supera
+  // (le opportunità di ottimizzazione, stimate, non concorrono al gate).
   // Il messaggio va su stderr per non sporcare l'output machine-readable su stdout.
   if (
     config.costAlertThresholdUsd !== undefined &&
-    result.value.totalMonthlyCostUsd > config.costAlertThresholdUsd
+    result.value.totalWasteMonthlyUsd > config.costAlertThresholdUsd
   ) {
     console.error(
       chalk.red.bold(
-        `\n  Cost threshold exceeded: $${result.value.totalMonthlyCostUsd.toFixed(2)}/mo ` +
+        `\n  Waste threshold exceeded: $${result.value.totalWasteMonthlyUsd.toFixed(2)}/mo ` +
           `> $${config.costAlertThresholdUsd.toFixed(2)}/mo threshold.\n`,
       ),
     );

--- a/apps/cli/src/formatters/waste-report.markdown-formatter.spec.ts
+++ b/apps/cli/src/formatters/waste-report.markdown-formatter.spec.ts
@@ -1,4 +1,4 @@
-import { AwsRegion, EbsVolume } from 'cloud-cost-domain';
+import { AwsRegion, EbsVolume, Gp2Volume } from 'cloud-cost-domain';
 import type { WastedResourcesSummary } from 'cloud-cost-domain';
 import type { WasteReportMeta } from 'cloud-cost-application';
 import { formatWasteReportAsMarkdown } from './waste-report.markdown-formatter';
@@ -27,11 +27,25 @@ function makeVolume(id: string, monthlyCostUsd: number): EbsVolume {
   });
 }
 
+function makeGp2(id: string, monthlyCostUsd: number): Gp2Volume {
+  return new Gp2Volume({
+    volumeId: id,
+    region,
+    accountId: '123456789012',
+    sizeGb: 200,
+    createTime: new Date('2025-01-01'),
+    detectedAt: meta.generatedAt,
+    tags: {},
+    monthlyCostUsd,
+  });
+}
+
 describe('formatWasteReportAsMarkdown', () => {
   it('renders the empty case', () => {
     const summary: WastedResourcesSummary = {
       findings: [],
-      totalMonthlyCostUsd: 0,
+      totalWasteMonthlyUsd: 0,
+      totalOptimizationMonthlyUsd: 0,
       scanErrors: [],
     };
 
@@ -41,63 +55,81 @@ describe('formatWasteReportAsMarkdown', () => {
     expect(md).toContain('prices as of 2025-06');
   });
 
-  it('renders headline, breakdown, details and recommendations', () => {
+  it('renders headline (waste), breakdown, details and recommendations', () => {
     const summary: WastedResourcesSummary = {
       findings: [makeVolume('vol-aaa', 8), makeVolume('vol-bbb', 4)],
-      totalMonthlyCostUsd: 12,
+      totalWasteMonthlyUsd: 12,
+      totalOptimizationMonthlyUsd: 0,
       scanErrors: [],
     };
 
     const md = formatWasteReportAsMarkdown(summary, meta);
 
-    // headline + annualized
     expect(md).toContain('$12.00/month');
     expect(md).toContain('$144.00/year');
     expect(md).toContain('across 2 resource(s)');
-    // account + regions context
     expect(md).toContain('account `123456789012`');
     expect(md).toContain('us-east-1, eu-west-1');
-    // breakdown total row
-    expect(md).toContain('| **Total** | **2** | **$12.00** |');
-    // collapsible details + per-finding row
+    expect(md).toContain('| **Total waste** | **2** | **$12.00** |');
     expect(md).toContain('<details>');
     expect(md).toContain('vol-aaa');
-    // recommendation present, sorted by cost (vol-aaa first)
     const recIndexAaa = md.indexOf('Delete unattached EBS vol-aaa');
     const recIndexBbb = md.indexOf('Delete unattached EBS vol-bbb');
     expect(recIndexAaa).toBeGreaterThan(-1);
     expect(recIndexAaa).toBeLessThan(recIndexBbb);
   });
 
-  it('flags when the total is over the configured threshold', () => {
+  it('puts optimization findings in a separate section, out of the waste total', () => {
+    const summary: WastedResourcesSummary = {
+      findings: [makeVolume('vol-waste', 30), makeGp2('vol-gp2', 4)],
+      totalWasteMonthlyUsd: 30,
+      totalOptimizationMonthlyUsd: 4,
+      scanErrors: [],
+    };
+
+    const md = formatWasteReportAsMarkdown(summary, meta);
+
+    // headline is waste only
+    expect(md).toContain('$30.00/month** of waste');
+    expect(md).toContain('across 1 resource(s)');
+    // optimization is a separate section with its own total
+    expect(md).toContain('### Optimization opportunities');
+    expect(md).toContain('| **Total optimization** | **1** | **$4.00** |');
+    expect(md).toContain('without deleting');
+  });
+
+  it('flags when the WASTE total is over the configured threshold', () => {
     const summary: WastedResourcesSummary = {
       findings: [makeVolume('vol-aaa', 600)],
-      totalMonthlyCostUsd: 600,
+      totalWasteMonthlyUsd: 600,
+      totalOptimizationMonthlyUsd: 0,
       scanErrors: [],
     };
 
     const md = formatWasteReportAsMarkdown(summary, meta, { costAlertThresholdUsd: 500 });
 
-    expect(md).toContain('Over the $500.00/mo threshold');
+    expect(md).toContain('Over the $500.00/mo waste threshold');
     expect(md).toContain('pipeline should fail');
   });
 
-  it('shows "under threshold" when the total is within budget', () => {
+  it('shows "under threshold" when the waste total is within budget', () => {
     const summary: WastedResourcesSummary = {
       findings: [makeVolume('vol-aaa', 100)],
-      totalMonthlyCostUsd: 100,
+      totalWasteMonthlyUsd: 100,
+      totalOptimizationMonthlyUsd: 0,
       scanErrors: [],
     };
 
     const md = formatWasteReportAsMarkdown(summary, meta, { costAlertThresholdUsd: 500 });
 
-    expect(md).toContain('Under the $500.00/mo threshold');
+    expect(md).toContain('Under the $500.00/mo waste threshold');
   });
 
   it('reports scan errors as partial results', () => {
     const summary: WastedResourcesSummary = {
       findings: [],
-      totalMonthlyCostUsd: 0,
+      totalWasteMonthlyUsd: 0,
+      totalOptimizationMonthlyUsd: 0,
       scanErrors: [
         { kind: 'rds-instance', region: 'eu-west-1', error: new Error('AccessDenied') },
       ],

--- a/apps/cli/src/formatters/waste-report.markdown-formatter.ts
+++ b/apps/cli/src/formatters/waste-report.markdown-formatter.ts
@@ -1,14 +1,14 @@
 import {
   RESOURCE_KINDS,
   RESOURCE_KIND_LABELS,
+  RESOURCE_KIND_META,
   groupByKind,
 } from 'cloud-cost-domain';
-import type { WastedResourcesSummary } from 'cloud-cost-domain';
-import type { WasteReportMeta } from 'cloud-cost-application';
+import type { FindingCategory, WastedResourcesSummary } from 'cloud-cost-domain';
 import { presenterFor } from './resource-presenters';
 
 export interface MarkdownReportOptions {
-  /** Se valorizzata, il report mostra se il totale supera la soglia (CI). */
+  /** Se valorizzata, il report mostra se il TOTALE WASTE supera la soglia (CI). */
   costAlertThresholdUsd?: number;
 }
 
@@ -23,24 +23,31 @@ function esc(cell: string): string {
   return cell.replace(/\|/g, '\\|').replace(/\r?\n/g, ' ');
 }
 
-function footer(meta: WasteReportMeta): string {
+function footer(meta: { pricesAsOf: string }): string {
   return `---\n<sub>Estimates use AWS list prices as of ${meta.pricesAsOf}; actual billing may differ.</sub>`;
 }
 
 /**
- * Render Markdown pensato per i commenti automatici sulle Pull Request
- * (GitHub Actions / GitLab CI). Usa `<details>` per restare compatto e mette
- * il totale e l'eventuale sforamento di soglia ben in vista.
+ * Render Markdown pensato per i commenti automatici sulle Pull Request.
+ * Headline e soglia CI si basano sul **totale waste**; le opportunità di
+ * ottimizzazione (gp2→gp3, rightsizing) sono in una sezione a parte.
  */
 export function formatWasteReportAsMarkdown(
   summary: WastedResourcesSummary,
-  meta: WasteReportMeta,
+  meta: { accountId: string; regions: string[]; generatedAt: Date; pricesAsOf: string },
   options: MarkdownReportOptions = {},
 ): string {
   const lines: string[] = [];
   const grouped = groupByKind(summary.findings);
-  const total = summary.totalMonthlyCostUsd;
+  const waste = summary.totalWasteMonthlyUsd;
   const day = meta.generatedAt.toISOString().split('T')[0];
+
+  const kindsOf = (category: FindingCategory) =>
+    RESOURCE_KINDS.filter(
+      (k) => RESOURCE_KIND_META[k].category === category && grouped[k].length > 0,
+    );
+  const countOf = (category: FindingCategory) =>
+    kindsOf(category).reduce((n, k) => n + grouped[k].length, 0);
 
   lines.push('## ☁️ cloudrift — Cloud waste report');
   lines.push('');
@@ -56,63 +63,61 @@ export function formatWasteReportAsMarkdown(
     return lines.join('\n');
   }
 
-  // Headline
+  // Headline: solo waste.
   lines.push(
-    `**💸 ${money(total)}/month** potential savings ` +
-      `(**${money(total * 12)}/year**) across ${summary.findings.length} resource(s).`,
+    `**💸 ${money(waste)}/month** of waste ` +
+      `(**${money(waste * 12)}/year**) across ${countOf('waste')} resource(s).`,
   );
   if (options.costAlertThresholdUsd !== undefined) {
     lines.push('');
     lines.push(
-      total > options.costAlertThresholdUsd
-        ? `> ⚠️ **Over the ${money(options.costAlertThresholdUsd)}/mo threshold** — this pipeline should fail.`
-        : `> ✅ Under the ${money(options.costAlertThresholdUsd)}/mo threshold.`,
+      waste > options.costAlertThresholdUsd
+        ? `> ⚠️ **Over the ${money(options.costAlertThresholdUsd)}/mo waste threshold** — this pipeline should fail.`
+        : `> ✅ Under the ${money(options.costAlertThresholdUsd)}/mo waste threshold.`,
     );
   }
   lines.push('');
 
-  // Breakdown table
-  lines.push('### Breakdown');
+  // Breakdown waste.
+  lines.push('### Waste breakdown');
   lines.push('');
   lines.push('| Resource type | Count | $/month |');
   lines.push('|---|---:|---:|');
-  for (const kind of RESOURCE_KINDS) {
-    const findings = grouped[kind];
-    if (findings.length === 0) continue;
-    const subtotal = findings.reduce((s, r) => s + r.costEstimate.monthlyCostUsd, 0);
-    lines.push(`| ${RESOURCE_KIND_LABELS[kind]} | ${findings.length} | ${money(subtotal)} |`);
+  for (const kind of kindsOf('waste')) {
+    const subtotal = grouped[kind].reduce((s, r) => s + r.costEstimate.monthlyCostUsd, 0);
+    lines.push(`| ${RESOURCE_KIND_LABELS[kind]} | ${grouped[kind].length} | ${money(subtotal)} |`);
   }
-  lines.push(`| **Total** | **${summary.findings.length}** | **${money(total)}** |`);
+  lines.push(`| **Total waste** | **${countOf('waste')}** | **${money(waste)}** |`);
   lines.push('');
 
-  // Dettaglio per tipo (collassabile per mantenere il commento PR compatto)
-  for (const kind of RESOURCE_KINDS) {
-    const findings = grouped[kind];
-    if (findings.length === 0) continue;
-    const presenter = presenterFor(kind);
-    const subtotal = findings.reduce((s, r) => s + r.costEstimate.monthlyCostUsd, 0);
+  renderDetails('waste');
 
-    lines.push('<details>');
+  // Sezione optimization (a parte, non nel totale waste).
+  if (countOf('optimization') > 0) {
+    lines.push('### Optimization opportunities');
+    lines.push('');
     lines.push(
-      `<summary>${esc(presenter.title)} (${findings.length}) · ${money(subtotal)}/mo</summary>`,
+      '> Savings you can capture **without deleting** the resource. ' +
+        'Not counted in the waste total; items marked _estimated_ need verification.',
     );
     lines.push('');
-    const header = [...presenter.head, '$/mo'];
-    lines.push(`| ${header.join(' | ')} |`);
-    lines.push(`|${header.map(() => '---').join('|')}|`);
-    for (const finding of findings) {
-      const cells = [
-        ...presenter.row(finding).map(esc),
-        money(finding.costEstimate.monthlyCostUsd),
-      ];
-      lines.push(`| ${cells.join(' | ')} |`);
+    lines.push('| Resource type | Count | $/month |');
+    lines.push('|---|---:|---:|');
+    for (const kind of kindsOf('optimization')) {
+      const subtotal = grouped[kind].reduce((s, r) => s + r.costEstimate.monthlyCostUsd, 0);
+      const label = RESOURCE_KIND_META[kind].estimated
+        ? `${RESOURCE_KIND_LABELS[kind]} _(estimated)_`
+        : RESOURCE_KIND_LABELS[kind];
+      lines.push(`| ${label} | ${grouped[kind].length} | ${money(subtotal)} |`);
     }
+    lines.push(
+      `| **Total optimization** | **${countOf('optimization')}** | **${money(summary.totalOptimizationMonthlyUsd)}** |`,
+    );
     lines.push('');
-    lines.push('</details>');
-    lines.push('');
+    renderDetails('optimization');
   }
 
-  // Raccomandazioni principali (ordinate per costo decrescente)
+  // Raccomandazioni principali (ordinate per costo decrescente, tutte le categorie).
   const recommendations = RESOURCE_KINDS.flatMap((kind) =>
     grouped[kind].map((finding) => ({
       text: presenterFor(kind).recommend(finding),
@@ -132,7 +137,6 @@ export function formatWasteReportAsMarkdown(
     lines.push('');
   }
 
-  // Errori di scan: risultati parziali
   if (summary.scanErrors.length > 0) {
     lines.push('> ⚠️ **Partial results** — some scans could not complete:');
     for (const { kind, region, error } of summary.scanErrors) {
@@ -143,4 +147,29 @@ export function formatWasteReportAsMarkdown(
 
   lines.push(footer(meta));
   return lines.join('\n');
+
+  function renderDetails(category: FindingCategory): void {
+    for (const kind of kindsOf(category)) {
+      const presenter = presenterFor(kind);
+      const subtotal = grouped[kind].reduce((s, r) => s + r.costEstimate.monthlyCostUsd, 0);
+      lines.push('<details>');
+      lines.push(
+        `<summary>${esc(presenter.title)} (${grouped[kind].length}) · ${money(subtotal)}/mo</summary>`,
+      );
+      lines.push('');
+      const header = [...presenter.head, '$/mo'];
+      lines.push(`| ${header.join(' | ')} |`);
+      lines.push(`|${header.map(() => '---').join('|')}|`);
+      for (const finding of grouped[kind]) {
+        const cells = [
+          ...presenter.row(finding).map(esc),
+          money(finding.costEstimate.monthlyCostUsd),
+        ];
+        lines.push(`| ${cells.join(' | ')} |`);
+      }
+      lines.push('');
+      lines.push('</details>');
+      lines.push('');
+    }
+  }
 }

--- a/apps/cli/src/formatters/waste-report.pdf-formatter.ts
+++ b/apps/cli/src/formatters/waste-report.pdf-formatter.ts
@@ -3,9 +3,14 @@ import { createWriteStream } from 'fs';
 import {
   RESOURCE_KINDS,
   RESOURCE_KIND_LABELS,
+  RESOURCE_KIND_META,
   groupByKind,
 } from 'cloud-cost-domain';
-import type { WastedResource, WastedResourcesSummary } from 'cloud-cost-domain';
+import type {
+  FindingCategory,
+  WastedResource,
+  WastedResourcesSummary,
+} from 'cloud-cost-domain';
 import type { WasteReportMeta } from 'cloud-cost-application';
 import { presenterFor } from './resource-presenters';
 
@@ -77,7 +82,7 @@ function drawSummaryPage(
 
   // Metric boxes
   y += 14;
-  const monthly = summary.totalMonthlyCostUsd;
+  const monthly = summary.totalWasteMonthlyUsd;
   const annual = monthly * 12;
   const total = summary.findings.length;
   const isIncomplete = summary.scanErrors.length > 0;
@@ -89,12 +94,28 @@ function drawSummaryPage(
   drawMetricBox(doc, MARGIN + 162, y, 152, 'ANNUAL WASTE', annualLabel, C.warning);
   drawMetricBox(doc, MARGIN + 324, y, 123, 'RESOURCES FOUND', String(total), C.text);
 
-  // Breakdown
+  // Waste breakdown
   y += 90;
   doc.font('Helvetica-Bold').fontSize(10.5).fillColor(C.text)
-    .text('Breakdown by resource type', MARGIN, y, { lineBreak: false });
+    .text('Waste breakdown by resource type', MARGIN, y, { lineBreak: false });
   y += 16;
-  y = drawTable(doc, ['Resource type', 'Found', 'Est. cost/month'], buildBreakdownRows(summary), [290, 60, 149], y);
+  y = drawTable(doc, ['Resource type', 'Found', 'Est. cost/month'], buildBreakdownRows(summary, 'waste'), [290, 60, 149], y);
+
+  // Optimization opportunities (separate — not counted in the waste total)
+  const optimizationRows = buildBreakdownRows(summary, 'optimization');
+  if (optimizationRows.length > 0) {
+    y += 20;
+    doc.font('Helvetica-Bold').fontSize(10.5).fillColor(C.text)
+      .text('Optimization opportunities', MARGIN, y, { lineBreak: false });
+    y += 14;
+    doc.font('Helvetica').fontSize(8).fillColor(C.muted)
+      .text(
+        `Savings without deleting the resource — $${summary.totalOptimizationMonthlyUsd.toFixed(2)}/mo, not counted in the waste total. Items marked (estimated) need verification.`,
+        MARGIN, y, { width: CONTENT_W },
+      );
+    y += 18;
+    y = drawTable(doc, ['Resource type', 'Found', 'Est. saving/month'], optimizationRows, [290, 60, 149], y);
+  }
 
   // Recommendations
   const wins = buildQuickWins(summary);
@@ -287,16 +308,20 @@ function drawRecommendations(doc: PDFKit.PDFDocument, wins: QuickWin[], startY: 
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
-function buildBreakdownRows(summary: WastedResourcesSummary): string[][] {
+function buildBreakdownRows(
+  summary: WastedResourcesSummary,
+  category: FindingCategory,
+): string[][] {
   const grouped = groupByKind(summary.findings);
 
   return RESOURCE_KINDS
-    .filter((kind) => grouped[kind].length > 0)
+    .filter((kind) => RESOURCE_KIND_META[kind].category === category && grouped[kind].length > 0)
     .map((kind) => {
       const findings: WastedResource[] = grouped[kind];
       const cost = findings.reduce((sum, f) => sum + f.costEstimate.monthlyCostUsd, 0);
+      const estimatedSuffix = RESOURCE_KIND_META[kind].estimated ? ' (estimated)' : '';
       return [
-        `${RESOURCE_KIND_LABELS[kind]} (${findings[0].wasteReason})`,
+        `${RESOURCE_KIND_LABELS[kind]} (${findings[0].wasteReason})${estimatedSuffix}`,
         String(findings.length),
         `$${cost.toFixed(2)}/mo`,
       ];

--- a/apps/cli/src/formatters/waste-report.table-formatter.ts
+++ b/apps/cli/src/formatters/waste-report.table-formatter.ts
@@ -3,9 +3,10 @@ import chalk from 'chalk';
 import {
   RESOURCE_KINDS,
   RESOURCE_KIND_LABELS,
+  RESOURCE_KIND_META,
   groupByKind,
 } from 'cloud-cost-domain';
-import type { WastedResourcesSummary } from 'cloud-cost-domain';
+import type { FindingCategory, WastedResourcesSummary } from 'cloud-cost-domain';
 import { presenterFor } from './resource-presenters';
 
 export interface TableReportMeta {
@@ -19,21 +20,38 @@ export function formatWasteReportAsTable(
   const lines: string[] = [];
   const grouped = groupByKind(summary.findings);
 
-  for (const kind of RESOURCE_KINDS) {
-    const findings = grouped[kind];
-    if (findings.length === 0) continue;
+  const renderKindTables = (category: FindingCategory): boolean => {
+    let rendered = false;
+    for (const kind of RESOURCE_KINDS) {
+      if (RESOURCE_KIND_META[kind].category !== category) continue;
+      const findings = grouped[kind];
+      if (findings.length === 0) continue;
+      rendered = true;
 
-    const presenter = presenterFor(kind);
-    lines.push(chalk.bold.yellow(`\n  ${presenter.title}`));
-
-    const table = new Table({
-      head: [...presenter.head, 'Est. Cost'],
-      style: { head: ['cyan'] },
-    });
-    for (const finding of findings) {
-      table.push([...presenter.row(finding), chalk.red(finding.costEstimate.format())]);
+      const presenter = presenterFor(kind);
+      lines.push(chalk.bold.yellow(`\n  ${presenter.title}`));
+      const table = new Table({
+        head: [...presenter.head, 'Est. Cost'],
+        style: { head: ['cyan'] },
+      });
+      for (const finding of findings) {
+        table.push([...presenter.row(finding), chalk.red(finding.costEstimate.format())]);
+      }
+      lines.push(table.toString());
     }
-    lines.push(table.toString());
+    return rendered;
+  };
+
+  renderKindTables('waste');
+
+  // Sezione separata: opportunità di risparmio, NON conteggiate nel totale waste.
+  const hasOptimizations = summary.totalOptimizationMonthlyUsd > 0 ||
+    RESOURCE_KINDS.some((k) => RESOURCE_KIND_META[k].category === 'optimization' && grouped[k].length > 0);
+  if (hasOptimizations) {
+    lines.push(
+      chalk.bold.cyan('\n  ── Optimization opportunities (savings — verify before acting) ──'),
+    );
+    renderKindTables('optimization');
   }
 
   if (summary.findings.length === 0 && summary.scanErrors.length === 0) {
@@ -53,11 +71,22 @@ export function formatWasteReportAsTable(
     }
   }
 
+  const incomplete = summary.scanErrors.length > 0
+    ? chalk.yellow(' (incomplete — see warnings above)')
+    : '';
   lines.push(
     chalk.bold(
-      `\n  Total estimated waste: ${chalk.red(`$${summary.totalMonthlyCostUsd.toFixed(2)}/month`)}${summary.scanErrors.length > 0 ? chalk.yellow(' (incomplete — see warnings above)') : ''}`,
+      `\n  Total waste: ${chalk.red(`$${summary.totalWasteMonthlyUsd.toFixed(2)}/month`)}${incomplete}`,
     ),
   );
+  if (summary.totalOptimizationMonthlyUsd > 0) {
+    lines.push(
+      chalk.cyan(
+        `  Optimization opportunities: $${summary.totalOptimizationMonthlyUsd.toFixed(2)}/month ` +
+          `(savings, not counted in the waste total)`,
+      ),
+    );
+  }
   lines.push(
     chalk.dim(
       `  Estimates based on AWS list prices as of ${meta.pricesAsOf}; actual billing may differ.\n`,

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -48,7 +48,7 @@ program
     '--json [filename]',
     'Also write a JSON report to disk (optional filename, defaults to cloudrift-report-YYYY-MM-DD.json)',
   )
-  .action(analyzeWasteCommand);
+  .action((options) => analyzeWasteCommand(options));
 
 program.parseAsync(process.argv).catch((err: Error) => {
   console.error(err.message);

--- a/libs/cloud-cost/application/src/dto/waste-report.dto.spec.ts
+++ b/libs/cloud-cost/application/src/dto/waste-report.dto.spec.ts
@@ -1,5 +1,5 @@
 import { toWasteReportDto } from './waste-report.dto';
-import { AwsRegion, EbsVolume, ElasticIp } from 'cloud-cost-domain';
+import { AwsRegion, EbsVolume, ElasticIp, Gp2Volume } from 'cloud-cost-domain';
 import type { WastedResourcesSummary } from 'cloud-cost-domain';
 
 const region = AwsRegion.create('us-east-1');
@@ -29,7 +29,8 @@ const ip = new ElasticIp({
 
 const summary: WastedResourcesSummary = {
   findings: [volume, ip],
-  totalMonthlyCostUsd: 11.6,
+  totalWasteMonthlyUsd: 11.6,
+  totalOptimizationMonthlyUsd: 0,
   scanErrors: [
     { kind: 'nat-gateway', region: 'eu-west-1', error: new Error('throttled') },
   ],
@@ -56,25 +57,29 @@ describe('toWasteReportDto', () => {
       generatedAt: '2026-06-12T10:00:00.000Z',
       pricesAsOf: '2025-06',
     });
-    expect(dto.totalMonthlyCostUsd).toBe(11.6);
-    expect(dto.totalAnnualCostUsd).toBe(139.2);
-    expect(dto.resourceCount).toBe(2);
+    expect(dto.totalWasteMonthlyUsd).toBe(11.6);
+    expect(dto.totalWasteAnnualUsd).toBe(139.2);
+    expect(dto.totalOptimizationMonthlyUsd).toBe(0);
+    expect(dto.wasteCount).toBe(2);
+    expect(dto.optimizationCount).toBe(0);
   });
 
   it('builds the per-kind breakdown only for kinds with findings', () => {
     const dto = toWasteReportDto(summary, meta);
     expect(dto.breakdown).toEqual([
-      { kind: 'ebs-volume', label: 'EBS Volumes', count: 1, monthlyCostUsd: 8 },
-      { kind: 'elastic-ip', label: 'Elastic IPs', count: 1, monthlyCostUsd: 3.6 },
+      { kind: 'ebs-volume', label: 'EBS Volumes', category: 'waste', estimated: false, count: 1, monthlyCostUsd: 8 },
+      { kind: 'elastic-ip', label: 'Elastic IPs', category: 'waste', estimated: false, count: 1, monthlyCostUsd: 3.6 },
     ]);
   });
 
-  it('maps findings with ISO dates and waste reasons', () => {
+  it('maps findings with ISO dates, category and waste reasons', () => {
     const dto = toWasteReportDto(summary, meta);
     const volDto = dto.findings.find((f) => f.id === 'vol-1');
     expect(volDto).toEqual({
       id: 'vol-1',
       kind: 'ebs-volume',
+      category: 'waste',
+      estimated: false,
       region: 'us-east-1',
       accountId: '123456789012',
       detectedAt: '2026-06-09T00:00:00.000Z',
@@ -83,6 +88,30 @@ describe('toWasteReportDto', () => {
       monthlyCostUsd: 8,
       tags: { Environment: 'staging' },
     });
+  });
+
+  it('classifies gp2→gp3 as an optimization, separate from the waste total', () => {
+    const gp2 = new Gp2Volume({
+      volumeId: 'vol-gp2',
+      region,
+      accountId: '123456789012',
+      sizeGb: 200,
+      createTime: new Date('2025-01-01T00:00:00Z'),
+      detectedAt: new Date('2026-06-09T00:00:00Z'),
+      tags: {},
+      monthlyCostUsd: 4,
+    });
+    const dto = toWasteReportDto(
+      { findings: [volume, gp2], totalWasteMonthlyUsd: 8, totalOptimizationMonthlyUsd: 4, scanErrors: [] },
+      meta,
+    );
+
+    expect(dto.totalWasteMonthlyUsd).toBe(8);
+    expect(dto.totalOptimizationMonthlyUsd).toBe(4);
+    expect(dto.wasteCount).toBe(1);
+    expect(dto.optimizationCount).toBe(1);
+    const gp2Dto = dto.findings.find((f) => f.id === 'vol-gp2');
+    expect(gp2Dto?.category).toBe('optimization');
   });
 
   it('maps scan errors to plain messages', () => {

--- a/libs/cloud-cost/application/src/dto/waste-report.dto.ts
+++ b/libs/cloud-cost/application/src/dto/waste-report.dto.ts
@@ -1,10 +1,18 @@
-import { RESOURCE_KIND_LABELS, groupByKind } from 'cloud-cost-domain';
-import type { ResourceKind, WastedResourcesSummary } from 'cloud-cost-domain';
+import { RESOURCE_KIND_META, groupByKind } from 'cloud-cost-domain';
+import type {
+  FindingCategory,
+  ResourceKind,
+  WastedResourcesSummary,
+} from 'cloud-cost-domain';
 
 /**
  * Proiezione serializzabile (JSON-safe) del summary: è il contratto dati
  * per qualunque presentazione — CLI, PDF, API HTTP o frontend. Non contiene
  * classi né Date: solo primitivi e stringhe ISO.
+ *
+ * I finding sono divisi in due categorie: `waste` (spreco, conta nel totale
+ * waste / gate CI) e `optimization` (opportunità di risparmio, a parte). Le
+ * voci `estimated` sono stime (rightsizing) da verificare.
  */
 export interface WasteReportDto {
   meta: {
@@ -13,18 +21,24 @@ export interface WasteReportDto {
     generatedAt: string;
     pricesAsOf: string;
   };
-  totalMonthlyCostUsd: number;
-  totalAnnualCostUsd: number;
-  resourceCount: number;
+  totalWasteMonthlyUsd: number;
+  totalWasteAnnualUsd: number;
+  totalOptimizationMonthlyUsd: number;
+  wasteCount: number;
+  optimizationCount: number;
   breakdown: Array<{
     kind: ResourceKind;
     label: string;
+    category: FindingCategory;
+    estimated: boolean;
     count: number;
     monthlyCostUsd: number;
   }>;
   findings: Array<{
     id: string;
     kind: ResourceKind;
+    category: FindingCategory;
+    estimated: boolean;
     region: string;
     accountId: string;
     detectedAt: string;
@@ -57,12 +71,21 @@ export function toWasteReportDto(
     .filter((kind) => grouped[kind].length > 0)
     .map((kind) => ({
       kind,
-      label: RESOURCE_KIND_LABELS[kind],
+      label: RESOURCE_KIND_META[kind].label,
+      category: RESOURCE_KIND_META[kind].category,
+      estimated: RESOURCE_KIND_META[kind].estimated,
       count: grouped[kind].length,
       monthlyCostUsd: round2(
         grouped[kind].reduce((sum, r) => sum + r.costEstimate.monthlyCostUsd, 0),
       ),
     }));
+
+  let wasteCount = 0;
+  let optimizationCount = 0;
+  for (const finding of summary.findings) {
+    if (RESOURCE_KIND_META[finding.kind].category === 'waste') wasteCount++;
+    else optimizationCount++;
+  }
 
   return {
     meta: {
@@ -71,13 +94,17 @@ export function toWasteReportDto(
       generatedAt: meta.generatedAt.toISOString(),
       pricesAsOf: meta.pricesAsOf,
     },
-    totalMonthlyCostUsd: round2(summary.totalMonthlyCostUsd),
-    totalAnnualCostUsd: round2(summary.totalMonthlyCostUsd * 12),
-    resourceCount: summary.findings.length,
+    totalWasteMonthlyUsd: round2(summary.totalWasteMonthlyUsd),
+    totalWasteAnnualUsd: round2(summary.totalWasteMonthlyUsd * 12),
+    totalOptimizationMonthlyUsd: round2(summary.totalOptimizationMonthlyUsd),
+    wasteCount,
+    optimizationCount,
     breakdown,
     findings: summary.findings.map((finding) => ({
       id: finding.id,
       kind: finding.kind,
+      category: RESOURCE_KIND_META[finding.kind].category,
+      estimated: RESOURCE_KIND_META[finding.kind].estimated,
       region: finding.region.code,
       accountId: finding.accountId,
       detectedAt: finding.detectedAt.toISOString(),

--- a/libs/cloud-cost/application/src/use-cases/analyze-cloud-waste.use-case.spec.ts
+++ b/libs/cloud-cost/application/src/use-cases/analyze-cloud-waste.use-case.spec.ts
@@ -3,6 +3,7 @@ import {
   AwsRegion,
   EbsVolume,
   ElasticIp,
+  Gp2Volume,
 } from 'cloud-cost-domain';
 import type { ResourceKind, WastedResource, WasteScannerPort } from 'cloud-cost-domain';
 import { Result } from 'shared-kernel';
@@ -37,6 +38,19 @@ function makeElasticIp(allocationId: string): ElasticIp {
   });
 }
 
+function makeGp2Volume(id: string): Gp2Volume {
+  return new Gp2Volume({
+    volumeId: id,
+    region: usEast,
+    accountId: '123456789012',
+    sizeGb: 200,
+    createTime: new Date('2025-01-01'),
+    detectedAt: new Date('2026-06-09'),
+    tags: {},
+    monthlyCostUsd: 4,
+  });
+}
+
 /** Scanner fittizio: una risposta per regione, in ordine di chiamata. */
 function makeScanner(
   kind: ResourceKind,
@@ -61,11 +75,12 @@ describe('AnalyzeCloudWasteUseCase', () => {
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     expect(result.value.findings).toHaveLength(0);
-    expect(result.value.totalMonthlyCostUsd).toBe(0);
+    expect(result.value.totalWasteMonthlyUsd).toBe(0);
+    expect(result.value.totalOptimizationMonthlyUsd).toBe(0);
     expect(result.value.scanErrors).toHaveLength(0);
   });
 
-  it('aggregates findings from all scanners and computes total cost', async () => {
+  it('aggregates findings from all scanners and computes the waste total', async () => {
     const useCase = new AnalyzeCloudWasteUseCase([
       makeScanner('ebs-volume', [Result.ok([makeEbsVolume('vol-1'), makeEbsVolume('vol-2')])]),
       makeScanner('elastic-ip', [Result.ok([makeElasticIp('eipalloc-1')])]),
@@ -77,7 +92,22 @@ describe('AnalyzeCloudWasteUseCase', () => {
     if (!result.ok) return;
     expect(result.value.findings).toHaveLength(3);
     // 2 × (100 GB × $0.08) + 1 × $3.60 = $19.60
-    expect(result.value.totalMonthlyCostUsd).toBeCloseTo(19.6, 2);
+    expect(result.value.totalWasteMonthlyUsd).toBeCloseTo(19.6, 2);
+    expect(result.value.totalOptimizationMonthlyUsd).toBe(0);
+  });
+
+  it('splits the totals by category (waste vs optimization)', async () => {
+    const useCase = new AnalyzeCloudWasteUseCase([
+      makeScanner('ebs-volume', [Result.ok([makeEbsVolume('vol-1')])]), // waste
+      makeScanner('ebs-gp2-upgrade', [Result.ok([makeGp2Volume('vol-gp2')])]), // optimization
+    ]);
+
+    const result = await useCase.execute({ regions: [usEast] });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.totalWasteMonthlyUsd).toBeCloseTo(8, 2);
+    expect(result.value.totalOptimizationMonthlyUsd).toBeCloseTo(4, 2);
   });
 
   it('records a scanError with kind and region when a scanner fails, preserving other results', async () => {
@@ -126,7 +156,7 @@ describe('AnalyzeCloudWasteUseCase', () => {
 
     expect(result.ok).toBe(true);
     if (!result.ok) return;
-    expect(result.value.totalMonthlyCostUsd).toBeCloseTo(3.6, 2);
+    expect(result.value.totalWasteMonthlyUsd).toBeCloseTo(3.6, 2);
   });
 
   it('scans every region with every scanner', async () => {

--- a/libs/cloud-cost/application/src/use-cases/analyze-cloud-waste.use-case.ts
+++ b/libs/cloud-cost/application/src/use-cases/analyze-cloud-waste.use-case.ts
@@ -1,4 +1,5 @@
 import { Result } from 'shared-kernel';
+import { categoryOf } from 'cloud-cost-domain';
 import type {
   FindWastedResourcesRequest,
   FindWastedResourcesUseCasePort,
@@ -42,11 +43,22 @@ export class AnalyzeCloudWasteUseCase implements FindWastedResourcesUseCasePort 
       }),
     );
 
-    const totalMonthlyCostUsd = findings.reduce(
-      (sum, finding) => sum + finding.costEstimate.monthlyCostUsd,
-      0,
-    );
+    let totalWasteMonthlyUsd = 0;
+    let totalOptimizationMonthlyUsd = 0;
+    for (const finding of findings) {
+      const amount = finding.costEstimate.monthlyCostUsd;
+      if (categoryOf(finding.kind) === 'waste') {
+        totalWasteMonthlyUsd += amount;
+      } else {
+        totalOptimizationMonthlyUsd += amount;
+      }
+    }
 
-    return Result.ok({ findings, totalMonthlyCostUsd, scanErrors });
+    return Result.ok({
+      findings,
+      totalWasteMonthlyUsd,
+      totalOptimizationMonthlyUsd,
+      scanErrors,
+    });
   }
 }

--- a/libs/cloud-cost/domain/src/index.ts
+++ b/libs/cloud-cost/domain/src/index.ts
@@ -1,6 +1,17 @@
 // Wasted resource model
-export { RESOURCE_KINDS, RESOURCE_KIND_LABELS } from './wasted-resource';
-export type { ResourceKind, WastedResource } from './wasted-resource';
+export {
+  RESOURCE_KINDS,
+  RESOURCE_KIND_LABELS,
+  RESOURCE_KIND_META,
+  categoryOf,
+  isEstimated,
+} from './wasted-resource';
+export type {
+  ResourceKind,
+  WastedResource,
+  FindingCategory,
+  ResourceKindMeta,
+} from './wasted-resource';
 export { groupByKind } from './group-by-kind';
 export type { ResourceKindMap, FindingsByKind } from './group-by-kind';
 

--- a/libs/cloud-cost/domain/src/ports/inbound/find-wasted-resources.use-case.port.ts
+++ b/libs/cloud-cost/domain/src/ports/inbound/find-wasted-resources.use-case.port.ts
@@ -14,7 +14,10 @@ export interface ResourceScanError {
 
 export interface WastedResourcesSummary {
   findings: WastedResource[];
-  totalMonthlyCostUsd: number;
+  /** Somma dei finding di categoria `waste` (l'headline e il gate CI). */
+  totalWasteMonthlyUsd: number;
+  /** Somma dei finding di categoria `optimization` (mostrata a parte). */
+  totalOptimizationMonthlyUsd: number;
   scanErrors: ResourceScanError[];
 }
 

--- a/libs/cloud-cost/domain/src/wasted-resource.ts
+++ b/libs/cloud-cost/domain/src/wasted-resource.ts
@@ -14,16 +14,45 @@ export const RESOURCE_KINDS = [
 
 export type ResourceKind = (typeof RESOURCE_KINDS)[number];
 
-export const RESOURCE_KIND_LABELS: Record<ResourceKind, string> = {
-  'ebs-volume': 'EBS Volumes',
-  'elastic-ip': 'Elastic IPs',
-  'rds-instance': 'RDS Instances',
-  'load-balancer': 'Load Balancers',
-  'ec2-instance': 'EC2 Instances',
-  'ebs-snapshot': 'EBS Snapshots',
-  'nat-gateway': 'NAT Gateways',
-  'ebs-gp2-upgrade': 'EBS gp2→gp3 Upgrades',
+/**
+ * Categoria di un finding:
+ * - `waste`: denaro speso ora, eliminabile cancellando/staccando la risorsa.
+ *   Contribuisce al **totale waste** (l'headline e il gate CI).
+ * - `optimization`: opportunità di risparmio mantenendo la risorsa (es. gp2→gp3,
+ *   rightsizing). Mostrata a parte, NON nel totale waste.
+ */
+export type FindingCategory = 'waste' | 'optimization';
+
+export interface ResourceKindMeta {
+  label: string;
+  category: FindingCategory;
+  /** Il risparmio è una stima euristica (rightsizing) anziché un valore certo. */
+  estimated: boolean;
+}
+
+export const RESOURCE_KIND_META: Record<ResourceKind, ResourceKindMeta> = {
+  'ebs-volume': { label: 'EBS Volumes', category: 'waste', estimated: false },
+  'elastic-ip': { label: 'Elastic IPs', category: 'waste', estimated: false },
+  'rds-instance': { label: 'RDS Instances', category: 'waste', estimated: false },
+  'load-balancer': { label: 'Load Balancers', category: 'waste', estimated: false },
+  'ec2-instance': { label: 'EC2 Instances', category: 'waste', estimated: false },
+  'ebs-snapshot': { label: 'EBS Snapshots', category: 'waste', estimated: false },
+  'nat-gateway': { label: 'NAT Gateways', category: 'waste', estimated: false },
+  'ebs-gp2-upgrade': { label: 'EBS gp2→gp3 Upgrades', category: 'optimization', estimated: false },
 };
+
+/** Etichette leggibili, derivate da RESOURCE_KIND_META (unica fonte). */
+export const RESOURCE_KIND_LABELS: Record<ResourceKind, string> = Object.fromEntries(
+  RESOURCE_KINDS.map((kind) => [kind, RESOURCE_KIND_META[kind].label]),
+) as Record<ResourceKind, string>;
+
+export function categoryOf(kind: ResourceKind): FindingCategory {
+  return RESOURCE_KIND_META[kind].category;
+}
+
+export function isEstimated(kind: ResourceKind): boolean {
+  return RESOURCE_KIND_META[kind].estimated;
+}
 
 /**
  * Contratto comune di ogni risorsa segnalata come spreco.


### PR DESCRIPTION
Two foundational changes for phase 3 (advanced detection). No new scanners
yet — this prepares the model and the test harness.

## Waste vs optimization (3.A)

Findings are now split into two categories so the headline stays honest:

- **`waste`** — money bleeding now (delete/detach). Drives the headline total
  and the CI exit-2 gate.
- **`optimization`** — savings without deleting (gp2→gp3 now; rightsizing in
  3.2/3.3). Shown in a separate section, **not** in the waste total. Estimated
  items are flagged.

`RESOURCE_KIND_META` is the single source (label + category + estimated);
`RESOURCE_KIND_LABELS` is derived. The summary exposes
`totalWasteMonthlyUsd` + `totalOptimizationMonthlyUsd`; the DTO adds
`category`/`estimated` and per-category counts. All four formatters render the
optimization section separately. **gp2→gp3 moved out of the waste total** — it
was never deletable waste (the headline number will drop accordingly; this is
the correction).

## CLI testability (3.0)

`analyzeWasteCommand` now takes an injectable `AnalyzeDeps` (`loadConfig`,
`resolveAccountId`, `createAnalysis`); the default is the real AWS composition,
so behaviour is unchanged. A new end-to-end spec drives canned findings through
the command with **no AWS** and locks down the CI-facing behaviour: format
routing, exit-2 over threshold / exit-0 under, clean JSON stdout (alert on
stderr), invalid `--format`, config error, all-regions-excluded, `--json` file.