### PR TITLE
feat(cli): EC2 underutilized

### DIFF
--- a/apps/cli/src/commands/analyze-waste.command.ts
+++ b/apps/cli/src/commands/analyze-waste.command.ts
@@ -15,6 +15,7 @@ import {
   NatGatewayWastePolicy,
   Gp2UpgradePolicy,
   EbsIdlePolicy,
+  Ec2UnderutilizedPolicy,
 } from 'cloud-cost-domain';
 import type {
   FindWastedResourcesUseCasePort,
@@ -34,6 +35,7 @@ import {
   AwsNatGatewayScanner,
   AwsGp2UpgradeScanner,
   AwsEbsIdleScanner,
+  AwsEc2UnderutilizedScanner,
   StaticPriceTableAdapter,
   TablePricingAdapter,
   AwsPricingApiAdapter,
@@ -92,17 +94,22 @@ export interface AnalyzeDeps {
   createAnalysis(ctx: AnalysisContext): Promise<Analysis>;
 }
 
-/** Composizione reale: pricing a livelli + 8 scanner AWS + use case generico. */
+/** Composizione reale: pricing a livelli + scanner AWS (uno advisory gated su --live-pricing) + use case generico. */
 async function defaultCreateAnalysis(ctx: AnalysisContext): Promise<Analysis> {
   // Pricing a livelli: listino statico (base) ← AWS Pricing API live (--live-pricing)
   // ← override utente (config.prices, vincono).
   let priceTable: PriceTable = BUILTIN_PRICE_TABLE;
   let pricesAsOf = BUILTIN_PRICES_AS_OF;
   let layered = false;
+  // L'EC2 underutilized scanner risolve il prezzo per-instance-type on-demand
+  // dalla stessa istanza di AwsPricingApiAdapter: senza --live-pricing non c'è
+  // un prezzo per instance type, quindi lo scanner non viene registrato.
+  let livePricingAdapter: AwsPricingApiAdapter | undefined;
 
   if (ctx.livePricing) {
     ctx.info(chalk.dim('  Fetching current prices from the AWS Pricing API...'));
-    const live = await new AwsPricingApiAdapter().warmUp(ctx.regions);
+    livePricingAdapter = new AwsPricingApiAdapter();
+    const live = await livePricingAdapter.warmUp(ctx.regions);
     if (live.ok) {
       priceTable = mergePriceTables(priceTable, live.value);
       pricesAsOf = new Date().toISOString().slice(0, 7); // YYYY-MM
@@ -148,6 +155,19 @@ async function defaultCreateAnalysis(ctx: AnalysisContext): Promise<Analysis> {
       cloudwatchWindowHours,
     ),
   ];
+
+  // Advisory, gated su --live-pricing: il prezzo per instance type non rientra
+  // nel listino statico (cardinalità troppo alta), quindi senza prezzi live
+  // non c'è risparmio stimabile e lo scanner resta disattivato.
+  if (livePricingAdapter) {
+    scanners.push(
+      new AwsEc2UnderutilizedScanner(
+        livePricingAdapter,
+        accountId,
+        new Ec2UnderutilizedPolicy(policyOptions, ctx.config.thresholds?.ec2CpuPercent ?? 5),
+      ),
+    );
+  }
 
   return { useCase: new AnalyzeCloudWasteUseCase(scanners), pricesAsOf: pricing.getPricesAsOf() };
 }

--- a/apps/cli/src/config/cloudrift.config.spec.ts
+++ b/apps/cli/src/config/cloudrift.config.spec.ts
@@ -56,6 +56,18 @@ describe('parseConfig', () => {
     if (!result.ok) expect(result.error.message).toContain('ebsIdleMaxOps');
   });
 
+  it('parses thresholds.ec2CpuPercent', () => {
+    const result = parseConfig(JSON.stringify({ thresholds: { ec2CpuPercent: 10 } }));
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value.thresholds?.ec2CpuPercent).toBe(10);
+  });
+
+  it('rejects a thresholds.ec2CpuPercent outside 0-100', () => {
+    const result = parseConfig(JSON.stringify({ thresholds: { ec2CpuPercent: 150 } }));
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toContain('ec2CpuPercent');
+  });
+
   it('returns empty config for an empty object', () => {
     const result = parseConfig('{}');
     expect(result.ok).toBe(true);

--- a/apps/cli/src/config/cloudrift.config.ts
+++ b/apps/cli/src/config/cloudrift.config.ts
@@ -38,6 +38,8 @@ export interface CloudriftConfig {
   thresholds?: {
     /** Operazioni I/O totali sotto cui un volume EBS attaccato è "idle". Default 0. */
     ebsIdleMaxOps?: number;
+    /** CPU massima (%) sotto cui un'istanza EC2 è "underutilized". Default 5. */
+    ec2CpuPercent?: number;
   };
 }
 
@@ -172,12 +174,24 @@ export function parseConfig(
       errors.push('thresholds must be an object');
     } else {
       const thresholds: NonNullable<CloudriftConfig['thresholds']> = {};
-      const { ebsIdleMaxOps } = obj.thresholds;
+      const { ebsIdleMaxOps, ec2CpuPercent } = obj.thresholds;
       if (ebsIdleMaxOps !== undefined) {
         if (typeof ebsIdleMaxOps === 'number' && Number.isFinite(ebsIdleMaxOps) && ebsIdleMaxOps >= 0) {
           thresholds.ebsIdleMaxOps = ebsIdleMaxOps;
         } else {
           errors.push('thresholds.ebsIdleMaxOps must be a non-negative number');
+        }
+      }
+      if (ec2CpuPercent !== undefined) {
+        if (
+          typeof ec2CpuPercent === 'number' &&
+          Number.isFinite(ec2CpuPercent) &&
+          ec2CpuPercent >= 0 &&
+          ec2CpuPercent <= 100
+        ) {
+          thresholds.ec2CpuPercent = ec2CpuPercent;
+        } else {
+          errors.push('thresholds.ec2CpuPercent must be a number between 0 and 100');
         }
       }
       config.thresholds = thresholds;

--- a/apps/cli/src/formatters/resource-presenters.ts
+++ b/apps/cli/src/formatters/resource-presenters.ts
@@ -120,6 +120,21 @@ export const presenters: PresenterMap = {
     recommend: (v) =>
       `Detach or delete idle EBS ${v.id} (${v.sizeGb} GB ${v.volumeType}) in ${v.region.code} — no I/O in last ${v.metricWindowHours}h`,
   },
+  'ec2-underutilized': {
+    title: 'EC2 Instances — Underutilized (rightsizing candidate, verify before acting)',
+    head: ['Instance ID', 'Region', 'Type', 'Avg CPU', 'Max CPU', 'Window'],
+    colWidths: [110, 72, 70, 70, 70, 60, 80],
+    row: (inst) => [
+      inst.id,
+      inst.region.code,
+      inst.instanceType,
+      `${inst.avgCpuPercent.toFixed(1)}%`,
+      `${inst.maxCpuPercent.toFixed(1)}%`,
+      `${inst.windowDays}d`,
+    ],
+    recommend: (inst) =>
+      `Review EC2 ${inst.id} (${inst.instanceType}) in ${inst.region.code} for rightsizing — max CPU ${inst.maxCpuPercent.toFixed(1)}% over ${inst.windowDays}d (verify RAM/network first)`,
+  },
 };
 
 export function presenterFor(kind: ResourceKind): ResourcePresenter {

--- a/libs/cloud-cost/domain/src/entities/underutilized-ec2-instance.entity.ts
+++ b/libs/cloud-cost/domain/src/entities/underutilized-ec2-instance.entity.ts
@@ -1,0 +1,58 @@
+import { Entity } from 'shared-kernel';
+import { AwsRegion } from '../value-objects/aws-region.value-object';
+import { CostEstimate } from '../value-objects/cost-estimate.value-object';
+import type { WastedResource } from '../wasted-resource';
+
+/**
+ * Istanza EC2 *running* con CPU massima sotto soglia sull'intera finestra di
+ * osservazione: probabile sovradimensionamento. Advisory, non spreco certo —
+ * CPU bassa non garantisce che RAM/rete siano altrettanto sottoutilizzate,
+ * va verificato prima di un rightsizing (es. AWS Compute Optimizer).
+ * `monthlyCostUsd` qui è il *risparmio* stimato da un downsize di un tier,
+ * non il costo dell'istanza.
+ */
+export interface UnderutilizedEc2InstanceProps {
+  instanceId: string;
+  region: AwsRegion;
+  accountId: string;
+  instanceType: string;
+  avgCpuPercent: number;
+  maxCpuPercent: number;
+  windowDays: number;
+  launchTime: Date;
+  detectedAt: Date;
+  tags: Record<string, string>;
+  monthlyCostUsd: number;
+}
+
+export class UnderutilizedEc2Instance extends Entity<string> implements WastedResource {
+  private readonly props: Readonly<UnderutilizedEc2InstanceProps>;
+
+  constructor(props: UnderutilizedEc2InstanceProps) {
+    super(props.instanceId);
+    this.props = Object.freeze({ ...props });
+  }
+
+  get region(): AwsRegion { return this.props.region; }
+  get accountId(): string { return this.props.accountId; }
+  get instanceType(): string { return this.props.instanceType; }
+  get avgCpuPercent(): number { return this.props.avgCpuPercent; }
+  get maxCpuPercent(): number { return this.props.maxCpuPercent; }
+  get windowDays(): number { return this.props.windowDays; }
+  get launchTime(): Date { return this.props.launchTime; }
+  get detectedAt(): Date { return this.props.detectedAt; }
+  get tags(): Record<string, string> { return this.props.tags; }
+
+  get kind(): 'ec2-underutilized' { return 'ec2-underutilized'; }
+
+  get wasteReason(): string {
+    return `CPU max ${this.props.maxCpuPercent.toFixed(1)}% avg ${this.props.avgCpuPercent.toFixed(1)}% over ${this.props.windowDays}d — verify RAM/network before rightsizing (see AWS Compute Optimizer)`;
+  }
+
+  get costEstimate(): CostEstimate {
+    return CostEstimate.of(
+      this.props.monthlyCostUsd,
+      `${this.props.instanceType} underutilized — estimated rightsizing saving`,
+    );
+  }
+}

--- a/libs/cloud-cost/domain/src/group-by-kind.ts
+++ b/libs/cloud-cost/domain/src/group-by-kind.ts
@@ -8,6 +8,7 @@ import type { EbsSnapshot } from './entities/ebs-snapshot.entity';
 import type { NatGateway } from './entities/nat-gateway.entity';
 import type { Gp2Volume } from './entities/gp2-volume.entity';
 import type { IdleEbsVolume } from './entities/idle-ebs-volume.entity';
+import type { UnderutilizedEc2Instance } from './entities/underutilized-ec2-instance.entity';
 
 /**
  * Mappa kind → entità concreta. Permette ai consumer (formatter, frontend)
@@ -23,6 +24,7 @@ export interface ResourceKindMap {
   'nat-gateway': NatGateway;
   'ebs-gp2-upgrade': Gp2Volume;
   'ebs-idle': IdleEbsVolume;
+  'ec2-underutilized': UnderutilizedEc2Instance;
 }
 
 export type FindingsByKind = {

--- a/libs/cloud-cost/domain/src/index.ts
+++ b/libs/cloud-cost/domain/src/index.ts
@@ -34,6 +34,8 @@ export { Gp2Volume } from './entities/gp2-volume.entity';
 export type { Gp2VolumeProps } from './entities/gp2-volume.entity';
 export { IdleEbsVolume } from './entities/idle-ebs-volume.entity';
 export type { IdleEbsVolumeProps } from './entities/idle-ebs-volume.entity';
+export { UnderutilizedEc2Instance } from './entities/underutilized-ec2-instance.entity';
+export type { UnderutilizedEc2InstanceProps } from './entities/underutilized-ec2-instance.entity';
 
 // Value Objects
 export { AwsRegion, InvalidAwsRegionError } from './value-objects/aws-region.value-object';
@@ -58,6 +60,7 @@ export {
   NatGatewayWastePolicy,
   Gp2UpgradePolicy,
   EbsIdlePolicy,
+  Ec2UnderutilizedPolicy,
 } from './policies/resource-waste-policies';
 
 // Outbound Ports

--- a/libs/cloud-cost/domain/src/policies/resource-waste-policies.spec.ts
+++ b/libs/cloud-cost/domain/src/policies/resource-waste-policies.spec.ts
@@ -8,6 +8,7 @@ import {
   NatGatewayWastePolicy,
   Gp2UpgradePolicy,
   EbsIdlePolicy,
+  Ec2UnderutilizedPolicy,
 } from './resource-waste-policies';
 import { DEFAULT_IGNORE_TAG } from './waste-policy';
 import { EbsVolume } from '../entities/ebs-volume.entity';
@@ -19,6 +20,8 @@ import { EbsSnapshot } from '../entities/ebs-snapshot.entity';
 import { NatGateway } from '../entities/nat-gateway.entity';
 import { Gp2Volume } from '../entities/gp2-volume.entity';
 import { IdleEbsVolume } from '../entities/idle-ebs-volume.entity';
+import { UnderutilizedEc2Instance } from '../entities/underutilized-ec2-instance.entity';
+import type { UnderutilizedEc2InstanceProps } from '../entities/underutilized-ec2-instance.entity';
 import type { EbsSnapshotProps } from '../entities/ebs-snapshot.entity';
 import type { Ec2InstanceProps } from '../entities/ec2-instance.entity';
 import { AwsRegion } from '../value-objects/aws-region.value-object';
@@ -398,5 +401,57 @@ describe('EbsIdlePolicy', () => {
     expect(
       policy.evaluate(makeIdleVolume({ tags: { [DEFAULT_IGNORE_TAG]: 'true' } }), now).isWaste,
     ).toBe(false);
+  });
+});
+
+describe('Ec2UnderutilizedPolicy', () => {
+  const policy = new Ec2UnderutilizedPolicy();
+
+  function makeInstance(
+    overrides: Partial<UnderutilizedEc2InstanceProps> = {},
+  ): UnderutilizedEc2Instance {
+    return new UnderutilizedEc2Instance({
+      instanceId: 'i-underused',
+      region,
+      accountId: '123456789012',
+      instanceType: 'm5.large',
+      avgCpuPercent: 1.2,
+      maxCpuPercent: 2.5,
+      windowDays: 14,
+      launchTime: oldDate,
+      detectedAt: now,
+      tags: {},
+      monthlyCostUsd: 16,
+      ...overrides,
+    });
+  }
+
+  it('flags an old instance with low max CPU', () => {
+    const verdict = policy.evaluate(makeInstance(), now);
+    expect(verdict.isWaste).toBe(true);
+    expect(verdict.reason).toContain('14d');
+  });
+
+  it('does not flag an instance with CPU above threshold', () => {
+    expect(policy.evaluate(makeInstance({ maxCpuPercent: 10 }), now).isWaste).toBe(false);
+  });
+
+  it('does not flag a freshly launched instance (grace period)', () => {
+    expect(policy.evaluate(makeInstance({ launchTime: yesterday }), now).isWaste).toBe(false);
+  });
+
+  it('honours a custom CPU threshold', () => {
+    const lenient = new Ec2UnderutilizedPolicy({}, 15);
+    expect(lenient.evaluate(makeInstance({ maxCpuPercent: 10 }), now).isWaste).toBe(true);
+  });
+
+  it('does not flag an instance carrying the ignore tag', () => {
+    expect(
+      policy.evaluate(makeInstance({ tags: { [DEFAULT_IGNORE_TAG]: 'true' } }), now).isWaste,
+    ).toBe(false);
+  });
+
+  it('includes the rightsizing advisory in the wasteReason', () => {
+    expect(makeInstance().wasteReason).toContain('verify RAM/network before rightsizing');
   });
 });

--- a/libs/cloud-cost/domain/src/policies/resource-waste-policies.ts
+++ b/libs/cloud-cost/domain/src/policies/resource-waste-policies.ts
@@ -8,6 +8,7 @@ import type { EbsSnapshot } from '../entities/ebs-snapshot.entity';
 import type { NatGateway } from '../entities/nat-gateway.entity';
 import type { Gp2Volume } from '../entities/gp2-volume.entity';
 import type { IdleEbsVolume } from '../entities/idle-ebs-volume.entity';
+import type { UnderutilizedEc2Instance } from '../entities/underutilized-ec2-instance.entity';
 
 export class EbsVolumeWastePolicy extends WastePolicy<EbsVolume> {
   protected judge(volume: EbsVolume, now: Date): WasteVerdict {
@@ -97,6 +98,22 @@ export class EbsIdlePolicy extends WastePolicy<IdleEbsVolume> {
       return notWaste(`created less than ${this.minAgeDays}d ago`);
     }
     return waste(`zero I/O in last ${volume.metricWindowHours}h`);
+  }
+}
+
+export class Ec2UnderutilizedPolicy extends WastePolicy<UnderutilizedEc2Instance> {
+  /** maxCpuPercent: soglia di CPU massima sotto cui l'istanza è sottoutilizzata. */
+  constructor(options: WastePolicyOptions = {}, private readonly maxCpuPercent = 5) {
+    super(options);
+  }
+
+  protected judge(instance: UnderutilizedEc2Instance, now: Date): WasteVerdict {
+    if (instance.maxCpuPercent >= this.maxCpuPercent) return notWaste('CPU above threshold');
+    // Un'istanza appena lanciata potrebbe non aver ancora accumulato traffico reale.
+    if (this.isWithinGracePeriod(instance.launchTime, now)) {
+      return notWaste(`launched less than ${this.minAgeDays}d ago`);
+    }
+    return waste(`max CPU ${instance.maxCpuPercent.toFixed(1)}% over ${instance.windowDays}d`);
   }
 }
 

--- a/libs/cloud-cost/domain/src/wasted-resource.ts
+++ b/libs/cloud-cost/domain/src/wasted-resource.ts
@@ -11,6 +11,7 @@ export const RESOURCE_KINDS = [
   'nat-gateway',
   'ebs-gp2-upgrade',
   'ebs-idle',
+  'ec2-underutilized',
 ] as const;
 
 export type ResourceKind = (typeof RESOURCE_KINDS)[number];
@@ -41,6 +42,11 @@ export const RESOURCE_KIND_META: Record<ResourceKind, ResourceKindMeta> = {
   'nat-gateway': { label: 'NAT Gateways', category: 'waste', estimated: false },
   'ebs-gp2-upgrade': { label: 'EBS gp2→gp3 Upgrades', category: 'optimization', estimated: false },
   'ebs-idle': { label: 'EBS Volumes (idle)', category: 'waste', estimated: false },
+  'ec2-underutilized': {
+    label: 'EC2 Instances (underutilized)',
+    category: 'optimization',
+    estimated: true,
+  },
 };
 
 /** Etichette leggibili, derivate da RESOURCE_KIND_META (unica fonte). */

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/index.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/index.ts
@@ -7,6 +7,8 @@ export { AwsEbsSnapshotScanner } from './scanners/aws-ebs-snapshot.scanner';
 export { AwsNatGatewayScanner } from './scanners/aws-nat-gateway.scanner';
 export { AwsGp2UpgradeScanner } from './scanners/aws-gp2-upgrade.scanner';
 export { AwsEbsIdleScanner } from './scanners/aws-ebs-idle.scanner';
+export { AwsEc2UnderutilizedScanner } from './scanners/aws-ec2-underutilized.scanner';
+export type { Ec2InstancePricingSource } from './scanners/aws-ec2-underutilized.scanner';
 export { AwsAdapterError } from './errors/aws-adapter.error';
 export {
   StaticPriceTableAdapter,

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/pricing/aws-pricing-api.adapter.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/pricing/aws-pricing-api.adapter.ts
@@ -139,6 +139,36 @@ export class AwsPricingApiAdapter {
   }
 
   /**
+   * Prezzo on-demand mensile per un singolo instance type, risolto on-demand
+   * (non rientra in `warmUp`/`PRICE_SPECS`: la cardinalità degli instance
+   * type è troppo alta per un prefetch). Va chiamato solo per i type
+   * effettivamente osservati durante uno scan.
+   */
+  async getEc2InstancePricePerMonth(
+    region: AwsRegion,
+    instanceType: string,
+  ): Promise<number | undefined> {
+    const location = REGION_TO_LOCATION[region.code];
+    if (!location) return undefined;
+    return this.fetchPrice(
+      {
+        key: `ec2-${instanceType}`,
+        serviceCode: 'AmazonEC2',
+        filters: [
+          { Field: 'instanceType', Value: instanceType },
+          { Field: 'productFamily', Value: 'Compute Instance' },
+          { Field: 'tenancy', Value: 'Shared' },
+          { Field: 'operatingSystem', Value: 'Linux' },
+          { Field: 'preInstalledSw', Value: 'NA' },
+          { Field: 'capacitystatus', Value: 'Used' },
+        ],
+        unit: 'hourly',
+      },
+      location,
+    );
+  }
+
+  /**
    * Restituisce il prezzo per una spec **solo se i prodotti restituiti
    * concordano su un unico valore**. Filtri ambigui (più valori distinti) ⇒
    * `undefined`, per non rischiare un prezzo sbagliato (peggio del listino).

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-ec2-underutilized.scanner.spec.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-ec2-underutilized.scanner.spec.ts
@@ -1,0 +1,155 @@
+import { EC2Client, DescribeInstancesCommand } from '@aws-sdk/client-ec2';
+import {
+  CloudWatchClient,
+  GetMetricStatisticsCommand,
+} from '@aws-sdk/client-cloudwatch';
+import { AwsEc2UnderutilizedScanner } from './aws-ec2-underutilized.scanner';
+import type { Ec2InstancePricingSource } from './aws-ec2-underutilized.scanner';
+import { AwsRegion, type UnderutilizedEc2Instance } from 'cloud-cost-domain';
+import { AwsAdapterError } from '../errors/aws-adapter.error';
+
+jest.mock('@aws-sdk/client-ec2');
+jest.mock('@aws-sdk/client-cloudwatch');
+
+const mockEc2Send = jest.fn();
+const mockEc2Destroy = jest.fn();
+const mockCwSend = jest.fn();
+const mockCwDestroy = jest.fn();
+const mockGetEc2InstancePrice = jest.fn();
+
+const mockPricing: Ec2InstancePricingSource = {
+  getEc2InstancePricePerMonth: mockGetEc2InstancePrice,
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (EC2Client as jest.Mock).mockImplementation(() => ({
+    send: mockEc2Send,
+    destroy: mockEc2Destroy,
+  }));
+  (CloudWatchClient as jest.Mock).mockImplementation(() => ({
+    send: mockCwSend,
+    destroy: mockCwDestroy,
+  }));
+  mockGetEc2InstancePrice.mockResolvedValue(70); // $/mo
+});
+
+const region = AwsRegion.create('us-east-1');
+const scanner = new AwsEc2UnderutilizedScanner(mockPricing);
+const OLD_DATE = new Date('2024-03-01');
+
+function runningInstance(
+  overrides: Partial<{ InstanceId: string; InstanceType: string; LaunchTime: Date }> = {},
+) {
+  return {
+    InstanceId: overrides.InstanceId ?? 'i-1',
+    InstanceType: overrides.InstanceType ?? 'm5.large',
+    State: { Name: 'running' },
+    LaunchTime: overrides.LaunchTime ?? OLD_DATE,
+    Tags: [],
+  };
+}
+
+describe('AwsEc2UnderutilizedScanner', () => {
+  it('exposes its resource kind', () => {
+    expect(scanner.kind).toBe('ec2-underutilized');
+  });
+
+  it('reports an old running instance with low max CPU and costs it at half the instance price', async () => {
+    mockEc2Send.mockResolvedValueOnce({ Reservations: [{ Instances: [runningInstance()] }] });
+    mockCwSend.mockResolvedValue({ Datapoints: [{ Average: 1.2, Maximum: 2.5 }] });
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.map((i) => i.id)).toEqual(['i-1']);
+    const inst = result.value[0] as UnderutilizedEc2Instance;
+    expect(inst.kind).toBe('ec2-underutilized');
+    expect(inst.avgCpuPercent).toBe(1.2);
+    expect(inst.maxCpuPercent).toBe(2.5);
+    expect(inst.costEstimate.monthlyCostUsd).toBeCloseTo(35, 2); // 70 * 0.5
+  });
+
+  it('does not report an instance with CPU above the threshold', async () => {
+    mockEc2Send.mockResolvedValueOnce({ Reservations: [{ Instances: [runningInstance()] }] });
+    mockCwSend.mockResolvedValue({ Datapoints: [{ Average: 30, Maximum: 80 }] });
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toHaveLength(0);
+  });
+
+  it('does not report a freshly launched instance (grace period)', async () => {
+    mockEc2Send.mockResolvedValueOnce({
+      Reservations: [{ Instances: [runningInstance({ LaunchTime: new Date() })] }],
+    });
+    mockCwSend.mockResolvedValue({ Datapoints: [{ Average: 1, Maximum: 2 }] });
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toHaveLength(0);
+  });
+
+  it('skips CloudWatch and pricing entirely when no running instances exist', async () => {
+    mockEc2Send.mockResolvedValueOnce({ Reservations: [] });
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    expect(mockCwSend).not.toHaveBeenCalled();
+    expect(mockGetEc2InstancePrice).not.toHaveBeenCalled();
+  });
+
+  it('filters DescribeInstances on instance-state-name=running', async () => {
+    mockEc2Send.mockResolvedValueOnce({ Reservations: [] });
+
+    await scanner.scan(region);
+
+    const args = (DescribeInstancesCommand as unknown as jest.Mock).mock.calls[0][0];
+    expect(args.Filters).toEqual([{ Name: 'instance-state-name', Values: ['running'] }]);
+  });
+
+  it('queries CPUUtilization with Average and Maximum statistics', async () => {
+    mockEc2Send.mockResolvedValueOnce({ Reservations: [{ Instances: [runningInstance()] }] });
+    mockCwSend.mockResolvedValue({ Datapoints: [{ Average: 1, Maximum: 2 }] });
+
+    await scanner.scan(region);
+
+    const args = (GetMetricStatisticsCommand as unknown as jest.Mock).mock.calls[0][0];
+    expect(args.MetricName).toBe('CPUUtilization');
+    expect(args.Statistics).toEqual(['Average', 'Maximum']);
+    expect(args.Dimensions).toEqual([{ Name: 'InstanceId', Value: 'i-1' }]);
+  });
+
+  it('fetches the instance price only once per distinct instance type', async () => {
+    mockEc2Send.mockResolvedValueOnce({
+      Reservations: [
+        {
+          Instances: [
+            runningInstance({ InstanceId: 'i-1', InstanceType: 'm5.large' }),
+            runningInstance({ InstanceId: 'i-2', InstanceType: 'm5.large' }),
+          ],
+        },
+      ],
+    });
+    mockCwSend.mockResolvedValue({ Datapoints: [{ Average: 1, Maximum: 2 }] });
+
+    await scanner.scan(region);
+
+    expect(mockGetEc2InstancePrice).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns Result.fail wrapping AwsAdapterError and destroys both clients on error', async () => {
+    mockEc2Send.mockRejectedValueOnce(new Error('boom'));
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect((result.error as AwsAdapterError).service).toBe('EC2');
+    expect(mockEc2Destroy).toHaveBeenCalledTimes(1);
+    expect(mockCwDestroy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-ec2-underutilized.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-ec2-underutilized.scanner.ts
@@ -1,0 +1,141 @@
+import {
+  EC2Client,
+  DescribeInstancesCommand,
+  type Instance,
+  type Reservation,
+} from '@aws-sdk/client-ec2';
+import {
+  CloudWatchClient,
+  GetMetricStatisticsCommand,
+} from '@aws-sdk/client-cloudwatch';
+import { Result } from 'shared-kernel';
+import type { AwsRegion, WasteScannerPort, WastedResource } from 'cloud-cost-domain';
+import { UnderutilizedEc2Instance, Ec2UnderutilizedPolicy } from 'cloud-cost-domain';
+import { AwsAdapterError } from '../errors/aws-adapter.error';
+import { paginate } from '../utils/paginate';
+import { mapWithConcurrency } from '../utils/map-with-concurrency';
+
+const DEFAULT_WINDOW_DAYS = 14;
+const CLOUDWATCH_CONCURRENCY = 5;
+const PRICING_CONCURRENCY = 5;
+/** Risparmio stimato da un downsize di un tier (advisory, da verificare). */
+const RIGHTSIZE_SAVING_FRACTION = 0.5;
+
+/**
+ * Il prezzo per-instance-type è risolto on-demand dalla Pricing API (la
+ * cardinalità degli instance type è troppo alta per il listino statico/il
+ * prefetch di `warmUp`): `AwsPricingApiAdapter` soddisfa questa interfaccia
+ * per duck typing.
+ */
+export interface Ec2InstancePricingSource {
+  getEc2InstancePricePerMonth(region: AwsRegion, instanceType: string): Promise<number | undefined>;
+}
+
+/**
+ * Rileva istanze EC2 *running* con CPU massima sotto soglia sull'intera
+ * finestra di osservazione: probabile sovradimensionamento. Advisory
+ * (categoria optimization, stima): CPU bassa non garantisce che RAM/rete
+ * siano altrettanto sottoutilizzate, va verificato prima di un rightsizing.
+ * Richiede `--live-pricing`: senza un prezzo per instance type, non c'è
+ * risparmio stimabile.
+ */
+export class AwsEc2UnderutilizedScanner implements WasteScannerPort {
+  readonly kind = 'ec2-underutilized' as const;
+
+  constructor(
+    private readonly pricing: Ec2InstancePricingSource,
+    private readonly accountId = 'unknown',
+    private readonly policy = new Ec2UnderutilizedPolicy(),
+    private readonly windowDays = DEFAULT_WINDOW_DAYS,
+  ) {}
+
+  async scan(region: AwsRegion): Promise<Result<WastedResource[]>> {
+    const ec2 = new EC2Client({ region: region.code });
+    const cw = new CloudWatchClient({ region: region.code });
+    try {
+      const reservations = await paginate<Reservation>(async (cursor) => {
+        const r = await ec2.send(
+          new DescribeInstancesCommand({
+            Filters: [{ Name: 'instance-state-name', Values: ['running'] }],
+            NextToken: cursor,
+          }),
+        );
+        return { items: r.Reservations ?? [], cursor: r.NextToken };
+      });
+
+      const rawInstances = reservations.flatMap((r) => r.Instances ?? []);
+      if (rawInstances.length === 0) return Result.ok([]);
+
+      const endTime = new Date();
+      const startTime = new Date(endTime.getTime() - this.windowDays * 24 * 60 * 60 * 1000);
+      const periodSeconds = this.windowDays * 24 * 3600;
+
+      const cpu = await mapWithConcurrency(rawInstances, CLOUDWATCH_CONCURRENCY, (i) =>
+        this.cpuStats(cw, i.InstanceId!, startTime, endTime, periodSeconds),
+      );
+
+      const instanceTypes = [...new Set(rawInstances.map((i) => i.InstanceType ?? 'unknown'))];
+      const priceEntries = await mapWithConcurrency(
+        instanceTypes,
+        PRICING_CONCURRENCY,
+        async (instanceType) => ({
+          instanceType,
+          price: (await this.pricing.getEc2InstancePricePerMonth(region, instanceType)) ?? 0,
+        }),
+      );
+      const priceByType = new Map(priceEntries.map((e) => [e.instanceType, e.price]));
+
+      const now = new Date();
+      const instances = rawInstances
+        .map((inst: Instance, index) => {
+          const instanceType = inst.InstanceType ?? 'unknown';
+          const monthlyPrice = priceByType.get(instanceType) ?? 0;
+          return new UnderutilizedEc2Instance({
+            instanceId: inst.InstanceId!,
+            region,
+            accountId: this.accountId,
+            instanceType,
+            avgCpuPercent: cpu[index].avg,
+            maxCpuPercent: cpu[index].max,
+            windowDays: this.windowDays,
+            launchTime: inst.LaunchTime ?? new Date(),
+            detectedAt: now,
+            tags: Object.fromEntries(
+              (inst.Tags ?? []).map((t) => [t.Key ?? '', t.Value ?? '']),
+            ),
+            monthlyCostUsd: +(monthlyPrice * RIGHTSIZE_SAVING_FRACTION).toFixed(4),
+          });
+        })
+        .filter((instance) => this.policy.evaluate(instance, now).isWaste);
+
+      return Result.ok(instances);
+    } catch (err) {
+      return Result.fail(new AwsAdapterError('EC2', err as Error));
+    } finally {
+      ec2.destroy();
+      cw.destroy();
+    }
+  }
+
+  private async cpuStats(
+    cw: CloudWatchClient,
+    instanceId: string,
+    startTime: Date,
+    endTime: Date,
+    periodSeconds: number,
+  ): Promise<{ avg: number; max: number }> {
+    const r = await cw.send(
+      new GetMetricStatisticsCommand({
+        Namespace: 'AWS/EC2',
+        MetricName: 'CPUUtilization',
+        Dimensions: [{ Name: 'InstanceId', Value: instanceId }],
+        StartTime: startTime,
+        EndTime: endTime,
+        Period: periodSeconds,
+        Statistics: ['Average', 'Maximum'],
+      }),
+    );
+    const dp = r.Datapoints?.[0];
+    return { avg: dp?.Average ?? 0, max: dp?.Maximum ?? 0 };
+  }
+}


### PR DESCRIPTION
# 🚀 Implementazione EC2 Sottoutilizzate (`ec2-underutilized`)

Aggiunto il tracciamento e il calcolo del risparmio stimato per le istanze **EC2 sottoutilizzate**.

Di seguito il dettaglio delle modifiche per dominio e modulo.

---

## 🔹 Domain (`libs/cloud-cost/domain`)

### `underutilized-ec2-instance.entity.ts`

Nuova entità introdotta con i seguenti campi:

- `instanceType`
- `avgCpuPercent`
- `maxCpuPercent`
- `windowDays`
- `launchTime`
- `monthlyCostUsd`

> `monthlyCostUsd` rappresenta il **risparmio stimato**, non il costo totale dell’istanza.

### `resource-waste-policies.ts` (`Ec2UnderutilizedPolicy`)

Definisce i criteri di eleggibilità.

Un’istanza è considerata candidata se:

- `maxCpuPercent` rimane sotto la soglia configurata (default **5%**)
- La condizione è verificata per l’intera finestra temporale di analisi
- Viene rispettato un grace period basato su `launchTime`

### `RESOURCE_KIND_META['ec2-underutilized']`

Registrato sotto la categoria:

- `optimization`

Configurazione metadata:

- `estimated: true`

Questo garantisce che la risorsa:

- compaia nella sezione **Optimization opportunities**
- **non influenzi** il totale del waste bloccante usato nel gate CI

---

## 🔹 AWS Adapter (`libs/cloud-cost/infrastructure/aws-adapter`)

### `aws-ec2-underutilized.scanner.ts`

Responsabilità:

- Recupera le istanze attive tramite `DescribeInstances(running)`
- Esegue `mapWithConcurrency(5)` per interrogare CloudWatch

Metriche analizzate:

- `CPUUtilization (Average)`
- `CPUUtilization (Maximum)`

Analisi effettuata sull’intera finestra temporale configurata (default **14 giorni**).

### Pricing

#### `AwsPricingApiAdapter.getEc2InstancePricePerMonth(region, instanceType)`

Recupera il prezzo **on-demand** in tempo reale per lo specifico instance type.

Nota:

- escluso dal prefetch `warmUp`
- motivazione: elevata numerosità del listino prezzi

### Calcolo del risparmio

Il risparmio stimato viene calcolato come:

```ts
prezzo_mensile_istanza × 0.5
```

Utilizzando la costante:

```ts
RIGHTSIZE_SAVING_FRACTION
```

---

## 🔹 CLI (`apps/cli`)

### Registrazione Scanner

Lo scanner viene registrato in `defaultCreateAnalysis` solo se è attivo il flag:

```bash
--live-pricing
```

Riutilizza la stessa istanza globale di:

```ts
AwsPricingApiAdapter
```

### Configurazione

Aggiunta una nuova soglia configurabile:

```ts
thresholds.ec2CpuPercent
```

Vincoli:

- Range consentito: `0–100`
- Default: `5`

### Output

Implementati i presenter per i formati:

- `table`
- `markdown`
- `pdf`

---

## 🧪 Testing & Quality Assurance

Aggiunti:

- Unit test completi per policy e scanner
- Mock dedicati per i test infrastrutturali
- Test di copertura per la configurazione CLI

Verificati con successo:

- Build ✅
- Lint ✅
- Test suite completa ✅