### PR TITLE
feat(cli) add EBS idle

### DIFF
--- a/apps/cli/src/commands/analyze-waste.command.ts
+++ b/apps/cli/src/commands/analyze-waste.command.ts
@@ -14,6 +14,7 @@ import {
   EbsSnapshotWastePolicy,
   NatGatewayWastePolicy,
   Gp2UpgradePolicy,
+  EbsIdlePolicy,
 } from 'cloud-cost-domain';
 import type {
   FindWastedResourcesUseCasePort,
@@ -32,6 +33,7 @@ import {
   AwsEbsSnapshotScanner,
   AwsNatGatewayScanner,
   AwsGp2UpgradeScanner,
+  AwsEbsIdleScanner,
   StaticPriceTableAdapter,
   TablePricingAdapter,
   AwsPricingApiAdapter,
@@ -139,6 +141,12 @@ async function defaultCreateAnalysis(ctx: AnalysisContext): Promise<Analysis> {
       cloudwatchWindowHours,
     ),
     new AwsGp2UpgradeScanner(pricing, accountId, new Gp2UpgradePolicy(policyOptions)),
+    new AwsEbsIdleScanner(
+      pricing,
+      accountId,
+      new EbsIdlePolicy(policyOptions, ctx.config.thresholds?.ebsIdleMaxOps ?? 0),
+      cloudwatchWindowHours,
+    ),
   ];
 
   return { useCase: new AnalyzeCloudWasteUseCase(scanners), pricesAsOf: pricing.getPricesAsOf() };

--- a/apps/cli/src/config/cloudrift.config.spec.ts
+++ b/apps/cli/src/config/cloudrift.config.spec.ts
@@ -44,6 +44,18 @@ describe('parseConfig', () => {
     if (!result.ok) expect(result.error.message).toContain('prices');
   });
 
+  it('parses thresholds.ebsIdleMaxOps', () => {
+    const result = parseConfig(JSON.stringify({ thresholds: { ebsIdleMaxOps: 50 } }));
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value.thresholds?.ebsIdleMaxOps).toBe(50);
+  });
+
+  it('rejects a negative thresholds.ebsIdleMaxOps', () => {
+    const result = parseConfig(JSON.stringify({ thresholds: { ebsIdleMaxOps: -1 } }));
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toContain('ebsIdleMaxOps');
+  });
+
   it('returns empty config for an empty object', () => {
     const result = parseConfig('{}');
     expect(result.ok).toBe(true);

--- a/apps/cli/src/config/cloudrift.config.ts
+++ b/apps/cli/src/config/cloudrift.config.ts
@@ -34,6 +34,11 @@ export interface CloudriftConfig {
    * Vincono su listino statico e su AWS Pricing API.
    */
   prices?: Record<string, Record<string, number>>;
+  /** Soglie per-check. */
+  thresholds?: {
+    /** Operazioni I/O totali sotto cui un volume EBS attaccato è "idle". Default 0. */
+    ebsIdleMaxOps?: number;
+  };
 }
 
 export class ConfigError extends DomainError {
@@ -159,6 +164,23 @@ export function parseConfig(
       errors.push(
         'prices must be an object of region → { priceKey: number } (e.g. { "eu-west-1": { "nat-gateway": 28.5 } })',
       );
+    }
+  }
+
+  if (obj.thresholds !== undefined) {
+    if (!isPlainObject(obj.thresholds)) {
+      errors.push('thresholds must be an object');
+    } else {
+      const thresholds: NonNullable<CloudriftConfig['thresholds']> = {};
+      const { ebsIdleMaxOps } = obj.thresholds;
+      if (ebsIdleMaxOps !== undefined) {
+        if (typeof ebsIdleMaxOps === 'number' && Number.isFinite(ebsIdleMaxOps) && ebsIdleMaxOps >= 0) {
+          thresholds.ebsIdleMaxOps = ebsIdleMaxOps;
+        } else {
+          errors.push('thresholds.ebsIdleMaxOps must be a non-negative number');
+        }
+      }
+      config.thresholds = thresholds;
     }
   }
 

--- a/apps/cli/src/formatters/resource-presenters.ts
+++ b/apps/cli/src/formatters/resource-presenters.ts
@@ -106,6 +106,20 @@ export const presenters: PresenterMap = {
     recommend: (v) =>
       `Modify EBS ${v.id} (${v.sizeGb} GB gp2) in ${v.region.code} to gp3 — saves ${v.costEstimate.format()}, no downtime`,
   },
+  'ebs-idle': {
+    title: 'EBS Volumes — Idle (attached, no I/O)',
+    head: ['Volume ID', 'Region', 'Size', 'Type', 'Attached to'],
+    colWidths: [130, 72, 56, 50, 130, 70],
+    row: (v) => [
+      v.id,
+      v.region.code,
+      `${v.sizeGb} GB`,
+      v.volumeType,
+      v.attachedInstanceId ?? '—',
+    ],
+    recommend: (v) =>
+      `Detach or delete idle EBS ${v.id} (${v.sizeGb} GB ${v.volumeType}) in ${v.region.code} — no I/O in last ${v.metricWindowHours}h`,
+  },
 };
 
 export function presenterFor(kind: ResourceKind): ResourcePresenter {

--- a/libs/cloud-cost/domain/src/entities/idle-ebs-volume.entity.ts
+++ b/libs/cloud-cost/domain/src/entities/idle-ebs-volume.entity.ts
@@ -1,0 +1,63 @@
+import { Entity } from 'shared-kernel';
+import { AwsRegion } from '../value-objects/aws-region.value-object';
+import { CostEstimate } from '../value-objects/cost-estimate.value-object';
+import type { WastedResource } from '../wasted-resource';
+
+/**
+ * Volume EBS *attaccato* (in-use) ma con zero (o quasi) I/O nella finestra
+ * osservata: si paga lo storage di un disco che non lavora. È spreco a costo
+ * pieno, distinto da `ebs-volume` (volumi non attaccati, state=available).
+ */
+export interface IdleEbsVolumeProps {
+  volumeId: string;
+  region: AwsRegion;
+  accountId: string;
+  sizeGb: number;
+  volumeType: string;
+  attachedInstanceId?: string;
+  /** Somma delle operazioni di lettura nella finestra. */
+  readOps: number;
+  /** Somma delle operazioni di scrittura nella finestra. */
+  writeOps: number;
+  metricWindowHours: number;
+  createTime: Date;
+  detectedAt: Date;
+  tags: Record<string, string>;
+  monthlyCostUsd: number;
+}
+
+export class IdleEbsVolume extends Entity<string> implements WastedResource {
+  private readonly props: Readonly<IdleEbsVolumeProps>;
+
+  constructor(props: IdleEbsVolumeProps) {
+    super(props.volumeId);
+    this.props = Object.freeze({ ...props });
+  }
+
+  get region(): AwsRegion { return this.props.region; }
+  get accountId(): string { return this.props.accountId; }
+  get sizeGb(): number { return this.props.sizeGb; }
+  get volumeType(): string { return this.props.volumeType; }
+  get attachedInstanceId(): string | undefined { return this.props.attachedInstanceId; }
+  get metricWindowHours(): number { return this.props.metricWindowHours; }
+  get createTime(): Date { return this.props.createTime; }
+  get detectedAt(): Date { return this.props.detectedAt; }
+  get tags(): Record<string, string> { return this.props.tags; }
+
+  get kind(): 'ebs-idle' { return 'ebs-idle'; }
+
+  get wasteReason(): string {
+    return `attached but zero I/O over ${this.props.metricWindowHours}h — detach or delete`;
+  }
+
+  totalOps(): number {
+    return this.props.readOps + this.props.writeOps;
+  }
+
+  get costEstimate(): CostEstimate {
+    return CostEstimate.of(
+      this.props.monthlyCostUsd,
+      `${this.props.sizeGb} GB ${this.props.volumeType} idle EBS (no I/O)`,
+    );
+  }
+}

--- a/libs/cloud-cost/domain/src/group-by-kind.ts
+++ b/libs/cloud-cost/domain/src/group-by-kind.ts
@@ -7,6 +7,7 @@ import type { Ec2Instance } from './entities/ec2-instance.entity';
 import type { EbsSnapshot } from './entities/ebs-snapshot.entity';
 import type { NatGateway } from './entities/nat-gateway.entity';
 import type { Gp2Volume } from './entities/gp2-volume.entity';
+import type { IdleEbsVolume } from './entities/idle-ebs-volume.entity';
 
 /**
  * Mappa kind → entità concreta. Permette ai consumer (formatter, frontend)
@@ -21,6 +22,7 @@ export interface ResourceKindMap {
   'ebs-snapshot': EbsSnapshot;
   'nat-gateway': NatGateway;
   'ebs-gp2-upgrade': Gp2Volume;
+  'ebs-idle': IdleEbsVolume;
 }
 
 export type FindingsByKind = {

--- a/libs/cloud-cost/domain/src/index.ts
+++ b/libs/cloud-cost/domain/src/index.ts
@@ -32,6 +32,8 @@ export { NatGateway } from './entities/nat-gateway.entity';
 export type { NatGatewayProps } from './entities/nat-gateway.entity';
 export { Gp2Volume } from './entities/gp2-volume.entity';
 export type { Gp2VolumeProps } from './entities/gp2-volume.entity';
+export { IdleEbsVolume } from './entities/idle-ebs-volume.entity';
+export type { IdleEbsVolumeProps } from './entities/idle-ebs-volume.entity';
 
 // Value Objects
 export { AwsRegion, InvalidAwsRegionError } from './value-objects/aws-region.value-object';
@@ -55,6 +57,7 @@ export {
   EbsSnapshotWastePolicy,
   NatGatewayWastePolicy,
   Gp2UpgradePolicy,
+  EbsIdlePolicy,
 } from './policies/resource-waste-policies';
 
 // Outbound Ports

--- a/libs/cloud-cost/domain/src/policies/resource-waste-policies.spec.ts
+++ b/libs/cloud-cost/domain/src/policies/resource-waste-policies.spec.ts
@@ -7,6 +7,7 @@ import {
   EbsSnapshotWastePolicy,
   NatGatewayWastePolicy,
   Gp2UpgradePolicy,
+  EbsIdlePolicy,
 } from './resource-waste-policies';
 import { DEFAULT_IGNORE_TAG } from './waste-policy';
 import { EbsVolume } from '../entities/ebs-volume.entity';
@@ -17,6 +18,7 @@ import { Ec2Instance } from '../entities/ec2-instance.entity';
 import { EbsSnapshot } from '../entities/ebs-snapshot.entity';
 import { NatGateway } from '../entities/nat-gateway.entity';
 import { Gp2Volume } from '../entities/gp2-volume.entity';
+import { IdleEbsVolume } from '../entities/idle-ebs-volume.entity';
 import type { EbsSnapshotProps } from '../entities/ebs-snapshot.entity';
 import type { Ec2InstanceProps } from '../entities/ec2-instance.entity';
 import { AwsRegion } from '../value-objects/aws-region.value-object';
@@ -346,5 +348,55 @@ describe('Gp2UpgradePolicy', () => {
 
   it('reports the saving in the wasteReason', () => {
     expect(makeGp2Volume().wasteReason).toContain('saves $4.00/mo');
+  });
+});
+
+describe('EbsIdlePolicy', () => {
+  const policy = new EbsIdlePolicy();
+
+  function makeIdleVolume(
+    overrides: { readOps?: number; writeOps?: number; createTime?: Date; tags?: Record<string, string> } = {},
+  ): IdleEbsVolume {
+    return new IdleEbsVolume({
+      volumeId: 'vol-idle',
+      region,
+      accountId: '123456789012',
+      sizeGb: 100,
+      volumeType: 'gp3',
+      attachedInstanceId: 'i-123',
+      readOps: overrides.readOps ?? 0,
+      writeOps: overrides.writeOps ?? 0,
+      metricWindowHours: 48,
+      createTime: overrides.createTime ?? oldDate,
+      detectedAt: now,
+      tags: overrides.tags ?? {},
+      monthlyCostUsd: 8,
+    });
+  }
+
+  it('flags an old attached volume with zero I/O', () => {
+    const verdict = policy.evaluate(makeIdleVolume(), now);
+    expect(verdict.isWaste).toBe(true);
+    expect(verdict.reason).toContain('48h');
+  });
+
+  it('does not flag a volume with I/O activity', () => {
+    expect(policy.evaluate(makeIdleVolume({ readOps: 10, writeOps: 5 }), now).isWaste).toBe(false);
+  });
+
+  it('does not flag a freshly created volume (grace period)', () => {
+    expect(policy.evaluate(makeIdleVolume({ createTime: yesterday }), now).isWaste).toBe(false);
+  });
+
+  it('honours a custom max-ops threshold', () => {
+    const lenient = new EbsIdlePolicy({}, 100);
+    expect(lenient.evaluate(makeIdleVolume({ readOps: 50, writeOps: 40 }), now).isWaste).toBe(true);
+    expect(lenient.evaluate(makeIdleVolume({ readOps: 80, writeOps: 40 }), now).isWaste).toBe(false);
+  });
+
+  it('does not flag a volume carrying the ignore tag', () => {
+    expect(
+      policy.evaluate(makeIdleVolume({ tags: { [DEFAULT_IGNORE_TAG]: 'true' } }), now).isWaste,
+    ).toBe(false);
   });
 });

--- a/libs/cloud-cost/domain/src/policies/resource-waste-policies.ts
+++ b/libs/cloud-cost/domain/src/policies/resource-waste-policies.ts
@@ -1,4 +1,4 @@
-import { WastePolicy, waste, notWaste, type WasteVerdict } from './waste-policy';
+import { WastePolicy, waste, notWaste, type WasteVerdict, type WastePolicyOptions } from './waste-policy';
 import type { EbsVolume } from '../entities/ebs-volume.entity';
 import type { ElasticIp } from '../entities/elastic-ip.entity';
 import type { RdsInstance } from '../entities/rds-instance.entity';
@@ -7,6 +7,7 @@ import type { Ec2Instance } from '../entities/ec2-instance.entity';
 import type { EbsSnapshot } from '../entities/ebs-snapshot.entity';
 import type { NatGateway } from '../entities/nat-gateway.entity';
 import type { Gp2Volume } from '../entities/gp2-volume.entity';
+import type { IdleEbsVolume } from '../entities/idle-ebs-volume.entity';
 
 export class EbsVolumeWastePolicy extends WastePolicy<EbsVolume> {
   protected judge(volume: EbsVolume, now: Date): WasteVerdict {
@@ -80,6 +81,22 @@ export class NatGatewayWastePolicy extends WastePolicy<NatGateway> {
       return notWaste(`created less than ${this.minAgeDays}d ago`);
     }
     return waste(`zero traffic in last ${gateway.metricWindowHours}h`);
+  }
+}
+
+export class EbsIdlePolicy extends WastePolicy<IdleEbsVolume> {
+  /** maxOps: soglia di operazioni I/O totali sotto la quale il volume è idle. */
+  constructor(options: WastePolicyOptions = {}, private readonly maxOps = 0) {
+    super(options);
+  }
+
+  protected judge(volume: IdleEbsVolume, now: Date): WasteVerdict {
+    if (volume.totalOps() > this.maxOps) return notWaste('has I/O activity');
+    // Un volume appena creato potrebbe non aver ancora ricevuto I/O.
+    if (this.isWithinGracePeriod(volume.createTime, now)) {
+      return notWaste(`created less than ${this.minAgeDays}d ago`);
+    }
+    return waste(`zero I/O in last ${volume.metricWindowHours}h`);
   }
 }
 

--- a/libs/cloud-cost/domain/src/wasted-resource.ts
+++ b/libs/cloud-cost/domain/src/wasted-resource.ts
@@ -10,6 +10,7 @@ export const RESOURCE_KINDS = [
   'ebs-snapshot',
   'nat-gateway',
   'ebs-gp2-upgrade',
+  'ebs-idle',
 ] as const;
 
 export type ResourceKind = (typeof RESOURCE_KINDS)[number];
@@ -39,6 +40,7 @@ export const RESOURCE_KIND_META: Record<ResourceKind, ResourceKindMeta> = {
   'ebs-snapshot': { label: 'EBS Snapshots', category: 'waste', estimated: false },
   'nat-gateway': { label: 'NAT Gateways', category: 'waste', estimated: false },
   'ebs-gp2-upgrade': { label: 'EBS gp2→gp3 Upgrades', category: 'optimization', estimated: false },
+  'ebs-idle': { label: 'EBS Volumes (idle)', category: 'waste', estimated: false },
 };
 
 /** Etichette leggibili, derivate da RESOURCE_KIND_META (unica fonte). */

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/index.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/index.ts
@@ -6,6 +6,7 @@ export { AwsEc2InstanceScanner } from './scanners/aws-ec2-instance.scanner';
 export { AwsEbsSnapshotScanner } from './scanners/aws-ebs-snapshot.scanner';
 export { AwsNatGatewayScanner } from './scanners/aws-nat-gateway.scanner';
 export { AwsGp2UpgradeScanner } from './scanners/aws-gp2-upgrade.scanner';
+export { AwsEbsIdleScanner } from './scanners/aws-ebs-idle.scanner';
 export { AwsAdapterError } from './errors/aws-adapter.error';
 export {
   StaticPriceTableAdapter,

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-ebs-idle.scanner.spec.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-ebs-idle.scanner.spec.ts
@@ -1,0 +1,129 @@
+import { EC2Client, DescribeVolumesCommand } from '@aws-sdk/client-ec2';
+import {
+  CloudWatchClient,
+  GetMetricStatisticsCommand,
+} from '@aws-sdk/client-cloudwatch';
+import { AwsEbsIdleScanner } from './aws-ebs-idle.scanner';
+import { AwsRegion, type IdleEbsVolume } from 'cloud-cost-domain';
+import { AwsAdapterError } from '../errors/aws-adapter.error';
+import { mockPricing } from '../testing/mock-pricing';
+
+jest.mock('@aws-sdk/client-ec2');
+jest.mock('@aws-sdk/client-cloudwatch');
+
+const mockEc2Send = jest.fn();
+const mockEc2Destroy = jest.fn();
+const mockCwSend = jest.fn();
+const mockCwDestroy = jest.fn();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (EC2Client as jest.Mock).mockImplementation(() => ({
+    send: mockEc2Send,
+    destroy: mockEc2Destroy,
+  }));
+  (CloudWatchClient as jest.Mock).mockImplementation(() => ({
+    send: mockCwSend,
+    destroy: mockCwDestroy,
+  }));
+});
+
+const region = AwsRegion.create('us-east-1');
+const scanner = new AwsEbsIdleScanner(mockPricing);
+const OLD_DATE = new Date('2024-03-01');
+
+function inUseVolume(overrides: Partial<{ VolumeId: string; VolumeType: string; Size: number; CreateTime: Date }> = {}) {
+  return {
+    VolumeId: overrides.VolumeId ?? 'vol-1',
+    VolumeType: overrides.VolumeType ?? 'gp3',
+    Size: overrides.Size ?? 100,
+    State: 'in-use',
+    CreateTime: overrides.CreateTime ?? OLD_DATE,
+    Attachments: [{ InstanceId: 'i-123' }],
+  };
+}
+
+describe('AwsEbsIdleScanner', () => {
+  it('exposes its resource kind', () => {
+    expect(scanner.kind).toBe('ebs-idle');
+  });
+
+  it('reports an old in-use volume with zero I/O and costs it at full price', async () => {
+    mockEc2Send.mockResolvedValueOnce({ Volumes: [inUseVolume()] });
+    mockCwSend.mockResolvedValue({ Datapoints: [{ Sum: 0 }] });
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.map((v) => v.id)).toEqual(['vol-1']);
+    const vol = result.value[0] as IdleEbsVolume;
+    expect(vol.kind).toBe('ebs-idle');
+    expect(vol.attachedInstanceId).toBe('i-123');
+    expect(vol.costEstimate.monthlyCostUsd).toBeCloseTo(8, 2); // 100 GB × $0.08
+  });
+
+  it('does not report a volume with I/O activity', async () => {
+    mockEc2Send.mockResolvedValueOnce({ Volumes: [inUseVolume()] });
+    mockCwSend.mockResolvedValue({ Datapoints: [{ Sum: 5000 }] });
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toHaveLength(0);
+  });
+
+  it('does not report a freshly created idle volume (grace period)', async () => {
+    mockEc2Send.mockResolvedValueOnce({ Volumes: [inUseVolume({ CreateTime: new Date() })] });
+    mockCwSend.mockResolvedValue({ Datapoints: [] });
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toHaveLength(0);
+  });
+
+  it('skips CloudWatch entirely when no in-use volumes exist', async () => {
+    mockEc2Send.mockResolvedValueOnce({ Volumes: [] });
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    expect(mockCwSend).not.toHaveBeenCalled();
+  });
+
+  it('filters DescribeVolumes on status=in-use', async () => {
+    mockEc2Send.mockResolvedValueOnce({ Volumes: [] });
+
+    await scanner.scan(region);
+
+    const args = (DescribeVolumesCommand as unknown as jest.Mock).mock.calls[0][0];
+    expect(args.Filters).toEqual([{ Name: 'status', Values: ['in-use'] }]);
+  });
+
+  it('queries VolumeReadOps and VolumeWriteOps for the volume', async () => {
+    mockEc2Send.mockResolvedValueOnce({ Volumes: [inUseVolume()] });
+    mockCwSend.mockResolvedValue({ Datapoints: [{ Sum: 0 }] });
+
+    await scanner.scan(region);
+
+    const metricCalls = (GetMetricStatisticsCommand as unknown as jest.Mock).mock.calls.map(
+      (c) => c[0].MetricName,
+    );
+    expect(metricCalls).toContain('VolumeReadOps');
+    expect(metricCalls).toContain('VolumeWriteOps');
+    const firstArgs = (GetMetricStatisticsCommand as unknown as jest.Mock).mock.calls[0][0];
+    expect(firstArgs.Dimensions).toEqual([{ Name: 'VolumeId', Value: 'vol-1' }]);
+  });
+
+  it('returns Result.fail wrapping AwsAdapterError and destroys both clients on error', async () => {
+    mockEc2Send.mockRejectedValueOnce(new Error('boom'));
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect((result.error as AwsAdapterError).service).toBe('EBS');
+    expect(mockEc2Destroy).toHaveBeenCalledTimes(1);
+    expect(mockCwDestroy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-ebs-idle.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-ebs-idle.scanner.ts
@@ -1,0 +1,125 @@
+import {
+  EC2Client,
+  DescribeVolumesCommand,
+  type Volume,
+} from '@aws-sdk/client-ec2';
+import {
+  CloudWatchClient,
+  GetMetricStatisticsCommand,
+} from '@aws-sdk/client-cloudwatch';
+import { Result } from 'shared-kernel';
+import type {
+  AwsRegion,
+  PricingPort,
+  WasteScannerPort,
+  WastedResource,
+} from 'cloud-cost-domain';
+import { IdleEbsVolume, EbsIdlePolicy } from 'cloud-cost-domain';
+import { AwsAdapterError } from '../errors/aws-adapter.error';
+import { paginate } from '../utils/paginate';
+import { mapWithConcurrency } from '../utils/map-with-concurrency';
+
+const DEFAULT_LOOKBACK_HOURS = 48;
+const CLOUDWATCH_CONCURRENCY = 5;
+
+/**
+ * Rileva i volumi EBS *attaccati* (in-use) ma senza I/O nella finestra
+ * osservata: storage pagato per un disco fermo. Distinto da `ebs-volume`
+ * (volumi non attaccati). Per ogni volume somma `VolumeReadOps` +
+ * `VolumeWriteOps` da CloudWatch; la soglia/decisione è della policy.
+ */
+export class AwsEbsIdleScanner implements WasteScannerPort {
+  readonly kind = 'ebs-idle' as const;
+
+  constructor(
+    private readonly pricing: PricingPort,
+    private readonly accountId = 'unknown',
+    private readonly policy = new EbsIdlePolicy(),
+    private readonly windowHours = DEFAULT_LOOKBACK_HOURS,
+  ) {}
+
+  async scan(region: AwsRegion): Promise<Result<WastedResource[]>> {
+    const ec2 = new EC2Client({ region: region.code });
+    const cw = new CloudWatchClient({ region: region.code });
+    try {
+      const rawVolumes = await paginate<Volume>(async (cursor) => {
+        const r = await ec2.send(
+          new DescribeVolumesCommand({
+            Filters: [{ Name: 'status', Values: ['in-use'] }],
+            NextToken: cursor,
+          }),
+        );
+        return { items: r.Volumes ?? [], cursor: r.NextToken };
+      });
+
+      if (rawVolumes.length === 0) return Result.ok([]);
+
+      const endTime = new Date();
+      const startTime = new Date(endTime.getTime() - this.windowHours * 60 * 60 * 1000);
+      const periodSeconds = this.windowHours * 3600;
+      const now = new Date();
+
+      const ops = await mapWithConcurrency(rawVolumes, CLOUDWATCH_CONCURRENCY, async (v) => {
+        const [readOps, writeOps] = await Promise.all([
+          this.sumMetric(cw, v.VolumeId!, 'VolumeReadOps', startTime, endTime, periodSeconds),
+          this.sumMetric(cw, v.VolumeId!, 'VolumeWriteOps', startTime, endTime, periodSeconds),
+        ]);
+        return { readOps, writeOps };
+      });
+
+      const volumes = rawVolumes
+        .map((v: Volume, index) => {
+          const volumeType = v.VolumeType ?? 'gp2';
+          const sizeGb = v.Size ?? 0;
+          const pricePerGb = this.pricing.getEbsVolumePricePerGbMonth(region, volumeType);
+          return new IdleEbsVolume({
+            volumeId: v.VolumeId!,
+            region,
+            accountId: this.accountId,
+            sizeGb,
+            volumeType,
+            attachedInstanceId: v.Attachments?.[0]?.InstanceId,
+            readOps: ops[index].readOps,
+            writeOps: ops[index].writeOps,
+            metricWindowHours: this.windowHours,
+            createTime: v.CreateTime ?? new Date(),
+            detectedAt: now,
+            tags: Object.fromEntries(
+              (v.Tags ?? []).map((t) => [t.Key ?? '', t.Value ?? '']),
+            ),
+            monthlyCostUsd: +(pricePerGb * sizeGb).toFixed(4),
+          });
+        })
+        .filter((volume) => this.policy.evaluate(volume, now).isWaste);
+
+      return Result.ok(volumes);
+    } catch (err) {
+      return Result.fail(new AwsAdapterError('EBS', err as Error));
+    } finally {
+      ec2.destroy();
+      cw.destroy();
+    }
+  }
+
+  private async sumMetric(
+    cw: CloudWatchClient,
+    volumeId: string,
+    metricName: string,
+    startTime: Date,
+    endTime: Date,
+    periodSeconds: number,
+  ): Promise<number> {
+    const r = await cw.send(
+      new GetMetricStatisticsCommand({
+        Namespace: 'AWS/EBS',
+        MetricName: metricName,
+        Dimensions: [{ Name: 'VolumeId', Value: volumeId }],
+        StartTime: startTime,
+        EndTime: endTime,
+        Period: periodSeconds,
+        Statistics: ['Sum'],
+      }),
+    );
+    return r.Datapoints?.[0]?.Sum ?? 0;
+  }
+}


### PR DESCRIPTION
# Fase 3.1 completata ✅ — Rilevamento EBS inattivi

Aggiunto il rilevamento dei **volumi EBS inattivi** (volumi attaccati ma con attività I/O nulla).  
Questi rappresentano uno spreco di storage: il volume continua a essere fatturato a costo pieno pur essendo di fatto inutilizzato.

## Domain

Introdotto il supporto per una nuova regola:

- **Kind:** `ebs-idle`
- **Categoria:** `waste`

Nuove entità di dominio:

### `IdleEbsVolume`

Fact disponibili:

- `readOps`
- `writeOps`
- `window`
- `attachedInstanceId`

### `EbsIdlePolicy`

- Soglia `maxOps` configurabile (type-specific, via costruttore)
- Grace period basato su `createTime` per evitare falsi positivi su volumi appena creati

**Coverage:** +5 test

---

## Infrastructure

Aggiunto un nuovo scanner:

### `AwsEbsIdleScanner`

Dettagli implementativi:

- Utilizza `DescribeVolumes` con `status=in-use`
- Recupera le metriche CloudWatch per ogni volume:
  - `VolumeReadOps`
  - `VolumeWriteOps`
- Le metriche vengono aggregate tramite `Sum` sulla finestra temporale configurata
- Elaborazione parallelizzata tramite `mapWithConcurrency(5)`

Pricing:

- Riutilizza il metodo esistente `getEbsVolumePricePerGbMonth`
- Nessun nuovo metodo di pricing introdotto

**Coverage:** +8 test

---

## CLI

Aggiornato il presenter:

- Aggiunta la colonna **"Attached to"**

Registrazione scanner:

- Registrato in `defaultCreateAnalysis`
- Utilizza soglia e finestra temporale configurabili

---

## Configurazione

Aggiunta una nuova opzione di configurazione:

- `thresholds.ebsIdleMaxOps`
  - Default: `0`

Validazione inclusa.

**Coverage:** +2 test

---

## Verifica

- Typecheck: ✅ (`satisfies` exhaustiveness preservata)
- Test: ✅
  - `aws-adapter`: 105 test
  - `domain`: +5
  - `cli`: +2
- Lint: ✅ 0 errori
- Build: ✅
- Render visivo: ✅ (sezione waste + totale)

---

## IAM

Nessun nuovo permesso IAM richiesto.

Permessi già coperti:

- `ec2:DescribeVolumes`
- `cloudwatch:GetMetricStatistics`

---

## Nota su sovrapposizione regole

Esiste una sovrapposizione minore tra:

- `ebs-idle` (**waste**) → suggerisce detach/delete di un volume inutilizzato
- `ebs-gp2-upgrade` (**optimization**) → suggerisce upgrade da gp2 a gp3

Un volume `gp2` che sia contemporaneamente **in-use** e **idle** potrebbe comparire in entrambe le analisi.

Questo comportamento è intenzionale perché:

- Le regole appartengono a categorie diverse
- Le raccomandazioni non sono in contraddizione
- Viene preservata l’indipendenza del modello a plugin

In pratica, questa sovrapposizione è rara e il segnale di **waste** dovrebbe essere considerato prioritario.