### PR TITLE
feat(test): add AWS verification script and improve domain/e2e coverage

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,79 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and maintainers of **cloudrift** pledge to make participation in our project a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior:
+
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Project maintainers are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior they deem inappropriate, threatening, offensive, or harmful.
+
+Maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, issues, and other contributions that are not aligned with this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all project spaces (issues, pull requests, discussions, and any other communication channel associated with the **cloudrift** repository), and also applies when an individual is officially representing the project in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the project maintainer at **raffaelevasini@gmail.com**. All complaints will be reviewed and investigated promptly and fairly.
+
+All maintainers are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Maintainers will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome.
+
+**Consequence**: A private, written warning, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved for a specified period of time, including unsolicited interaction with those enforcing the Code of Conduct.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the project for a specified period of time.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the project.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][mozilla].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[mozilla]: https://github.com/mozilla/diversity

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,84 @@
+# Contributing to cloudrift
+
+Thanks for your interest in contributing! This document covers everything you need to set up the project, make a change, and submit it.
+
+By participating in this project you agree to abide by the [Code of Conduct](./CODE_OF_CONDUCT.md).
+
+## License note
+
+cloudrift is distributed under a custom non-commercial license (see [LICENSE.md](./LICENSE.md)): free for personal, educational, research, and evaluation use; commercial use requires a separate agreement with the copyright holder. By submitting a contribution, you agree that it is licensed under the same terms as the rest of the project.
+
+## Prerequisites
+
+- **Node.js 18+**
+- **pnpm** (`npm install -g pnpm`) — this is a pnpm workspace; do not use `npm`/`yarn`
+- AWS credentials with read-only permissions if you want to run the CLI against a real account (see the [README](./README.md#required-iam-permissions))
+
+## Getting set up
+
+```sh
+git clone https://github.com/elleVas/cloudrift.git
+cd cloudrift
+pnpm install
+```
+
+The repo is an [Nx](https://nx.dev) monorepo:
+
+- `apps/cli` — the `@cloudrift/cli` command-line app
+- `libs/cloud-cost/domain` — entities and waste policies (pure logic, no I/O)
+- `libs/cloud-cost/application` — use cases / DTOs orchestrating the domain
+- `libs/cloud-cost/infrastructure/aws-adapter` — AWS SDK scanners and pricing adapters
+- `libs/shared/kernel` — `Result`, `Entity`, `ValueObject` base types shared across libs
+
+Read [docs/en/architecture.md](./docs/en/architecture.md) before making structural changes — it explains the layering and why the domain has zero AWS imports.
+
+## Everyday commands
+
+Always go through Nx rather than calling the underlying tool directly:
+
+```sh
+pnpm nx run-many -t build        # build all projects
+pnpm nx run-many -t test         # run all unit tests
+pnpm nx run-many -t lint         # lint all projects
+pnpm nx run-many -t typecheck    # typecheck all projects
+pnpm nx affected -t test         # run only what your change actually affects
+```
+
+To target a single project: `pnpm nx test cloud-cost-domain`, `pnpm nx test cli`, etc.
+
+CI (`.github/workflows/ci.yml`) runs lint, test, and build on every PR to `main`. A PR won't be merged if any of these fail.
+
+## Making a change
+
+1. **Open an issue first** for anything beyond a trivial fix (typo, doc clarification) — it avoids wasted work if the approach needs discussion.
+2. Create a branch off `main`.
+3. Make your change. Keep it focused: one logical change per PR.
+4. Add or update tests. This project treats the test pyramid seriously — see [docs/en/testing.md](./docs/en/testing.md) for what belongs at the domain, infrastructure, and CLI e2e level. A scanner change with no spec update will be asked to add one.
+5. Run `pnpm nx affected -t lint,test,typecheck` and make sure it's clean.
+6. Commit with a clear message (imperative mood, e.g. `feat(cli): add --pdf artifact support`). Conventional-commit-style prefixes (`feat`, `fix`, `docs`, `refactor`, `test`, `chore`) are appreciated but not enforced.
+7. Open a pull request against `main`, describing what changed and why.
+
+### Adding a new resource scanner
+
+There's a dedicated walkthrough for this: [docs/en/adding-a-resource.md](./docs/en/adding-a-resource.md). It covers the entity → policy → scanner → DTO → formatter chain end to end.
+
+### Code style
+
+- No new abstractions beyond what the change needs — prefer duplication over a premature shared helper.
+- The domain layer (`libs/cloud-cost/domain`) must never import an AWS SDK package. If you find yourself wanting to, the logic belongs in the infrastructure adapter instead.
+- Comments explain *why*, not *what* — well-named identifiers should make the *what* obvious.
+- `pnpm nx run-many -t lint` runs ESLint with the workspace's shared config; fix warnings on lines you touch, but you're not expected to clean up unrelated pre-existing warnings in the same PR.
+
+## Reporting bugs
+
+Open a [GitHub issue](https://github.com/elleVas/cloudrift/issues) with:
+
+- the command you ran (flags included, credentials redacted)
+- what you expected vs. what happened
+- the cloudrift version (`cloudrift --version`) and Node version
+
+For security vulnerabilities, do **not** open a public issue — see [SECURITY.md](./SECURITY.md).
+
+## Questions
+
+Open a [GitHub Discussion](https://github.com/elleVas/cloudrift/discussions) or issue, or email **raffaelevasini@gmail.com**.

--- a/README.md
+++ b/README.md
@@ -372,6 +372,7 @@ Full documentation is in the [`docs/`](./docs/) folder — English in [`docs/en/
 | [docs/en/technical-choices.md](./docs/en/technical-choices.md)  | Nx, pnpm, TypeScript, AWS SDK v3, Result pattern, jest |
 | [docs/en/how-it-works.md](./docs/en/how-it-works.md)            | End-to-end execution flow, code walkthrough            |
 | [docs/en/adding-a-resource.md](./docs/en/adding-a-resource.md)  | Step-by-step guide to adding a new resource type       |
+| [docs/en/testing.md](./docs/en/testing.md)                      | Test pyramid, where each level lives, manual AWS verification |
 | [docs/en/releasing.md](./docs/en/releasing.md)                  | How `@cloudrift/cli` is built and published to npm     |
 
 ### Adding a new resource type
@@ -770,6 +771,7 @@ Tutta la documentazione è nella cartella [`docs/`](./docs/) — italiano in [`d
 | [docs/it/scelte-tecniche.md](./docs/it/scelte-tecniche.md)           | Nx, pnpm, TypeScript, AWS SDK v3, Result pattern, jest            |
 | [docs/it/funzionamento.md](./docs/it/funzionamento.md)               | Flusso di esecuzione end-to-end, spiegazione del codice           |
 | [docs/it/aggiungere-risorsa.md](./docs/it/aggiungere-risorsa.md)     | Guida passo per passo per aggiungere un nuovo tipo di risorsa     |
+| [docs/it/test.md](./docs/it/test.md)                                 | Piramide dei test, dove vive ogni livello, verifica manuale AWS   |
 | [docs/it/rilascio.md](./docs/it/rilascio.md)                         | Come `@cloudrift/cli` viene buildato e pubblicato su npm           |
 
 ---

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,39 @@
+# Security Policy
+
+## Supported Versions
+
+`@cloudrift/cli` has not yet been published to npm (see [docs/en/releasing.md](./docs/en/releasing.md)) — there is currently a single supported line: the latest commit on `main`. Once releases start shipping, only the most recent published major version will receive security fixes.
+
+## Reporting a Vulnerability
+
+**Do not open a public GitHub issue for security vulnerabilities.**
+
+Instead, report it privately by emailing **raffaelevasini@gmail.com** with:
+
+- a description of the vulnerability and its potential impact
+- steps to reproduce it (a minimal repro is very helpful)
+- the cloudrift version / commit SHA you tested against
+
+You should expect an initial response within **5 business days**. If the report is confirmed, a fix will be prioritized and a coordinated disclosure timeline agreed with you before any public details are shared. Credit is given to reporters who wish to be acknowledged, once a fix is released.
+
+If you'd rather report through GitHub's private channel, you can also use [GitHub Security Advisories](https://github.com/elleVas/cloudrift/security/advisories/new) for this repository.
+
+## Scope and Threat Model
+
+cloudrift is a CLI tool that:
+
+- reads **read-only** AWS API data (`Describe*`, `GetMetricStatistics`, `GetCallerIdentity`) via the AWS SDK, using whatever credentials are already configured in your environment (env vars, shared config/profile, instance/task role) — it never provisions, modifies, or deletes AWS resources, and never requests or stores credentials itself
+- writes report artifacts (JSON/PDF) only to paths you explicitly pass via `--json`/`--pdf`
+- makes outbound network calls only to AWS service endpoints (and, optionally, the AWS Pricing API with `--live-pricing`) — there is no telemetry, analytics, or other third-party network traffic
+
+Vulnerability classes we're particularly interested in:
+
+- a cloudrift bug that could cause AWS credentials, account IDs, or scan results to leak somewhere they shouldn't (logs, third-party network calls, written files outside the requested path)
+- a dependency (npm package, including transitive ones) with a known exploitable vulnerability that's reachable from cloudrift's code paths
+- command-injection, path-traversal, or arbitrary file write issues in CLI flag handling (e.g. `--json`, `--pdf`, `--config`)
+
+Out of scope:
+
+- vulnerabilities in AWS services themselves (report those to AWS Security)
+- issues that require an attacker to already have write access to your AWS credentials or local filesystem
+- the IAM permissions you grant to the credentials you run cloudrift with — that's on the user to scope to read-only, as documented in the [README](./README.md#required-iam-permissions)

--- a/apps/cli/src/commands/analyze-waste.command.spec.ts
+++ b/apps/cli/src/commands/analyze-waste.command.spec.ts
@@ -159,4 +159,31 @@ describe('analyzeWasteCommand (CLI end-to-end)', () => {
       await rm(dir, { recursive: true, force: true });
     }
   });
+
+  it('writes a PDF artifact to disk with --pdf <file>', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'cloudrift-cli-'));
+    const file = join(dir, 'out.pdf');
+    try {
+      await run({ format: 'table', pdf: file }, makeDeps({
+        summary: summaryOf([wasteVolume('vol-1', 8)], 8),
+      }));
+      const written = await readFile(file);
+      expect(written.length).toBeGreaterThan(0);
+      expect(written.subarray(0, 5).toString('latin1')).toBe('%PDF-');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('reports a partial scan without crashing, exit code dictated only by the cost threshold', async () => {
+    const summary: WastedResourcesSummary = {
+      ...summaryOf([], 0),
+      scanErrors: [
+        { kind: 'ebs-volume', region: 'us-east-1', error: new Error('AccessDenied') },
+      ],
+    };
+    await run({ format: 'table' }, makeDeps({ summary }));
+    expect(process.exitCode).toBeUndefined();
+    expect(stdout).toContain('partial results');
+  });
 });

--- a/docs/en/testing.md
+++ b/docs/en/testing.md
@@ -1,0 +1,80 @@
+# Testing
+
+> 🇮🇹 [Versione italiana](../it/test.md)
+
+This document describes the test pyramid for cloudrift: what each level covers, where to find concrete examples, and how to manually verify scanners against a real AWS sandbox account.
+
+## The pyramid
+
+```
+        ┌─────────────────────────┐
+        │   CLI e2e (apps/cli)    │   command-level: format, exit code, artifacts
+        ├─────────────────────────┤
+        │  Infra (scanner specs)  │   AWS SDK mocked: query shape, pagination, errors
+        ├─────────────────────────┤
+        │  Domain (entity/policy) │   pure logic: waste rules, boundaries, no I/O
+        └─────────────────────────┘
+        ┌─────────────────────────┐
+        │  Manual AWS sandbox     │   scripts/verify-against-aws.mjs (this doc)
+        └─────────────────────────┘
+```
+
+### Domain — entities and policies
+
+Pure unit tests, no mocks. One spec per entity, asserting the exposed fields, the entity-specific computed value, `kind`, `wasteReason` and `costEstimate`:
+
+- [`libs/cloud-cost/domain/src/entities/ebs-snapshot.entity.spec.ts`](../../libs/cloud-cost/domain/src/entities/ebs-snapshot.entity.spec.ts)
+- [`libs/cloud-cost/domain/src/entities/elastic-ip.entity.spec.ts`](../../libs/cloud-cost/domain/src/entities/elastic-ip.entity.spec.ts)
+- [`libs/cloud-cost/domain/src/entities/gp2-volume.entity.spec.ts`](../../libs/cloud-cost/domain/src/entities/gp2-volume.entity.spec.ts)
+- [`libs/cloud-cost/domain/src/entities/idle-ebs-volume.entity.spec.ts`](../../libs/cloud-cost/domain/src/entities/idle-ebs-volume.entity.spec.ts)
+- [`libs/cloud-cost/domain/src/entities/underutilized-ec2-instance.entity.spec.ts`](../../libs/cloud-cost/domain/src/entities/underutilized-ec2-instance.entity.spec.ts)
+- [`libs/cloud-cost/domain/src/entities/rds-underutilized-instance.entity.spec.ts`](../../libs/cloud-cost/domain/src/entities/rds-underutilized-instance.entity.spec.ts)
+
+Policies live in one file, [`libs/cloud-cost/domain/src/policies/resource-waste-policies.spec.ts`](../../libs/cloud-cost/domain/src/policies/resource-waste-policies.spec.ts), covering for every policy: waste vs not-waste, the grace period, the `ignoreTag`, `excludeTagValues`, and the exact boundary of each threshold (age `===` `minAgeDays`, CPU `===` threshold, ops `===` `maxOps`) — boundaries matter because grace-period and CPU/ops comparisons use opposite-strictness operators (`<` vs `>=`/`>`), so an off-by-one there silently changes which resources get flagged.
+
+### Infra — scanners
+
+One spec per scanner under [`libs/cloud-cost/infrastructure/aws-adapter/src/scanners/`](../../libs/cloud-cost/infrastructure/aws-adapter/src/scanners/), with the AWS SDK client mocked. Each covers: the candidate filter (e.g. `DescribeVolumes` with `Filters=[status=available]`), pagination, concurrency, SDK errors, and `destroy()` on the client. The four CloudWatch-based scanners (`aws-ebs-idle`, `aws-ec2-underutilized`, `aws-nat-gateway`, `aws-rds-underutilized`) additionally assert the exact `Namespace`, `Period`, `Statistics` and `Dimensions` sent to `GetMetricStatistics` — this is the contract the manual verification script below leans on.
+
+### CLI e2e
+
+[`apps/cli/src/commands/analyze-waste.command.spec.ts`](../../apps/cli/src/commands/analyze-waste.command.spec.ts) drives the command with a fake `AnalyzeDeps` (no AWS), asserting format selection (table/json/markdown), exit codes (0/1/2), the `--json <file>` and `--pdf <file>` artifacts, and that a partial scan (`summary.scanErrors` non-empty) doesn't crash the command — the exit code stays driven only by the cost threshold, never by scan errors, and the incomplete-scan note (produced by the formatters, see [`waste-report.markdown-formatter.spec.ts`](../../apps/cli/src/formatters/waste-report.markdown-formatter.spec.ts)) reaches stdout.
+
+## Manual verification against a real AWS account
+
+Mocked SDK calls verify the *shape* of a query; they cannot verify that the shape actually matches what AWS returns for real resources. [`scripts/verify-against-aws.mjs`](../../scripts/verify-against-aws.mjs) closes that gap: it runs all 11 scanners against a real AWS account and prints what they find, next to the static query descriptor that the corresponding scanner spec already enforces in CI.
+
+It is **not** run by `pnpm test` or by CI — it calls real AWS APIs and must be run by hand against a **sandbox** account.
+
+### Seeding checklist
+
+Create these in the sandbox account before running the script (any region, default `us-east-1`):
+
+| Resource | What to create | Expected finding |
+| --- | --- | --- |
+| EBS volume | one **unattached** volume, older than 7 days | `ebs-volume` |
+| Elastic IP | one **unassociated** EIP | `elastic-ip` |
+| NAT Gateway | one gateway with **no traffic** for 48h | `nat-gateway` |
+| EC2 instance | one instance **stopped** for more than 7 days | `ec2-instance` |
+| EC2 instance | one **running** instance with low CPU for 14+ days | `ec2-underutilized` |
+| EBS volume (gp2) | one **attached** gp2 volume | `ebs-gp2-upgrade` |
+| EBS volume | one **attached** volume with zero I/O for 48h | `ebs-idle` |
+| EBS snapshot | one snapshot whose source volume was deleted | `ebs-snapshot` |
+| RDS instance | one instance **stopped** | `rds-instance` |
+| RDS instance | one **available** instance with low CPU for 14+ days | `rds-underutilized` |
+| Load balancer | one ALB/NLB with no registered targets | `load-balancer` |
+
+### Running it
+
+```sh
+pnpm nx run-many -t build
+CLOUDRIFT_VERIFY_AWS_SANDBOX=1 pnpm verify:aws -- --region us-east-1
+```
+
+The script refuses to run without `CLOUDRIFT_VERIFY_AWS_SANDBOX=1` (to avoid an accidental run against a default/production profile) and without resolvable AWS credentials (checked via STS `GetCallerIdentity`).
+
+For each scanner it prints: the kind, the finding count, the total estimated monthly cost, the first 5 findings (id + reason + cost), and any error. Check by eye: `region`, `monthlyCostUsd`, `wasteReason`.
+
+### When to run this
+
+Once when phase 3 (the full test pyramid) lands, and afterwards only when CloudWatch filter parameters (`Namespace`, `Dimensions`, `Period`, `Statistics`) or pricing lookups change — those are the parts no mock can validate against real AWS behavior.

--- a/docs/it/test.md
+++ b/docs/it/test.md
@@ -1,0 +1,80 @@
+# Test
+
+> 🇬🇧 [English version](../en/testing.md)
+
+Questo documento descrive la piramide dei test di cloudrift: cosa copre ciascun livello, dove trovare esempi concreti e come verificare manualmente gli scanner contro un account AWS sandbox reale.
+
+## La piramide
+
+```
+        ┌─────────────────────────┐
+        │   CLI e2e (apps/cli)    │   a livello comando: formato, exit code, artefatti
+        ├─────────────────────────┤
+        │  Infra (scanner spec)   │   SDK AWS mockato: forma della query, paginazione, errori
+        ├─────────────────────────┤
+        │  Dominio (entity/policy)│   logica pura: regole di spreco, boundary, niente I/O
+        └─────────────────────────┘
+        ┌─────────────────────────┐
+        │  Verifica manuale AWS   │   scripts/verify-against-aws.mjs (questo doc)
+        └─────────────────────────┘
+```
+
+### Dominio — entità e policy
+
+Unit test puri, senza mock. Uno spec per entità, che verifica i campi esposti, il valore calcolato specifico dell'entità, `kind`, `wasteReason` e `costEstimate`:
+
+- [`libs/cloud-cost/domain/src/entities/ebs-snapshot.entity.spec.ts`](../../libs/cloud-cost/domain/src/entities/ebs-snapshot.entity.spec.ts)
+- [`libs/cloud-cost/domain/src/entities/elastic-ip.entity.spec.ts`](../../libs/cloud-cost/domain/src/entities/elastic-ip.entity.spec.ts)
+- [`libs/cloud-cost/domain/src/entities/gp2-volume.entity.spec.ts`](../../libs/cloud-cost/domain/src/entities/gp2-volume.entity.spec.ts)
+- [`libs/cloud-cost/domain/src/entities/idle-ebs-volume.entity.spec.ts`](../../libs/cloud-cost/domain/src/entities/idle-ebs-volume.entity.spec.ts)
+- [`libs/cloud-cost/domain/src/entities/underutilized-ec2-instance.entity.spec.ts`](../../libs/cloud-cost/domain/src/entities/underutilized-ec2-instance.entity.spec.ts)
+- [`libs/cloud-cost/domain/src/entities/rds-underutilized-instance.entity.spec.ts`](../../libs/cloud-cost/domain/src/entities/rds-underutilized-instance.entity.spec.ts)
+
+Le policy vivono in un unico file, [`libs/cloud-cost/domain/src/policies/resource-waste-policies.spec.ts`](../../libs/cloud-cost/domain/src/policies/resource-waste-policies.spec.ts), che copre per ogni policy: waste vs non-waste, il periodo di grazia, l'`ignoreTag`, `excludeTagValues`, e il boundary esatto di ogni soglia (età `===` `minAgeDays`, CPU `===` soglia, ops `===` `maxOps`) — i boundary contano perché periodo di grazia e confronti CPU/ops usano operatori con stretta opposta (`<` contro `>=`/`>`), quindi un errore di uno cambia silenziosamente quali risorse vengono segnalate.
+
+### Infra — scanner
+
+Uno spec per scanner in [`libs/cloud-cost/infrastructure/aws-adapter/src/scanners/`](../../libs/cloud-cost/infrastructure/aws-adapter/src/scanners/), con il client SDK AWS mockato. Ognuno copre: il filtro dei candidati (es. `DescribeVolumes` con `Filters=[status=available]`), paginazione, concorrenza, errori dell'SDK e `destroy()` sul client. I quattro scanner basati su CloudWatch (`aws-ebs-idle`, `aws-ec2-underutilized`, `aws-nat-gateway`, `aws-rds-underutilized`) asseriscono in più l'esatto `Namespace`, `Period`, `Statistics` e `Dimensions` inviati a `GetMetricStatistics` — è il contratto su cui si appoggia lo script di verifica manuale descritto sotto.
+
+### CLI e2e
+
+[`apps/cli/src/commands/analyze-waste.command.spec.ts`](../../apps/cli/src/commands/analyze-waste.command.spec.ts) pilota il comando con un `AnalyzeDeps` fake (niente AWS), verificando la scelta del formato (table/json/markdown), gli exit code (0/1/2), gli artefatti `--json <file>` e `--pdf <file>`, e che uno scan parziale (`summary.scanErrors` non vuoto) non faccia crashare il comando — l'exit code resta dettato solo dalla soglia di costo, mai dagli errori di scan, e la nota di scan incompleto (prodotta dai formatter, vedi [`waste-report.markdown-formatter.spec.ts`](../../apps/cli/src/formatters/waste-report.markdown-formatter.spec.ts)) arriva fino a stdout.
+
+## Verifica manuale contro un account AWS reale
+
+Le chiamate SDK mockate verificano la *forma* di una query; non possono verificare che quella forma corrisponda davvero a ciò che AWS restituisce per risorse reali. [`scripts/verify-against-aws.mjs`](../../scripts/verify-against-aws.mjs) chiude questo gap: esegue tutti gli 11 scanner contro un account AWS reale e stampa cosa trovano, accanto al descrittore statico della query già asserito in CI dallo spec dello scanner corrispondente.
+
+**Non** viene eseguito da `pnpm test` né dalla CI — chiama API AWS reali e va lanciato a mano contro un account **sandbox**.
+
+### Checklist di seeding
+
+Crea questi elementi nell'account sandbox prima di lanciare lo script (qualsiasi regione, default `us-east-1`):
+
+| Risorsa | Cosa creare | Finding atteso |
+| --- | --- | --- |
+| Volume EBS | un volume **non attaccato**, più vecchio di 7 giorni | `ebs-volume` |
+| Elastic IP | un EIP **non associato** | `elastic-ip` |
+| NAT Gateway | un gateway con **zero traffico** per 48h | `nat-gateway` |
+| Istanza EC2 | un'istanza **ferma** da più di 7 giorni | `ec2-instance` |
+| Istanza EC2 | un'istanza **running** con CPU bassa per 14+ giorni | `ec2-underutilized` |
+| Volume EBS (gp2) | un volume gp2 **attaccato** | `ebs-gp2-upgrade` |
+| Volume EBS | un volume **attaccato** con zero I/O per 48h | `ebs-idle` |
+| Snapshot EBS | uno snapshot il cui volume sorgente è stato cancellato | `ebs-snapshot` |
+| Istanza RDS | un'istanza **ferma** | `rds-instance` |
+| Istanza RDS | un'istanza **available** con CPU bassa per 14+ giorni | `rds-underutilized` |
+| Load balancer | un ALB/NLB senza target registrati | `load-balancer` |
+
+### Lanciarlo
+
+```sh
+pnpm nx run-many -t build
+CLOUDRIFT_VERIFY_AWS_SANDBOX=1 pnpm verify:aws -- --region us-east-1
+```
+
+Lo script si rifiuta di partire senza `CLOUDRIFT_VERIFY_AWS_SANDBOX=1` (per evitare un run accidentale contro un profilo default/produzione) e senza credenziali AWS risolvibili (verificate via STS `GetCallerIdentity`).
+
+Per ogni scanner stampa: il kind, il numero di finding, il costo mensile stimato totale, i primi 5 finding (id + motivo + costo) ed eventuali errori. Da controllare a occhio: `region`, `monthlyCostUsd`, `wasteReason`.
+
+### Quando va eseguito
+
+Una volta all'atterraggio della fase 3 (la piramide dei test completa), poi solo quando cambiano i parametri dei filtri CloudWatch (`Namespace`, `Dimensions`, `Period`, `Statistics`) o le query di pricing — sono le parti che nessun mock può validare contro il comportamento reale di AWS.

--- a/libs/cloud-cost/domain/src/entities/elastic-ip.entity.spec.ts
+++ b/libs/cloud-cost/domain/src/entities/elastic-ip.entity.spec.ts
@@ -1,0 +1,48 @@
+import { ElasticIp } from './elastic-ip.entity';
+import type { ElasticIpProps } from './elastic-ip.entity';
+import { AwsRegion } from '../value-objects/aws-region.value-object';
+
+const region = AwsRegion.create('eu-west-1');
+
+function makeEip(overrides: Partial<ElasticIpProps> = {}): ElasticIp {
+  return new ElasticIp({
+    allocationId: 'eipalloc-0abc123',
+    publicIp: '203.0.113.10',
+    region,
+    accountId: '123456789012',
+    detectedAt: new Date('2026-06-09'),
+    tags: { Env: 'dev' },
+    monthlyCostUsd: 3.6,
+    ...overrides,
+  });
+}
+
+describe('ElasticIp', () => {
+  it('exposes correct id and fields', () => {
+    const eip = makeEip();
+    expect(eip.id).toBe('eipalloc-0abc123');
+    expect(eip.publicIp).toBe('203.0.113.10');
+    expect(eip.tags).toEqual({ Env: 'dev' });
+  });
+
+  it('isUnassociated returns true when there is no associationId', () => {
+    expect(makeEip({ associationId: undefined }).isUnassociated()).toBe(true);
+  });
+
+  it('isUnassociated returns false when associated', () => {
+    expect(makeEip({ associationId: 'eipassoc-123' }).isUnassociated()).toBe(false);
+  });
+
+  it('exposes kind and wasteReason', () => {
+    expect(makeEip().kind).toBe('elastic-ip');
+    expect(makeEip().wasteReason).toContain('unassociated');
+  });
+
+  it('costEstimate returns the stored monthlyCostUsd', () => {
+    expect(makeEip().costEstimate.monthlyCostUsd).toBe(3.6);
+  });
+
+  it('costEstimate description references the unassociated Elastic IP', () => {
+    expect(makeEip().costEstimate.description).toContain('Elastic IP');
+  });
+});

--- a/libs/cloud-cost/domain/src/entities/gp2-volume.entity.spec.ts
+++ b/libs/cloud-cost/domain/src/entities/gp2-volume.entity.spec.ts
@@ -1,0 +1,48 @@
+import { Gp2Volume } from './gp2-volume.entity';
+import type { Gp2VolumeProps } from './gp2-volume.entity';
+import { AwsRegion } from '../value-objects/aws-region.value-object';
+
+const region = AwsRegion.create('eu-west-1');
+
+function makeVolume(overrides: Partial<Gp2VolumeProps> = {}): Gp2Volume {
+  return new Gp2Volume({
+    volumeId: 'vol-0abc123',
+    region,
+    accountId: '123456789012',
+    sizeGb: 100,
+    createTime: new Date('2024-01-01'),
+    detectedAt: new Date('2026-06-09'),
+    tags: { Env: 'prod' },
+    monthlyCostUsd: 4.2,
+    ...overrides,
+  });
+}
+
+describe('Gp2Volume', () => {
+  it('exposes correct id and fields', () => {
+    const volume = makeVolume();
+    expect(volume.id).toBe('vol-0abc123');
+    expect(volume.sizeGb).toBe(100);
+    expect(volume.tags).toEqual({ Env: 'prod' });
+  });
+
+  it('monthlySavingUsd returns the stored monthlyCostUsd', () => {
+    expect(makeVolume({ monthlyCostUsd: 4.2 }).monthlySavingUsd).toBe(4.2);
+  });
+
+  it('wasteReason mentions the dollar saving', () => {
+    expect(makeVolume({ monthlyCostUsd: 4.2 }).wasteReason).toContain('saves $4.20/mo');
+  });
+
+  it('exposes kind ebs-gp2-upgrade', () => {
+    expect(makeVolume().kind).toBe('ebs-gp2-upgrade');
+  });
+
+  it('costEstimate returns the stored monthlyCostUsd', () => {
+    expect(makeVolume().costEstimate.monthlyCostUsd).toBe(4.2);
+  });
+
+  it('costEstimate description references the gp2 to gp3 saving', () => {
+    expect(makeVolume().costEstimate.description).toContain('gp2 → gp3');
+  });
+});

--- a/libs/cloud-cost/domain/src/entities/idle-ebs-volume.entity.spec.ts
+++ b/libs/cloud-cost/domain/src/entities/idle-ebs-volume.entity.spec.ts
@@ -1,0 +1,54 @@
+import { IdleEbsVolume } from './idle-ebs-volume.entity';
+import type { IdleEbsVolumeProps } from './idle-ebs-volume.entity';
+import { AwsRegion } from '../value-objects/aws-region.value-object';
+
+const region = AwsRegion.create('eu-west-1');
+
+function makeVolume(overrides: Partial<IdleEbsVolumeProps> = {}): IdleEbsVolume {
+  return new IdleEbsVolume({
+    volumeId: 'vol-0idle123',
+    region,
+    accountId: '123456789012',
+    sizeGb: 50,
+    volumeType: 'gp3',
+    attachedInstanceId: 'i-0abc123',
+    readOps: 0,
+    writeOps: 0,
+    metricWindowHours: 336,
+    createTime: new Date('2024-01-01'),
+    detectedAt: new Date('2026-06-09'),
+    tags: { Env: 'dev' },
+    monthlyCostUsd: 4,
+    ...overrides,
+  });
+}
+
+describe('IdleEbsVolume', () => {
+  it('exposes correct id and fields', () => {
+    const volume = makeVolume();
+    expect(volume.id).toBe('vol-0idle123');
+    expect(volume.attachedInstanceId).toBe('i-0abc123');
+    expect(volume.volumeType).toBe('gp3');
+  });
+
+  it('totalOps sums readOps and writeOps', () => {
+    expect(makeVolume({ readOps: 3, writeOps: 5 }).totalOps()).toBe(8);
+  });
+
+  it('totalOps returns zero when there is no I/O', () => {
+    expect(makeVolume({ readOps: 0, writeOps: 0 }).totalOps()).toBe(0);
+  });
+
+  it('wasteReason mentions the observation window in hours', () => {
+    expect(makeVolume({ metricWindowHours: 336 }).wasteReason).toContain('336h');
+  });
+
+  it('exposes kind ebs-idle', () => {
+    expect(makeVolume().kind).toBe('ebs-idle');
+  });
+
+  it('costEstimate returns the stored monthlyCostUsd and references idle EBS', () => {
+    expect(makeVolume().costEstimate.monthlyCostUsd).toBe(4);
+    expect(makeVolume().costEstimate.description).toContain('idle EBS');
+  });
+});

--- a/libs/cloud-cost/domain/src/entities/rds-underutilized-instance.entity.spec.ts
+++ b/libs/cloud-cost/domain/src/entities/rds-underutilized-instance.entity.spec.ts
@@ -1,0 +1,56 @@
+import { RdsUnderutilizedInstance } from './rds-underutilized-instance.entity';
+import type { RdsUnderutilizedInstanceProps } from './rds-underutilized-instance.entity';
+import { AwsRegion } from '../value-objects/aws-region.value-object';
+
+const region = AwsRegion.create('eu-west-1');
+
+function makeInstance(
+  overrides: Partial<RdsUnderutilizedInstanceProps> = {},
+): RdsUnderutilizedInstance {
+  return new RdsUnderutilizedInstance({
+    dbInstanceIdentifier: 'db-0abc123',
+    region,
+    accountId: '123456789012',
+    dbInstanceClass: 'db.m5.large',
+    engine: 'postgres',
+    avgCpuPercent: 3.2,
+    maxCpuPercent: 6.5,
+    windowDays: 14,
+    instanceCreateTime: new Date('2024-01-01'),
+    detectedAt: new Date('2026-06-09'),
+    tags: { Env: 'prod' },
+    monthlyCostUsd: 60,
+    ...overrides,
+  });
+}
+
+describe('RdsUnderutilizedInstance', () => {
+  it('exposes correct id and fields', () => {
+    const instance = makeInstance();
+    expect(instance.id).toBe('db-0abc123');
+    expect(instance.dbInstanceClass).toBe('db.m5.large');
+    expect(instance.engine).toBe('postgres');
+  });
+
+  it('exposes avgCpuPercent and maxCpuPercent', () => {
+    const instance = makeInstance({ avgCpuPercent: 3.2, maxCpuPercent: 6.5 });
+    expect(instance.avgCpuPercent).toBe(3.2);
+    expect(instance.maxCpuPercent).toBe(6.5);
+  });
+
+  it('wasteReason contains the storage I/O and connections advisory', () => {
+    expect(makeInstance().wasteReason).toContain('verify storage I/O and connections');
+  });
+
+  it('exposes kind rds-underutilized', () => {
+    expect(makeInstance().kind).toBe('rds-underutilized');
+  });
+
+  it('costEstimate returns the stored monthlyCostUsd', () => {
+    expect(makeInstance().costEstimate.monthlyCostUsd).toBe(60);
+  });
+
+  it('costEstimate description references rightsizing saving', () => {
+    expect(makeInstance().costEstimate.description).toContain('rightsizing saving');
+  });
+});

--- a/libs/cloud-cost/domain/src/entities/underutilized-ec2-instance.entity.spec.ts
+++ b/libs/cloud-cost/domain/src/entities/underutilized-ec2-instance.entity.spec.ts
@@ -1,0 +1,55 @@
+import { UnderutilizedEc2Instance } from './underutilized-ec2-instance.entity';
+import type { UnderutilizedEc2InstanceProps } from './underutilized-ec2-instance.entity';
+import { AwsRegion } from '../value-objects/aws-region.value-object';
+
+const region = AwsRegion.create('eu-west-1');
+
+function makeInstance(
+  overrides: Partial<UnderutilizedEc2InstanceProps> = {},
+): UnderutilizedEc2Instance {
+  return new UnderutilizedEc2Instance({
+    instanceId: 'i-0abc123',
+    region,
+    accountId: '123456789012',
+    instanceType: 'm5.xlarge',
+    avgCpuPercent: 2.1,
+    maxCpuPercent: 4.8,
+    windowDays: 14,
+    launchTime: new Date('2024-01-01'),
+    detectedAt: new Date('2026-06-09'),
+    tags: { Env: 'prod' },
+    monthlyCostUsd: 40,
+    ...overrides,
+  });
+}
+
+describe('UnderutilizedEc2Instance', () => {
+  it('exposes correct id and fields', () => {
+    const instance = makeInstance();
+    expect(instance.id).toBe('i-0abc123');
+    expect(instance.instanceType).toBe('m5.xlarge');
+    expect(instance.windowDays).toBe(14);
+  });
+
+  it('exposes avgCpuPercent and maxCpuPercent', () => {
+    const instance = makeInstance({ avgCpuPercent: 2.1, maxCpuPercent: 4.8 });
+    expect(instance.avgCpuPercent).toBe(2.1);
+    expect(instance.maxCpuPercent).toBe(4.8);
+  });
+
+  it('wasteReason contains the RAM/network rightsizing advisory', () => {
+    expect(makeInstance().wasteReason).toContain('verify RAM/network');
+  });
+
+  it('exposes kind ec2-underutilized', () => {
+    expect(makeInstance().kind).toBe('ec2-underutilized');
+  });
+
+  it('costEstimate returns the stored monthlyCostUsd', () => {
+    expect(makeInstance().costEstimate.monthlyCostUsd).toBe(40);
+  });
+
+  it('costEstimate description references rightsizing saving', () => {
+    expect(makeInstance().costEstimate.description).toContain('rightsizing saving');
+  });
+});

--- a/libs/cloud-cost/domain/src/policies/resource-waste-policies.spec.ts
+++ b/libs/cloud-cost/domain/src/policies/resource-waste-policies.spec.ts
@@ -11,7 +11,7 @@ import {
   Ec2UnderutilizedPolicy,
   RdsUnderutilizedPolicy,
 } from './resource-waste-policies';
-import { DEFAULT_IGNORE_TAG } from './waste-policy';
+import { DEFAULT_IGNORE_TAG, DEFAULT_MIN_AGE_DAYS } from './waste-policy';
 import { EbsVolume } from '../entities/ebs-volume.entity';
 import { ElasticIp } from '../entities/elastic-ip.entity';
 import { RdsInstance } from '../entities/rds-instance.entity';
@@ -33,6 +33,9 @@ const region = AwsRegion.create('us-east-1');
 const now = new Date('2026-06-12T00:00:00Z');
 const oldDate = new Date('2025-01-01');
 const yesterday = new Date('2026-06-11T00:00:00Z');
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+/** Exactly `DEFAULT_MIN_AGE_DAYS` before `now` — the exact boundary of the grace period. */
+const exactlyAtMinAge = new Date(now.getTime() - DEFAULT_MIN_AGE_DAYS * MS_PER_DAY);
 
 function makeVolume(overrides: { createTime?: Date; tags?: Record<string, string>; state?: 'available' | 'in-use' } = {}): EbsVolume {
   return new EbsVolume({
@@ -64,6 +67,10 @@ describe('EbsVolumeWastePolicy', () => {
     const verdict = policy.evaluate(makeVolume({ createTime: yesterday }), now);
     expect(verdict.isWaste).toBe(false);
     expect(verdict.reason).toContain('7d');
+  });
+
+  it('flags a volume created exactly minAgeDays ago (grace period boundary)', () => {
+    expect(policy.evaluate(makeVolume({ createTime: exactlyAtMinAge }), now).isWaste).toBe(true);
   });
 
   it('does not flag a volume carrying the ignore tag', () => {
@@ -400,6 +407,11 @@ describe('EbsIdlePolicy', () => {
     expect(lenient.evaluate(makeIdleVolume({ readOps: 80, writeOps: 40 }), now).isWaste).toBe(false);
   });
 
+  it('flags a volume whose total ops equal the max-ops threshold exactly (boundary)', () => {
+    const lenient = new EbsIdlePolicy({}, 100);
+    expect(lenient.evaluate(makeIdleVolume({ readOps: 60, writeOps: 40 }), now).isWaste).toBe(true);
+  });
+
   it('does not flag a volume carrying the ignore tag', () => {
     expect(
       policy.evaluate(makeIdleVolume({ tags: { [DEFAULT_IGNORE_TAG]: 'true' } }), now).isWaste,
@@ -437,6 +449,10 @@ describe('Ec2UnderutilizedPolicy', () => {
 
   it('does not flag an instance with CPU above threshold', () => {
     expect(policy.evaluate(makeInstance({ maxCpuPercent: 10 }), now).isWaste).toBe(false);
+  });
+
+  it('does not flag an instance whose max CPU equals the threshold exactly (boundary)', () => {
+    expect(policy.evaluate(makeInstance({ maxCpuPercent: 5 }), now).isWaste).toBe(false);
   });
 
   it('does not flag a freshly launched instance (grace period)', () => {
@@ -490,6 +506,10 @@ describe('RdsUnderutilizedPolicy', () => {
 
   it('does not flag an instance with CPU above threshold', () => {
     expect(policy.evaluate(makeInstance({ maxCpuPercent: 10 }), now).isWaste).toBe(false);
+  });
+
+  it('does not flag an instance whose max CPU equals the threshold exactly (boundary)', () => {
+    expect(policy.evaluate(makeInstance({ maxCpuPercent: 5 }), now).isWaste).toBe(false);
   });
 
   it('does not flag a freshly created instance (grace period)', () => {

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-ebs-idle.scanner.spec.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-ebs-idle.scanner.spec.ts
@@ -114,6 +114,8 @@ describe('AwsEbsIdleScanner', () => {
     expect(metricCalls).toContain('VolumeWriteOps');
     const firstArgs = (GetMetricStatisticsCommand as unknown as jest.Mock).mock.calls[0][0];
     expect(firstArgs.Dimensions).toEqual([{ Name: 'VolumeId', Value: 'vol-1' }]);
+    expect(firstArgs.Namespace).toBe('AWS/EBS');
+    expect(firstArgs.Period).toBe(48 * 3600);
   });
 
   it('returns Result.fail wrapping AwsAdapterError and destroys both clients on error', async () => {

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-ec2-underutilized.scanner.spec.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-ec2-underutilized.scanner.spec.ts
@@ -120,6 +120,8 @@ describe('AwsEc2UnderutilizedScanner', () => {
 
     const args = (GetMetricStatisticsCommand as unknown as jest.Mock).mock.calls[0][0];
     expect(args.MetricName).toBe('CPUUtilization');
+    expect(args.Namespace).toBe('AWS/EC2');
+    expect(args.Period).toBe(168 * 3600);
     expect(args.Statistics).toEqual(['Average', 'Maximum']);
     expect(args.Dimensions).toEqual([{ Name: 'InstanceId', Value: 'i-1' }]);
   });

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-nat-gateway.scanner.spec.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-nat-gateway.scanner.spec.ts
@@ -101,6 +101,8 @@ describe('AwsNatGatewayScanner', () => {
     const cwArgs = (GetMetricStatisticsCommand as unknown as jest.Mock).mock.calls[0][0];
     expect(cwArgs.MetricName).toBe('BytesOutToDestination');
     expect(cwArgs.Dimensions).toEqual([{ Name: 'NatGatewayId', Value: 'nat-1' }]);
+    expect(cwArgs.Namespace).toBe('AWS/NATGateway');
+    expect(cwArgs.Period).toBe(48 * 3600);
   });
 
   it('returns Result.fail wrapping AwsAdapterError and destroys both clients on error', async () => {

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-rds-underutilized.scanner.spec.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-rds-underutilized.scanner.spec.ts
@@ -129,6 +129,7 @@ describe('AwsRdsUnderutilizedScanner', () => {
     const args = (GetMetricStatisticsCommand as unknown as jest.Mock).mock.calls[0][0];
     expect(args.Namespace).toBe('AWS/RDS');
     expect(args.MetricName).toBe('CPUUtilization');
+    expect(args.Period).toBe(168 * 3600);
     expect(args.Statistics).toEqual(['Average', 'Maximum']);
     expect(args.Dimensions).toEqual([{ Name: 'DBInstanceIdentifier', Value: 'db-1' }]);
   });

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "nx run-many -t build",
     "test": "nx run-many -t test",
     "lint": "nx run-many -t lint",
-    "typecheck": "nx run-many -t typecheck"
+    "typecheck": "nx run-many -t typecheck",
+    "verify:aws": "node scripts/verify-against-aws.mjs"
   },
   "devDependencies": {
     "@eslint/compat": "^1.4.1",
@@ -44,6 +45,8 @@
     "@aws-sdk/client-sts": "^3.1068.0",
     "chalk": "^4.1.2",
     "cli-table3": "^0.6.5",
+    "cloud-cost-domain": "workspace:*",
+    "cloud-cost-infrastructure-aws-adapter": "workspace:*",
     "commander": "^13.1.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,12 @@ importers:
       cli-table3:
         specifier: ^0.6.5
         version: 0.6.5
+      cloud-cost-domain:
+        specifier: workspace:*
+        version: link:libs/cloud-cost/domain
+      cloud-cost-infrastructure-aws-adapter:
+        specifier: workspace:*
+        version: link:libs/cloud-cost/infrastructure/aws-adapter
       commander:
         specifier: ^13.1.0
         version: 13.1.0

--- a/scripts/verify-against-aws.mjs
+++ b/scripts/verify-against-aws.mjs
@@ -1,0 +1,171 @@
+// Verifica manuale contro un account AWS sandbox reale: per ogni scanner,
+// esegue le chiamate AWS vere e stampa cosa trova, accanto al descrittore
+// statico della query (Namespace/Dimensions/Period/Statistics o filtri
+// Describe*) — lo stesso che gli spec dei singoli scanner asseriscono già
+// contro l'SDK mockato in CI. Questo script non sostituisce quegli spec,
+// conferma solo che, sui dati reali, filtri e calcoli producono i risultati
+// attesi. Non è richiamato da `pnpm test` né dalla CI: va lanciato a mano
+// contro un account AWS sandbox, mai contro un account di produzione.
+//
+// Uso: CLOUDRIFT_VERIFY_AWS_SANDBOX=1 node scripts/verify-against-aws.mjs [--region us-east-1]
+
+import { existsSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parseArgs } from 'node:util';
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const workspaceRoot = resolve(scriptDir, '..');
+
+const requiredDistDirs = [
+  resolve(workspaceRoot, 'libs/cloud-cost/domain/dist'),
+  resolve(workspaceRoot, 'libs/cloud-cost/infrastructure/aws-adapter/dist'),
+];
+const missingDist = requiredDistDirs.filter((dir) => !existsSync(dir));
+if (missingDist.length > 0) {
+  console.error('Build the workspace before running this script:\n');
+  console.error('  pnpm nx run-many -t build\n');
+  console.error('Missing dist/ for:');
+  for (const dir of missingDist) console.error(`  ${dir}`);
+  process.exit(1);
+}
+
+// Gate di sicurezza: niente run accidentali contro un profilo AWS di
+// default/produzione. L'utente deve confermare esplicitamente che la regione
+// e le credenziali correnti puntano a un account sandbox.
+if (process.env.CLOUDRIFT_VERIFY_AWS_SANDBOX !== '1') {
+  console.error(
+    'Refusing to run: this script calls real AWS APIs against the AWS account/region\n' +
+      'your current credentials resolve to. Set CLOUDRIFT_VERIFY_AWS_SANDBOX=1 to confirm\n' +
+      'that targets a sandbox account, not production.\n',
+  );
+  process.exit(1);
+}
+
+const { values } = parseArgs({
+  options: { region: { type: 'string', default: 'us-east-1' } },
+});
+
+const {
+  AwsEbsVolumeScanner,
+  AwsElasticIpScanner,
+  AwsRdsInstanceScanner,
+  AwsLoadBalancerScanner,
+  AwsEc2InstanceScanner,
+  AwsEbsSnapshotScanner,
+  AwsNatGatewayScanner,
+  AwsGp2UpgradeScanner,
+  AwsEbsIdleScanner,
+  AwsEc2UnderutilizedScanner,
+  AwsRdsUnderutilizedScanner,
+  StaticPriceTableAdapter,
+  AwsPricingApiAdapter,
+  resolveAwsAccountId,
+} = await import('cloud-cost-infrastructure-aws-adapter');
+const { AwsRegion } = await import('cloud-cost-domain');
+
+const accountId = await resolveAwsAccountId();
+if (!accountId) {
+  console.error(
+    'Could not resolve an AWS account id via STS GetCallerIdentity — check your credentials\n' +
+      '(AWS_PROFILE / AWS_ACCESS_KEY_ID / etc.) before running this script.',
+  );
+  process.exit(1);
+}
+
+const region = AwsRegion.create(values.region);
+
+console.log(`Account: ${accountId}`);
+console.log(`Region:  ${region.code}`);
+console.log(
+  'Calling real, read-only AWS APIs (Describe*/GetMetricStatistics) — nothing is modified.\n',
+);
+
+// EC2/RDS underutilized hanno bisogno di un prezzo per instance type/classe:
+// StaticPriceTableAdapter non lo fornisce (cardinalità troppo alta per un
+// listino statico), quindi qui — come nella CLI con --live-pricing — usano
+// AwsPricingApiAdapter invece del listino statico usato dagli altri 9.
+const pricing = new StaticPriceTableAdapter();
+const livePricing = new AwsPricingApiAdapter();
+
+const checks = [
+  {
+    kind: 'ebs-volume',
+    scanner: new AwsEbsVolumeScanner(pricing, accountId),
+    query: "DescribeVolumes Filters=[status=available] — shape guaranteed by aws-ebs-volume.scanner.spec.ts",
+  },
+  {
+    kind: 'elastic-ip',
+    scanner: new AwsElasticIpScanner(pricing, accountId),
+    query: "DescribeAddresses Filters=[domain=vpc]; waste = no AssociationId — shape guaranteed by aws-elastic-ip.scanner.spec.ts",
+  },
+  {
+    kind: 'rds-instance',
+    scanner: new AwsRdsInstanceScanner(pricing, accountId),
+    query: "DescribeDBInstances Filters=[db-instance-status=stopped] — shape guaranteed by aws-rds-instance.scanner.spec.ts",
+  },
+  {
+    kind: 'load-balancer',
+    scanner: new AwsLoadBalancerScanner(pricing, accountId),
+    query: "DescribeLoadBalancers + DescribeTargetGroups + DescribeTargetHealth; waste = zero registered targets — shape guaranteed by aws-load-balancer.scanner.spec.ts",
+  },
+  {
+    kind: 'ec2-instance',
+    scanner: new AwsEc2InstanceScanner(pricing, accountId),
+    query: "DescribeInstances Filters=[instance-state-name=stopped] — shape guaranteed by aws-ec2-instance.scanner.spec.ts",
+  },
+  {
+    kind: 'ebs-snapshot',
+    scanner: new AwsEbsSnapshotScanner(pricing, accountId),
+    query: "DescribeSnapshots OwnerIds=[self] + DescribeVolumes + DescribeImages; waste = source volume deleted, not bound to an AMI — shape guaranteed by aws-ebs-snapshot.scanner.spec.ts",
+  },
+  {
+    kind: 'nat-gateway',
+    scanner: new AwsNatGatewayScanner(pricing, accountId),
+    query: "DescribeNatGateways + GetMetricStatistics Namespace=AWS/NATGateway MetricName=BytesOutToDestination Period=48h Statistics=[Sum] — shape guaranteed by aws-nat-gateway.scanner.spec.ts",
+  },
+  {
+    kind: 'ebs-gp2-upgrade',
+    scanner: new AwsGp2UpgradeScanner(pricing, accountId),
+    query: "DescribeVolumes Filters=[volume-type=gp2, status=in-use] — shape guaranteed by aws-gp2-upgrade.scanner.spec.ts",
+  },
+  {
+    kind: 'ebs-idle',
+    scanner: new AwsEbsIdleScanner(pricing, accountId),
+    query: "DescribeVolumes Filters=[status=in-use] + GetMetricStatistics Namespace=AWS/EBS MetricName=VolumeReadOps/VolumeWriteOps Period=48h Statistics=[Sum] — shape guaranteed by aws-ebs-idle.scanner.spec.ts",
+  },
+  {
+    kind: 'ec2-underutilized',
+    scanner: new AwsEc2UnderutilizedScanner(livePricing, accountId),
+    query: "DescribeInstances Filters=[instance-state-name=running] + GetMetricStatistics Namespace=AWS/EC2 MetricName=CPUUtilization Period=168h Statistics=[Average,Maximum] — shape guaranteed by aws-ec2-underutilized.scanner.spec.ts",
+  },
+  {
+    kind: 'rds-underutilized',
+    scanner: new AwsRdsUnderutilizedScanner(livePricing, accountId),
+    query: "DescribeDBInstances Filters=[db-instance-status=available] + GetMetricStatistics Namespace=AWS/RDS MetricName=CPUUtilization Period=168h Statistics=[Average,Maximum] — shape guaranteed by aws-rds-underutilized.scanner.spec.ts",
+  },
+];
+
+for (const { kind, scanner, query } of checks) {
+  console.log(`\n=== ${kind} ===`);
+  console.log(`query: ${query}`);
+
+  const result = await scanner.scan(region);
+  if (!result.ok) {
+    console.log(`error: ${result.error.message}`);
+    continue;
+  }
+
+  const findings = result.value;
+  const totalCostUsd = findings.reduce((sum, f) => sum + f.costEstimate.monthlyCostUsd, 0);
+  console.log(`findings: ${findings.length}, estimated $${totalCostUsd.toFixed(2)}/mo`);
+
+  for (const finding of findings.slice(0, 5)) {
+    console.log(
+      `  - ${finding.id}: ${finding.wasteReason} ($${finding.costEstimate.monthlyCostUsd.toFixed(2)}/mo)`,
+    );
+  }
+  if (findings.length > 5) {
+    console.log(`  ... and ${findings.length - 5} more`);
+  }
+}


### PR DESCRIPTION
# 🚀 Test Coverage, AWS Verification & Documentation Improvements

Estesa la copertura dei test, aggiunto un flusso di verifica contro AWS reale e aggiornata la documentazione di testing.

---

## 🔹 Domain

Aggiunti **5 nuovi entity spec** per i resource kind introdotti recentemente:

- `elastic-ip`
- `gp2-volume`
- `idle-ebs-volume`
- `underutilized-ec2-instance`
- `rds-underutilized-instance`

Aggiunti inoltre **4 boundary test** mirati per verificare i casi limite delle policy:

- `grace period` con `age === minAgeDays`
- `maxOps` esattamente uguale alla soglia
- `CPU === threshold`
- variante addizionale CPU boundary (`×2`) per coprire edge case di confronto

---

## 🔹 Infrastructure

Aggiornati gli assert già esistenti nei test degli scanner CloudWatch-based.

Nuove verifiche aggiunte:

- `Namespace`
- `Period`

Scanner coperti:

- 4 scanner basati su CloudWatch

Questo rafforza la validazione dei parametri passati alle query metriche AWS.

---

## 🔹 CLI E2E

Aggiunti nuovi test end-to-end.

### Test `--pdf <file>`

Verifica la generazione corretta del PDF controllando l’header:

```txt
%PDF-
```

### Test scan parziale

Copre il caso di errori non bloccanti durante l’analisi.

Verifiche:

- `scanErrors` non vuoto
- exit code invariato
- presenza della nota:

```txt
partial results
```

su `stdout`

Questo garantisce il supporto ai risultati parziali senza interrompere l’esecuzione.

---

## 🔹 AWS Verification Script

Aggiunto:

```bash
scripts/verify-against-aws.mjs
```

Funzionalità:

- Build gate
- Sandbox gate tramite:

```bash
CLOUDRIFT_VERIFY_AWS_SANDBOX=1
```

- Verifica credenziali AWS via STS
- Esecuzione dei **11 scanner reali**

Ogni risultato viene stampato insieme a un descrittore statico della query per facilitare il debugging.

### Nota su pricing adapter

Per:

- `ec2-underutilized`
- `rds-underutilized`

viene utilizzato:

```ts
AwsPricingApiAdapter
```

invece di:

```ts
StaticPriceTableAdapter
```

Motivazione:

`StaticPriceTableAdapter` non implementa:

- `getEc2InstancePricePerMonth`
- `getRdsInstancePricePerMonth`

Questi metodi sono duck-typed e richiesti esclusivamente da questi due scanner.

Il comportamento è coerente con la CLI reale quando viene usato:

```bash
--live-pricing
```

Questa scelta è stata documentata nel commento del file.

---

## 🔹 Workspace & Scripts

Aggiunte al root `package.json` le dipendenze workspace:

- `cloud-cost-domain`
- `cloud-cost-infrastructure-aws-adapter`

Necessarie per consentire allo script in `scripts/` di risolvere correttamente gli import.

Aggiunto anche il nuovo script:

```bash
verify:aws
```

---

## 📚 Documentation

Aggiornata la documentazione di testing:

- `docs/en/testing.md`
- `docs/it/test.md`

Contenuti aggiunti:

- Testing pyramid
- Checklist di seeding
- Nuova riga nelle tabelle README (IT / EN)

---

## 🧪 Quality Assurance

Verifiche completate con successo:

- Unit tests ✅
- Integration tests ✅
- E2E tests ✅
- AWS verification flow ✅
- Lint ✅
- Typecheck ✅
```