### PR TITLE
feat(cloud-cost): Added new Resource Checks — Log Groups, Orphaned EN…

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,11 @@
 | **EBS Volumes (idle)** | Attached (in-use) but zero I/O in the last 48h | gp3: $0.08/GB-mo · gp2: $0.10/GB-mo · io1: $0.125/GB-mo |
 | **EC2 Instances (underutilized)** | Running, max CPU ≤ 5% over 14 days — rightsizing candidate, requires `--live-pricing` | Saving: ~50% of the instance's monthly cost (estimate — verify RAM/network before acting) |
 | **RDS Instances (underutilized)** | Available, max CPU ≤ 5% over 14 days — rightsizing candidate, requires `--live-pricing` | Saving: ~50% of the instance's monthly cost (estimate — verify storage I/O/connections before acting) |
+| **CloudWatch Log Groups** | No retention policy configured (logs grow forever) | $0.03/GB-month |
+| **Orphaned ENIs** | `Status: available` (not attached to any instance) | $0 (hygiene flag, not a direct cost) |
+| **S3 Buckets (no lifecycle)** | No lifecycle configuration — rightsizing candidate | Saving: ~40% of Standard storage cost (estimate — verify access patterns before acting) |
 
-Every finding is also tagged `waste` or `optimization`: `waste` is money being spent now and feeds the headline total and the CI gate; `optimization` (gp2→gp3, EC2/RDS underutilized) is a saving opportunity that keeps the resource, shown separately and never gated. `EC2/RDS Instances (underutilized)` are additionally *estimates* — verify before acting.
+Every finding is also tagged `waste` or `optimization`: `waste` is money being spent now and feeds the headline total and the CI gate; `optimization` (gp2→gp3, EC2/RDS underutilized, S3 no-lifecycle) is a saving opportunity that keeps the resource, shown separately and never gated. `EC2/RDS Instances (underutilized)` and `S3 Buckets (no lifecycle)` are additionally *estimates* — verify before acting.
 
 > **Honest caveat (rightsizing):** the underutilized check is a single-metric heuristic — max CPU below a threshold over the lookback window, nothing else. It does **not** look at RAM, network throughput, IOPS or connection counts, so it can't tell you *which* smaller instance type actually fits. We do this because it requires no extra IAM permissions and works the same on every account; we don't replace [AWS Compute Optimizer](https://aws.amazon.com/compute-optimizer/), which models multiple metrics and recommends a specific target type. Treat our finding as "go check this instance," not as a sizing recommendation — cross-check with Compute Optimizer (or your own metrics) before resizing.
 
@@ -115,6 +118,9 @@ If everything is configured correctly you'll see tables listing the wasted resou
 
 ---
 
+<details>
+<summary><strong>Usage</strong> — flags, examples, PDF report, partial-failure handling, per-region pricing</summary>
+
 ### Usage
 
 ```sh
@@ -194,6 +200,11 @@ If scanning a resource type fails (e.g. missing CloudWatch permissions for NAT G
 
 Prices are region-aware (defined in `prices.json` in the infrastructure layer). Regions with explicit pricing: `us-east-1`, `us-west-2`, `eu-west-1`, `eu-central-1`, `ap-southeast-1`, `ap-northeast-1`. All other regions fall back to us-east-1 defaults.
 
+</details>
+
+<details>
+<summary><strong>Configuration file</strong> — <code>cloudrift.config.json</code> fields, overrides, false-positive tuning</summary>
+
 ### Configuration file
 
 cloudrift reads `cloudrift.config.json` (or `.cloudriftrc`) from the current directory, or a path passed with `--config`. CLI flags take precedence over the config file, which takes precedence over the built-in defaults. All fields are optional:
@@ -238,6 +249,11 @@ cloudrift reads `cloudrift.config.json` (or `.cloudriftrc`) from the current dir
 > A staging NAT Gateway with no weekend traffic is a classic false positive: widen `cloudwatchWindowHours` to `168` so a quiet weekend doesn't flag it.
 > A batch workload that only spikes CPU once a week needs a wider `utilizationWindowHours` (up to `336`) so a quiet 7-day sample doesn't get flagged as underutilized.
 
+</details>
+
+<details>
+<summary><strong>Pricing sources</strong> — static table, live AWS Pricing API, your overrides</summary>
+
 ### Pricing sources
 
 Costs are resolved from three layers; the most specific wins, per `(region, priceKey)`:
@@ -249,6 +265,11 @@ Costs are resolved from three layers; the most specific wins, per `(region, pric
 Every report shows `prices as of` (the static date, the live fetch date, or `+ custom overrides`).
 
 > **Honest caveat:** even with `--live-pricing`, AWS returns **list** prices, not *your* bill — Savings Plans, Reserved Instances and EDP discounts are not reflected. The `prices` override is the only way to make the report match what you actually pay. Anything the live API can't unambiguously resolve falls back to the static table.
+
+</details>
+
+<details>
+<summary><strong>Use in CI/CD</strong> — GitHub Actions example, budget gate</summary>
 
 ### Use in CI/CD
 
@@ -299,6 +320,8 @@ jobs:
 
 With a `cloudrift.config.json` committed (`{"costAlertThresholdUsd": 500}`), the last step's exit code 2 fails the check automatically — the pipeline blocks when newly created resources push waste over the threshold. Once `@cloudrift/cli` is published, the build/checkout steps collapse to a single `npx @cloudrift/cli@latest analyze …` line.
 
+</details>
+
 ### Required IAM permissions
 
 The AWS principal needs the following read-only permissions:
@@ -313,11 +336,15 @@ The AWS principal needs the following read-only permissions:
     "ec2:DescribeSnapshots",
     "ec2:DescribeImages",
     "ec2:DescribeNatGateways",
+    "ec2:DescribeNetworkInterfaces",
     "cloudwatch:GetMetricStatistics",
     "rds:DescribeDBInstances",
     "elasticloadbalancing:DescribeLoadBalancers",
     "elasticloadbalancing:DescribeTargetGroups",
     "elasticloadbalancing:DescribeTargetHealth",
+    "logs:DescribeLogGroups",
+    "s3:ListAllMyBuckets",
+    "s3:GetBucketLifecycleConfiguration",
     "sts:GetCallerIdentity"
   ],
   "Resource": "*"
@@ -325,6 +352,9 @@ The AWS principal needs the following read-only permissions:
 ```
 
 > `--live-pricing` additionally requires `pricing:GetProducts` (the AWS Pricing API). It is **not** needed for the default static pricing.
+
+<details>
+<summary><strong>Development</strong> — watch mode, per-library tests, lint, typecheck</summary>
 
 ### Development
 
@@ -347,6 +377,8 @@ pnpm nx run-many -t lint
 # Type check
 pnpm nx run-many -t typecheck
 ```
+
+</details>
 
 ### Releasing
 
@@ -412,8 +444,11 @@ No changes to `AnalyzeCloudWasteUseCase`, the summary, or the report DTO are nee
 | **EBS Volumes (idle)** | Attaccati (in-use) ma zero I/O nelle ultime 48h                     | gp3: $0,08/GB-mese · gp2: $0,10/GB-mese · io1: $0,125/GB-mese |
 | **EC2 Instances (underutilized)** | Running, CPU massima ≤ 5% in 14 giorni — candidato a rightsizing, richiede `--live-pricing` | Risparmio: ~50% del costo mensile dell'istanza (stima — verificare RAM/rete prima di agire) |
 | **RDS Instances (underutilized)** | Disponibile (`available`), CPU massima ≤ 5% in 14 giorni — candidato a rightsizing, richiede `--live-pricing` | Risparmio: ~50% del costo mensile dell'istanza (stima — verificare storage I/O/connessioni prima di agire) |
+| **CloudWatch Log Groups** | Nessuna retention policy configurata (i log crescono all'infinito) | $0,03/GB-mese |
+| **ENI orfane** | `Status: available` (non attaccate a nessuna istanza) | $0 (segnalazione di igiene, non un costo diretto) |
+| **S3 Buckets (no lifecycle)** | Nessuna lifecycle configuration — candidato a rightsizing | Risparmio: ~40% del costo storage Standard (stima — verificare i pattern di accesso prima di agire) |
 
-Ogni finding è anche etichettato `waste` o `optimization`: `waste` è denaro speso ora e contribuisce al totale principale e al gate CI; `optimization` (gp2→gp3, EC2/RDS underutilized) è un'opportunità di risparmio che mantiene la risorsa, mostrata a parte e mai usata come gate. `EC2/RDS Instances (underutilized)` sono inoltre delle *stime* — da verificare prima di agire.
+Ogni finding è anche etichettato `waste` o `optimization`: `waste` è denaro speso ora e contribuisce al totale principale e al gate CI; `optimization` (gp2→gp3, EC2/RDS underutilized, S3 no-lifecycle) è un'opportunità di risparmio che mantiene la risorsa, mostrata a parte e mai usata come gate. `EC2/RDS Instances (underutilized)` e `S3 Buckets (no lifecycle)` sono inoltre delle *stime* — da verificare prima di agire.
 
 > **Nota onesta (rightsizing):** il check di sottoutilizzo è un'euristica su una singola metrica — CPU massima sotto una soglia nella finestra di osservazione, nient'altro. **Non** guarda RAM, throughput di rete, IOPS o numero di connessioni, quindi non può dirti *quale* instance type più piccolo sia davvero adatto. Lo facciamo così perché non richiede permessi IAM aggiuntivi e funziona uguale su ogni account; non sostituiamo [AWS Compute Optimizer](https://aws.amazon.com/compute-optimizer/), che modella più metriche e raccomanda un target specifico. Tratta il nostro finding come "vai a controllare questa istanza", non come una raccomandazione di sizing — verifica con Compute Optimizer (o con le tue metriche) prima di ridimensionare.
 
@@ -503,6 +538,9 @@ node apps/cli/dist/main.js analyze -r us-east-1 eu-west-1
 Se tutto è configurato correttamente vedrai tabelle con le risorse sprecate trovate e il totale stimato. Se un account non ha risorse sprecate vedrai un messaggio "No wasted resources found".
 
 ---
+
+<details>
+<summary><strong>Utilizzo</strong> — flag, esempi, report PDF, gestione errori parziali, prezzi per regione</summary>
 
 ### Utilizzo
 
@@ -598,6 +636,11 @@ Se la scansione di un tipo di risorsa fallisce (es. permessi mancanti su CloudWa
 
 I prezzi sono per-regione (file `prices.json` nell'infrastruttura). Regioni supportate con prezzi specifici: `us-east-1`, `us-west-2`, `eu-west-1`, `eu-central-1`, `ap-southeast-1`, `ap-northeast-1`. Per le altre regioni viene usato il prezzo di default (us-east-1).
 
+</details>
+
+<details>
+<summary><strong>File di configurazione</strong> — campi di <code>cloudrift.config.json</code>, override, tuning falsi positivi</summary>
+
 ### File di configurazione
 
 cloudrift legge `cloudrift.config.json` (o `.cloudriftrc`) dalla directory corrente, oppure il percorso passato con `--config`. I flag CLI hanno la precedenza sul file di config, che a sua volta ha la precedenza sui default. Tutti i campi sono opzionali:
@@ -642,6 +685,11 @@ cloudrift legge `cloudrift.config.json` (o `.cloudriftrc`) dalla directory corre
 > Un NAT Gateway di staging senza traffico nel weekend è il classico falso positivo: allarga `cloudwatchWindowHours` a `168` così un weekend tranquillo non lo segnala.
 > Un workload batch che picca la CPU solo una volta a settimana ha bisogno di un `utilizationWindowHours` più ampio (fino a `336`) per non essere segnalato come sottoutilizzato per via di un campione di 7 giorni troppo tranquillo.
 
+</details>
+
+<details>
+<summary><strong>Fonti dei prezzi</strong> — tabella statica, AWS Pricing API live, tuoi override</summary>
+
 ### Fonti dei prezzi
 
 I costi sono risolti da tre livelli; vince il più specifico, per `(regione, chiave)`:
@@ -653,6 +701,11 @@ I costi sono risolti da tre livelli; vince il più specifico, per `(regione, chi
 Ogni report mostra `prices as of` (la data dello statico, quella del fetch live, o `+ custom overrides`).
 
 > **Nota onesta:** anche con `--live-pricing`, AWS restituisce i prezzi di **listino**, non la *tua* bolletta — Savings Plans, Reserved Instances e sconti EDP non sono riflessi. Gli override `prices` sono l'unico modo per far combaciare il report con ciò che paghi davvero. Tutto ciò che il live non riesce a risolvere in modo univoco ricade sulla tabella statica.
+
+</details>
+
+<details>
+<summary><strong>Uso in CI/CD</strong> — esempio GitHub Actions, gate di budget</summary>
 
 ### Uso in CI/CD
 
@@ -703,6 +756,8 @@ jobs:
 
 Con un `cloudrift.config.json` committato (`{"costAlertThresholdUsd": 500}`), il codice di uscita 2 dell'ultimo step fa fallire il check automaticamente — la pipeline si blocca quando nuove risorse spingono lo spreco oltre la soglia. Una volta pubblicato `@cloudrift/cli`, gli step di build/checkout si riducono a una singola riga `npx @cloudrift/cli@latest analyze …`.
 
+</details>
+
 ### Permessi IAM necessari
 
 Il principal AWS deve avere le seguenti permission in sola lettura:
@@ -717,11 +772,15 @@ Il principal AWS deve avere le seguenti permission in sola lettura:
     "ec2:DescribeSnapshots",
     "ec2:DescribeImages",
     "ec2:DescribeNatGateways",
+    "ec2:DescribeNetworkInterfaces",
     "cloudwatch:GetMetricStatistics",
     "rds:DescribeDBInstances",
     "elasticloadbalancing:DescribeLoadBalancers",
     "elasticloadbalancing:DescribeTargetGroups",
     "elasticloadbalancing:DescribeTargetHealth",
+    "logs:DescribeLogGroups",
+    "s3:ListAllMyBuckets",
+    "s3:GetBucketLifecycleConfiguration",
     "sts:GetCallerIdentity"
   ],
   "Resource": "*"
@@ -729,6 +788,9 @@ Il principal AWS deve avere le seguenti permission in sola lettura:
 ```
 
 > `--live-pricing` richiede in più `pricing:GetProducts` (AWS Pricing API). **Non** serve per il pricing statico di default.
+
+<details>
+<summary><strong>Sviluppo</strong> — modalità watch, test per libreria, lint, typecheck</summary>
 
 ### Sviluppo
 
@@ -751,6 +813,8 @@ pnpm nx run-many -t lint
 # Type check
 pnpm nx run-many -t typecheck
 ```
+
+</details>
 
 ### Rilascio
 

--- a/apps/cli/src/commands/analyze-waste.composition.ts
+++ b/apps/cli/src/commands/analyze-waste.composition.ts
@@ -12,6 +12,9 @@ import {
   EbsIdlePolicy,
   Ec2UnderutilizedPolicy,
   RdsUnderutilizedPolicy,
+  LogGroupWastePolicy,
+  OrphanedEniWastePolicy,
+  S3NoLifecyclePolicy,
 } from 'cloud-cost-domain';
 import type {
   AwsRegion,
@@ -33,6 +36,9 @@ import {
   AwsEbsIdleScanner,
   AwsEc2UnderutilizedScanner,
   AwsRdsUnderutilizedScanner,
+  AwsLogGroupScanner,
+  AwsEniOrphanedScanner,
+  AwsS3NoLifecycleScanner,
   StaticPriceTableAdapter,
   TablePricingAdapter,
   AwsPricingApiAdapter,
@@ -147,6 +153,9 @@ function buildScanners(
       new EbsIdlePolicy(policyOptions, ctx.config.thresholds?.ebsIdleMaxOps ?? 0),
       cloudwatchWindowHours,
     ),
+    new AwsLogGroupScanner(pricing, accountId, new LogGroupWastePolicy(policyOptions)),
+    new AwsEniOrphanedScanner(accountId, new OrphanedEniWastePolicy(policyOptions)),
+    new AwsS3NoLifecycleScanner(pricing, accountId, new S3NoLifecyclePolicy(policyOptions)),
   ];
 
   // Advisory, gated su --live-pricing: il prezzo per instance type/classe RDS

--- a/apps/cli/src/formatters/resource-presenters.ts
+++ b/apps/cli/src/formatters/resource-presenters.ts
@@ -151,6 +151,40 @@ export const presenters: PresenterMap = {
     recommend: (db) =>
       `Review RDS ${db.id} (${db.dbInstanceClass} ${db.engine}) in ${db.region.code} for rightsizing — max CPU ${db.maxCpuPercent.toFixed(1)}% over ${db.windowDays}d (verify storage I/O/connections first)`,
   },
+  'log-group': {
+    title: 'CloudWatch Log Groups — No retention policy',
+    head: ['Log Group', 'Region', 'Stored', 'Created'],
+    colWidths: [190, 70, 70, 84, 85],
+    row: (lg) => [
+      lg.id,
+      lg.region.code,
+      `${(lg.storedBytes / 1024 ** 3).toFixed(1)} GB`,
+      day(lg.creationTime),
+    ],
+    recommend: (lg) =>
+      `Set a retention policy on log group ${lg.id} in ${lg.region.code}`,
+  },
+  'eni-orphaned': {
+    title: 'Orphaned ENIs — Not attached (hygiene, no direct cost)',
+    head: ['Network Interface ID', 'Region', 'VPC', 'Subnet'],
+    colWidths: [160, 80, 130, 130, 80],
+    row: (eni) => [eni.id, eni.region.code, eni.vpcId, eni.subnetId],
+    recommend: (eni) =>
+      `Delete orphaned ENI ${eni.id} in ${eni.region.code} — not attached to any instance`,
+  },
+  's3-no-lifecycle': {
+    title: 'S3 Buckets — No lifecycle policy (rightsizing candidate, verify before acting)',
+    head: ['Bucket', 'Region', 'Size', 'Created'],
+    colWidths: [180, 80, 70, 90, 85],
+    row: (b) => [
+      b.id,
+      b.region.code,
+      `${(b.sizeBytes / 1024 ** 3).toFixed(1)} GB`,
+      day(b.creationDate),
+    ],
+    recommend: (b) =>
+      `Configure a lifecycle policy on bucket ${b.id} in ${b.region.code} — ${(b.sizeBytes / 1024 ** 3).toFixed(1)} GB with no tiering/expiration rule`,
+  },
 };
 
 export function presenterFor(kind: ResourceKind): ResourcePresenter {

--- a/libs/cloud-cost/domain/src/entities/log-group.entity.spec.ts
+++ b/libs/cloud-cost/domain/src/entities/log-group.entity.spec.ts
@@ -1,0 +1,49 @@
+import { LogGroup } from './log-group.entity';
+import type { LogGroupProps } from './log-group.entity';
+import { AwsRegion } from '../value-objects/aws-region.value-object';
+
+const region = AwsRegion.create('eu-west-1');
+
+function makeLogGroup(overrides: Partial<LogGroupProps> = {}): LogGroup {
+  return new LogGroup({
+    logGroupName: '/aws/lambda/my-fn',
+    region,
+    accountId: '123456789012',
+    storedBytes: 1024 ** 3,
+    creationTime: new Date('2024-03-01'),
+    detectedAt: new Date('2026-06-09'),
+    tags: { Env: 'dev' },
+    monthlyCostUsd: 0.03,
+    ...overrides,
+  });
+}
+
+describe('LogGroup', () => {
+  it('exposes correct id and fields', () => {
+    const lg = makeLogGroup();
+    expect(lg.id).toBe('/aws/lambda/my-fn');
+    expect(lg.storedBytes).toBe(1024 ** 3);
+    expect(lg.tags).toEqual({ Env: 'dev' });
+  });
+
+  it('hasRetentionPolicy returns false when retentionInDays is undefined', () => {
+    expect(makeLogGroup({ retentionInDays: undefined }).hasRetentionPolicy()).toBe(false);
+  });
+
+  it('hasRetentionPolicy returns true when retentionInDays is set', () => {
+    expect(makeLogGroup({ retentionInDays: 14 }).hasRetentionPolicy()).toBe(true);
+  });
+
+  it('exposes kind and wasteReason', () => {
+    expect(makeLogGroup().kind).toBe('log-group');
+    expect(makeLogGroup().wasteReason).toContain('retention');
+  });
+
+  it('costEstimate returns the stored monthlyCostUsd', () => {
+    expect(makeLogGroup().costEstimate.monthlyCostUsd).toBe(0.03);
+  });
+
+  it('costEstimate description references the stored size', () => {
+    expect(makeLogGroup().costEstimate.description).toContain('GB');
+  });
+});

--- a/libs/cloud-cost/domain/src/entities/log-group.entity.ts
+++ b/libs/cloud-cost/domain/src/entities/log-group.entity.ts
@@ -1,0 +1,44 @@
+import { Entity } from 'shared-kernel';
+import { AwsRegion } from '../value-objects/aws-region.value-object';
+import { CostEstimate } from '../value-objects/cost-estimate.value-object';
+import type { WastedResource } from '../wasted-resource';
+
+export interface LogGroupProps {
+  logGroupName: string;
+  region: AwsRegion;
+  accountId: string;
+  storedBytes: number;
+  retentionInDays?: number;
+  creationTime: Date;
+  detectedAt: Date;
+  tags: Record<string, string>;
+  monthlyCostUsd: number;
+}
+
+export class LogGroup extends Entity<string> implements WastedResource {
+  private readonly props: Readonly<LogGroupProps>;
+
+  constructor(props: LogGroupProps) {
+    super(props.logGroupName);
+    this.props = Object.freeze({ ...props });
+  }
+
+  get region(): AwsRegion { return this.props.region; }
+  get accountId(): string { return this.props.accountId; }
+  get storedBytes(): number { return this.props.storedBytes; }
+  get creationTime(): Date { return this.props.creationTime; }
+  get detectedAt(): Date { return this.props.detectedAt; }
+  get tags(): Record<string, string> { return this.props.tags; }
+
+  get kind(): 'log-group' { return 'log-group'; }
+  get wasteReason(): string { return 'no retention policy'; }
+
+  hasRetentionPolicy(): boolean {
+    return this.props.retentionInDays !== undefined;
+  }
+
+  get costEstimate(): CostEstimate {
+    const storedGb = (this.props.storedBytes / 1024 ** 3).toFixed(2);
+    return CostEstimate.of(this.props.monthlyCostUsd, `${storedGb} GB CW logs (no retention)`);
+  }
+}

--- a/libs/cloud-cost/domain/src/entities/orphaned-eni.entity.spec.ts
+++ b/libs/cloud-cost/domain/src/entities/orphaned-eni.entity.spec.ts
@@ -1,0 +1,46 @@
+import { OrphanedEni } from './orphaned-eni.entity';
+import type { OrphanedEniProps } from './orphaned-eni.entity';
+import { AwsRegion } from '../value-objects/aws-region.value-object';
+
+const region = AwsRegion.create('eu-west-1');
+
+function makeEni(overrides: Partial<OrphanedEniProps> = {}): OrphanedEni {
+  return new OrphanedEni({
+    networkInterfaceId: 'eni-0abc123',
+    region,
+    accountId: '123456789012',
+    vpcId: 'vpc-0123456789',
+    subnetId: 'subnet-0123456789',
+    status: 'available',
+    detectedAt: new Date('2026-06-09'),
+    tags: { Env: 'dev' },
+    ...overrides,
+  });
+}
+
+describe('OrphanedEni', () => {
+  it('exposes correct id and fields', () => {
+    const eni = makeEni();
+    expect(eni.id).toBe('eni-0abc123');
+    expect(eni.vpcId).toBe('vpc-0123456789');
+    expect(eni.subnetId).toBe('subnet-0123456789');
+    expect(eni.tags).toEqual({ Env: 'dev' });
+  });
+
+  it('isOrphaned returns true when status is available', () => {
+    expect(makeEni({ status: 'available' }).isOrphaned()).toBe(true);
+  });
+
+  it('isOrphaned returns false when status is in-use', () => {
+    expect(makeEni({ status: 'in-use' }).isOrphaned()).toBe(false);
+  });
+
+  it('exposes kind and wasteReason', () => {
+    expect(makeEni().kind).toBe('eni-orphaned');
+    expect(makeEni().wasteReason).toContain('not attached');
+  });
+
+  it('costEstimate is zero (hygiene flag, no direct cost)', () => {
+    expect(makeEni().costEstimate.monthlyCostUsd).toBe(0);
+  });
+});

--- a/libs/cloud-cost/domain/src/entities/orphaned-eni.entity.ts
+++ b/libs/cloud-cost/domain/src/entities/orphaned-eni.entity.ts
@@ -1,0 +1,49 @@
+import { Entity } from 'shared-kernel';
+import { AwsRegion } from '../value-objects/aws-region.value-object';
+import { CostEstimate } from '../value-objects/cost-estimate.value-object';
+import type { WastedResource } from '../wasted-resource';
+
+export interface OrphanedEniProps {
+  networkInterfaceId: string;
+  region: AwsRegion;
+  accountId: string;
+  vpcId: string;
+  subnetId: string;
+  status: string;
+  detectedAt: Date;
+  tags: Record<string, string>;
+}
+
+/**
+ * ENI con Status=available (non attaccata a nessuna istanza/ENI requester).
+ * Costo marginale, spesso $0: AWS non fattura le ENI inattive di per sé, ma
+ * accumulano limiti account e indicano automazione/cleanup mancante — è una
+ * segnalazione di igiene, non un risparmio diretto.
+ */
+export class OrphanedEni extends Entity<string> implements WastedResource {
+  private readonly props: Readonly<OrphanedEniProps>;
+
+  constructor(props: OrphanedEniProps) {
+    super(props.networkInterfaceId);
+    this.props = Object.freeze({ ...props });
+  }
+
+  get region(): AwsRegion { return this.props.region; }
+  get accountId(): string { return this.props.accountId; }
+  get vpcId(): string { return this.props.vpcId; }
+  get subnetId(): string { return this.props.subnetId; }
+  get status(): string { return this.props.status; }
+  get detectedAt(): Date { return this.props.detectedAt; }
+  get tags(): Record<string, string> { return this.props.tags; }
+
+  get kind(): 'eni-orphaned' { return 'eni-orphaned'; }
+  get wasteReason(): string { return 'orphaned (not attached)'; }
+
+  isOrphaned(): boolean {
+    return this.props.status === 'available';
+  }
+
+  get costEstimate(): CostEstimate {
+    return CostEstimate.of(0, 'Orphaned ENI (hygiene flag, no direct cost)');
+  }
+}

--- a/libs/cloud-cost/domain/src/entities/s3-bucket.entity.spec.ts
+++ b/libs/cloud-cost/domain/src/entities/s3-bucket.entity.spec.ts
@@ -1,0 +1,50 @@
+import { S3Bucket } from './s3-bucket.entity';
+import type { S3BucketProps } from './s3-bucket.entity';
+import { AwsRegion } from '../value-objects/aws-region.value-object';
+
+const region = AwsRegion.create('eu-west-1');
+
+function makeBucket(overrides: Partial<S3BucketProps> = {}): S3Bucket {
+  return new S3Bucket({
+    bucketName: 'my-bucket',
+    region,
+    accountId: '123456789012',
+    sizeBytes: 1024 ** 3,
+    hasLifecyclePolicy: false,
+    creationDate: new Date('2024-03-01'),
+    detectedAt: new Date('2026-06-09'),
+    tags: { Env: 'dev' },
+    monthlyCostUsd: 0.0092,
+    ...overrides,
+  });
+}
+
+describe('S3Bucket', () => {
+  it('exposes correct id and fields', () => {
+    const bucket = makeBucket();
+    expect(bucket.id).toBe('my-bucket');
+    expect(bucket.sizeBytes).toBe(1024 ** 3);
+    expect(bucket.tags).toEqual({ Env: 'dev' });
+  });
+
+  it('hasLifecyclePolicy returns false when not configured', () => {
+    expect(makeBucket({ hasLifecyclePolicy: false }).hasLifecyclePolicy()).toBe(false);
+  });
+
+  it('hasLifecyclePolicy returns true when configured', () => {
+    expect(makeBucket({ hasLifecyclePolicy: true }).hasLifecyclePolicy()).toBe(true);
+  });
+
+  it('exposes kind and wasteReason', () => {
+    expect(makeBucket().kind).toBe('s3-no-lifecycle');
+    expect(makeBucket().wasteReason).toContain('lifecycle');
+  });
+
+  it('costEstimate returns the stored monthlyCostUsd', () => {
+    expect(makeBucket().costEstimate.monthlyCostUsd).toBe(0.0092);
+  });
+
+  it('costEstimate description references the bucket size', () => {
+    expect(makeBucket().costEstimate.description).toContain('GB');
+  });
+});

--- a/libs/cloud-cost/domain/src/entities/s3-bucket.entity.ts
+++ b/libs/cloud-cost/domain/src/entities/s3-bucket.entity.ts
@@ -1,0 +1,54 @@
+import { Entity } from 'shared-kernel';
+import { AwsRegion } from '../value-objects/aws-region.value-object';
+import { CostEstimate } from '../value-objects/cost-estimate.value-object';
+import type { WastedResource } from '../wasted-resource';
+
+export interface S3BucketProps {
+  bucketName: string;
+  region: AwsRegion;
+  accountId: string;
+  sizeBytes: number;
+  hasLifecyclePolicy: boolean;
+  creationDate: Date;
+  detectedAt: Date;
+  tags: Record<string, string>;
+  /** Stima euristica del risparmio mensile abilitando una lifecycle policy. */
+  monthlyCostUsd: number;
+}
+
+/**
+ * Bucket S3 senza alcuna lifecycle policy configurata. Categoria
+ * `optimization` + `estimated: true`: non sappiamo quanta parte dei dati sia
+ * realmente "fredda", quindi il risparmio è una stima euristica da verificare,
+ * non un valore certo come per `ebs-gp2-upgrade`.
+ */
+export class S3Bucket extends Entity<string> implements WastedResource {
+  private readonly props: Readonly<S3BucketProps>;
+
+  constructor(props: S3BucketProps) {
+    super(props.bucketName);
+    this.props = Object.freeze({ ...props });
+  }
+
+  get region(): AwsRegion { return this.props.region; }
+  get accountId(): string { return this.props.accountId; }
+  get sizeBytes(): number { return this.props.sizeBytes; }
+  get creationDate(): Date { return this.props.creationDate; }
+  get detectedAt(): Date { return this.props.detectedAt; }
+  get tags(): Record<string, string> { return this.props.tags; }
+
+  get kind(): 's3-no-lifecycle' { return 's3-no-lifecycle'; }
+  get wasteReason(): string { return 'no lifecycle policy configured'; }
+
+  hasLifecyclePolicy(): boolean {
+    return this.props.hasLifecyclePolicy;
+  }
+
+  get costEstimate(): CostEstimate {
+    const sizeGb = (this.props.sizeBytes / 1024 ** 3).toFixed(2);
+    return CostEstimate.of(
+      this.props.monthlyCostUsd,
+      `${sizeGb} GB without lifecycle policy (estimated saving)`,
+    );
+  }
+}

--- a/libs/cloud-cost/domain/src/group-by-kind.ts
+++ b/libs/cloud-cost/domain/src/group-by-kind.ts
@@ -10,6 +10,9 @@ import type { Gp2Volume } from './entities/gp2-volume.entity';
 import type { IdleEbsVolume } from './entities/idle-ebs-volume.entity';
 import type { UnderutilizedEc2Instance } from './entities/underutilized-ec2-instance.entity';
 import type { RdsUnderutilizedInstance } from './entities/rds-underutilized-instance.entity';
+import type { LogGroup } from './entities/log-group.entity';
+import type { OrphanedEni } from './entities/orphaned-eni.entity';
+import type { S3Bucket } from './entities/s3-bucket.entity';
 
 /**
  * Mappa kind → entità concreta. Permette ai consumer (formatter, frontend)
@@ -27,6 +30,9 @@ export interface ResourceKindMap {
   'ebs-idle': IdleEbsVolume;
   'ec2-underutilized': UnderutilizedEc2Instance;
   'rds-underutilized': RdsUnderutilizedInstance;
+  'log-group': LogGroup;
+  'eni-orphaned': OrphanedEni;
+  's3-no-lifecycle': S3Bucket;
 }
 
 export type FindingsByKind = {

--- a/libs/cloud-cost/domain/src/index.ts
+++ b/libs/cloud-cost/domain/src/index.ts
@@ -38,6 +38,12 @@ export { UnderutilizedEc2Instance } from './entities/underutilized-ec2-instance.
 export type { UnderutilizedEc2InstanceProps } from './entities/underutilized-ec2-instance.entity';
 export { RdsUnderutilizedInstance } from './entities/rds-underutilized-instance.entity';
 export type { RdsUnderutilizedInstanceProps } from './entities/rds-underutilized-instance.entity';
+export { LogGroup } from './entities/log-group.entity';
+export type { LogGroupProps } from './entities/log-group.entity';
+export { OrphanedEni } from './entities/orphaned-eni.entity';
+export type { OrphanedEniProps } from './entities/orphaned-eni.entity';
+export { S3Bucket } from './entities/s3-bucket.entity';
+export type { S3BucketProps } from './entities/s3-bucket.entity';
 
 // Value Objects
 export { AwsRegion, InvalidAwsRegionError } from './value-objects/aws-region.value-object';
@@ -64,6 +70,9 @@ export {
   EbsIdlePolicy,
   Ec2UnderutilizedPolicy,
   RdsUnderutilizedPolicy,
+  LogGroupWastePolicy,
+  OrphanedEniWastePolicy,
+  S3NoLifecyclePolicy,
 } from './policies/resource-waste-policies';
 
 // Outbound Ports

--- a/libs/cloud-cost/domain/src/policies/resource-waste-policies.spec.ts
+++ b/libs/cloud-cost/domain/src/policies/resource-waste-policies.spec.ts
@@ -10,6 +10,9 @@ import {
   EbsIdlePolicy,
   Ec2UnderutilizedPolicy,
   RdsUnderutilizedPolicy,
+  LogGroupWastePolicy,
+  OrphanedEniWastePolicy,
+  S3NoLifecyclePolicy,
 } from './resource-waste-policies';
 import { DEFAULT_IGNORE_TAG, DEFAULT_MIN_AGE_DAYS } from './waste-policy';
 import { EbsVolume } from '../entities/ebs-volume.entity';
@@ -25,6 +28,9 @@ import { UnderutilizedEc2Instance } from '../entities/underutilized-ec2-instance
 import type { UnderutilizedEc2InstanceProps } from '../entities/underutilized-ec2-instance.entity';
 import { RdsUnderutilizedInstance } from '../entities/rds-underutilized-instance.entity';
 import type { RdsUnderutilizedInstanceProps } from '../entities/rds-underutilized-instance.entity';
+import { LogGroup } from '../entities/log-group.entity';
+import { OrphanedEni } from '../entities/orphaned-eni.entity';
+import { S3Bucket } from '../entities/s3-bucket.entity';
 import type { EbsSnapshotProps } from '../entities/ebs-snapshot.entity';
 import type { Ec2InstanceProps } from '../entities/ec2-instance.entity';
 import { AwsRegion } from '../value-objects/aws-region.value-object';
@@ -529,5 +535,96 @@ describe('RdsUnderutilizedPolicy', () => {
 
   it('includes the rightsizing advisory in the wasteReason', () => {
     expect(makeInstance().wasteReason).toContain('verify storage I/O and connections before rightsizing');
+  });
+});
+
+describe('LogGroupWastePolicy', () => {
+  const policy = new LogGroupWastePolicy();
+
+  function makeGroup(retentionInDays?: number, creationTime = oldDate): LogGroup {
+    return new LogGroup({
+      logGroupName: '/aws/lambda/my-fn',
+      region,
+      accountId: '123456789012',
+      storedBytes: 1024 ** 3,
+      retentionInDays,
+      creationTime,
+      detectedAt: now,
+      tags: {},
+      monthlyCostUsd: 0.03,
+    });
+  }
+
+  it('flags an old log group with no retention policy', () => {
+    expect(policy.evaluate(makeGroup(undefined), now).isWaste).toBe(true);
+  });
+
+  it('does not flag a log group with a retention policy', () => {
+    expect(policy.evaluate(makeGroup(14), now).isWaste).toBe(false);
+  });
+
+  it('does not flag a freshly created log group (grace period)', () => {
+    expect(policy.evaluate(makeGroup(undefined, yesterday), now).isWaste).toBe(false);
+  });
+});
+
+describe('OrphanedEniWastePolicy', () => {
+  const policy = new OrphanedEniWastePolicy();
+
+  function makeEni(status: string, tags: Record<string, string> = {}): OrphanedEni {
+    return new OrphanedEni({
+      networkInterfaceId: 'eni-1',
+      region,
+      accountId: '123456789012',
+      vpcId: 'vpc-1',
+      subnetId: 'subnet-1',
+      status,
+      detectedAt: now,
+      tags,
+    });
+  }
+
+  it('flags an available (unattached) ENI', () => {
+    expect(policy.evaluate(makeEni('available'), now).isWaste).toBe(true);
+  });
+
+  it('does not flag an in-use ENI', () => {
+    expect(policy.evaluate(makeEni('in-use'), now).isWaste).toBe(false);
+  });
+
+  it('does not flag an ENI carrying the ignore tag', () => {
+    expect(
+      policy.evaluate(makeEni('available', { [DEFAULT_IGNORE_TAG]: 'true' }), now).isWaste,
+    ).toBe(false);
+  });
+});
+
+describe('S3NoLifecyclePolicy', () => {
+  const policy = new S3NoLifecyclePolicy();
+
+  function makeBucket(hasLifecyclePolicy: boolean, creationDate = oldDate): S3Bucket {
+    return new S3Bucket({
+      bucketName: 'my-bucket',
+      region,
+      accountId: '123456789012',
+      sizeBytes: 1024 ** 3,
+      hasLifecyclePolicy,
+      creationDate,
+      detectedAt: now,
+      tags: {},
+      monthlyCostUsd: 0.0092,
+    });
+  }
+
+  it('flags an old bucket with no lifecycle policy', () => {
+    expect(policy.evaluate(makeBucket(false), now).isWaste).toBe(true);
+  });
+
+  it('does not flag a bucket with a lifecycle policy', () => {
+    expect(policy.evaluate(makeBucket(true), now).isWaste).toBe(false);
+  });
+
+  it('does not flag a freshly created bucket (grace period)', () => {
+    expect(policy.evaluate(makeBucket(false, yesterday), now).isWaste).toBe(false);
   });
 });

--- a/libs/cloud-cost/domain/src/policies/resource-waste-policies.ts
+++ b/libs/cloud-cost/domain/src/policies/resource-waste-policies.ts
@@ -10,6 +10,9 @@ import type { Gp2Volume } from '../entities/gp2-volume.entity';
 import type { IdleEbsVolume } from '../entities/idle-ebs-volume.entity';
 import type { UnderutilizedEc2Instance } from '../entities/underutilized-ec2-instance.entity';
 import type { RdsUnderutilizedInstance } from '../entities/rds-underutilized-instance.entity';
+import type { LogGroup } from '../entities/log-group.entity';
+import type { OrphanedEni } from '../entities/orphaned-eni.entity';
+import type { S3Bucket } from '../entities/s3-bucket.entity';
 
 export class EbsVolumeWastePolicy extends WastePolicy<EbsVolume> {
   protected judge(volume: EbsVolume, now: Date): WasteVerdict {
@@ -131,6 +134,33 @@ export class RdsUnderutilizedPolicy extends WastePolicy<RdsUnderutilizedInstance
       return notWaste(`created less than ${this.minAgeDays}d ago`);
     }
     return waste(`max CPU ${instance.maxCpuPercent.toFixed(1)}% over ${instance.windowDays}d`);
+  }
+}
+
+export class LogGroupWastePolicy extends WastePolicy<LogGroup> {
+  protected judge(group: LogGroup, now: Date): WasteVerdict {
+    if (group.hasRetentionPolicy()) return notWaste('retention policy configured');
+    if (this.isWithinGracePeriod(group.creationTime, now)) {
+      return notWaste(`created less than ${this.minAgeDays}d ago`);
+    }
+    return waste('no retention policy');
+  }
+}
+
+export class OrphanedEniWastePolicy extends WastePolicy<OrphanedEni> {
+  protected judge(eni: OrphanedEni): WasteVerdict {
+    // Le ENI non espongono una data di creazione: nessun periodo di grazia applicabile.
+    return eni.isOrphaned() ? waste('not attached') : notWaste('attached');
+  }
+}
+
+export class S3NoLifecyclePolicy extends WastePolicy<S3Bucket> {
+  protected judge(bucket: S3Bucket, now: Date): WasteVerdict {
+    if (bucket.hasLifecyclePolicy()) return notWaste('lifecycle policy configured');
+    if (this.isWithinGracePeriod(bucket.creationDate, now)) {
+      return notWaste(`created less than ${this.minAgeDays}d ago`);
+    }
+    return waste('no lifecycle policy');
   }
 }
 

--- a/libs/cloud-cost/domain/src/ports/outbound/pricing.port.ts
+++ b/libs/cloud-cost/domain/src/ports/outbound/pricing.port.ts
@@ -7,6 +7,8 @@ export interface PricingPort {
   getRdsStoragePricePerGbMonth(region: AwsRegion, storageType: string): number;
   getLoadBalancerPricePerMonth(region: AwsRegion): number;
   getNatGatewayPricePerMonth(region: AwsRegion): number;
+  getLogGroupPricePerGbMonth(region: AwsRegion): number;
+  getS3StandardPricePerGbMonth(region: AwsRegion): number;
   /** Data (YYYY-MM) dell'ultima verifica dei prezzi: va mostrata in ogni report. */
   getPricesAsOf(): string;
 }

--- a/libs/cloud-cost/domain/src/wasted-resource.ts
+++ b/libs/cloud-cost/domain/src/wasted-resource.ts
@@ -13,6 +13,9 @@ export const RESOURCE_KINDS = [
   'ebs-idle',
   'ec2-underutilized',
   'rds-underutilized',
+  'log-group',
+  'eni-orphaned',
+  's3-no-lifecycle',
 ] as const;
 
 export type ResourceKind = (typeof RESOURCE_KINDS)[number];
@@ -53,6 +56,9 @@ export const RESOURCE_KIND_META: Record<ResourceKind, ResourceKindMeta> = {
     category: 'optimization',
     estimated: true,
   },
+  'log-group': { label: 'CloudWatch Log Groups', category: 'waste', estimated: false },
+  'eni-orphaned': { label: 'Orphaned ENIs', category: 'waste', estimated: false },
+  's3-no-lifecycle': { label: 'S3 Buckets (no lifecycle)', category: 'optimization', estimated: true },
 };
 
 /** Etichette leggibili, derivate da RESOURCE_KIND_META (unica fonte). */

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/index.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/index.ts
@@ -11,6 +11,9 @@ export { AwsEc2UnderutilizedScanner } from './scanners/aws-ec2-underutilized.sca
 export type { Ec2InstancePricingSource } from './scanners/aws-ec2-underutilized.scanner';
 export { AwsRdsUnderutilizedScanner } from './scanners/aws-rds-underutilized.scanner';
 export type { RdsInstancePricingSource } from './scanners/aws-rds-underutilized.scanner';
+export { AwsLogGroupScanner } from './scanners/aws-log-group.scanner';
+export { AwsEniOrphanedScanner } from './scanners/aws-eni-orphaned.scanner';
+export { AwsS3NoLifecycleScanner } from './scanners/aws-s3-no-lifecycle.scanner';
 export { AwsAdapterError } from './errors/aws-adapter.error';
 export {
   StaticPriceTableAdapter,

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/pricing/prices.json
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/pricing/prices.json
@@ -17,7 +17,9 @@
     "rds-io2":       0.125,
     "rds-standard":  0.100,
     "load-balancer": 16.200,
-    "nat-gateway":   32.400
+    "nat-gateway":   32.400,
+    "cw-logs":       0.030,
+    "s3-standard":   0.023
   },
   "us-east-1": {
     "ebs-gp2":       0.100,
@@ -26,7 +28,9 @@
     "elastic-ip":    3.600,
     "rds-gp2":       0.115,
     "load-balancer": 16.200,
-    "nat-gateway":   32.400
+    "nat-gateway":   32.400,
+    "cw-logs":       0.030,
+    "s3-standard":   0.023
   },
   "us-west-2": {
     "ebs-gp2":       0.100,
@@ -35,7 +39,9 @@
     "elastic-ip":    3.600,
     "rds-gp2":       0.115,
     "load-balancer": 16.200,
-    "nat-gateway":   32.400
+    "nat-gateway":   32.400,
+    "cw-logs":       0.030,
+    "s3-standard":   0.023
   },
   "eu-west-1": {
     "ebs-gp2":       0.110,
@@ -44,7 +50,9 @@
     "elastic-ip":    3.960,
     "rds-gp2":       0.128,
     "load-balancer": 18.400,
-    "nat-gateway":   36.720
+    "nat-gateway":   36.720,
+    "cw-logs":       0.033,
+    "s3-standard":   0.024
   },
   "eu-central-1": {
     "ebs-gp2":       0.119,
@@ -53,7 +61,9 @@
     "elastic-ip":    3.960,
     "rds-gp2":       0.138,
     "load-balancer": 18.980,
-    "nat-gateway":   38.880
+    "nat-gateway":   38.880,
+    "cw-logs":       0.033,
+    "s3-standard":   0.0245
   },
   "ap-southeast-1": {
     "ebs-gp2":       0.114,
@@ -63,7 +73,9 @@
     "elastic-ip":    3.960,
     "rds-gp2":       0.131,
     "load-balancer": 18.250,
-    "nat-gateway":   36.792
+    "nat-gateway":   36.792,
+    "cw-logs":       0.033,
+    "s3-standard":   0.025
   },
   "ap-northeast-1": {
     "ebs-gp2":       0.120,
@@ -72,6 +84,8 @@
     "elastic-ip":    3.960,
     "rds-gp2":       0.142,
     "load-balancer": 19.710,
-    "nat-gateway":   38.880
+    "nat-gateway":   38.880,
+    "cw-logs":       0.033,
+    "s3-standard":   0.025
   }
 }

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/pricing/table-pricing.adapter.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/pricing/table-pricing.adapter.ts
@@ -63,6 +63,14 @@ export class TablePricingAdapter implements PricingPort {
     return this.lookup(region, 'nat-gateway') ?? 0;
   }
 
+  getLogGroupPricePerGbMonth(region: AwsRegion): number {
+    return this.lookup(region, 'cw-logs') ?? 0;
+  }
+
+  getS3StandardPricePerGbMonth(region: AwsRegion): number {
+    return this.lookup(region, 's3-standard') ?? 0;
+  }
+
   getPricesAsOf(): string {
     return this.pricesAsOf;
   }

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-eni-orphaned.scanner.spec.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-eni-orphaned.scanner.spec.ts
@@ -1,0 +1,65 @@
+import { EC2Client, DescribeNetworkInterfacesCommand } from '@aws-sdk/client-ec2';
+import { AwsEniOrphanedScanner } from './aws-eni-orphaned.scanner';
+import { AwsRegion } from 'cloud-cost-domain';
+import { AwsAdapterError } from '../errors/aws-adapter.error';
+
+jest.mock('@aws-sdk/client-ec2');
+
+const mockSend = jest.fn();
+const mockDestroy = jest.fn();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (EC2Client as jest.Mock).mockImplementation(() => ({
+    send: mockSend,
+    destroy: mockDestroy,
+  }));
+});
+
+const region = AwsRegion.create('us-east-1');
+const scanner = new AwsEniOrphanedScanner();
+
+describe('AwsEniOrphanedScanner', () => {
+  it('exposes its resource kind', () => {
+    expect(scanner.kind).toBe('eni-orphaned');
+  });
+
+  it('reports an available (unattached) ENI', async () => {
+    mockSend.mockResolvedValueOnce({
+      NetworkInterfaces: [
+        {
+          NetworkInterfaceId: 'eni-1',
+          VpcId: 'vpc-1',
+          SubnetId: 'subnet-1',
+          Status: 'available',
+        },
+      ],
+    });
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.map((eni) => eni.id)).toEqual(['eni-1']);
+    expect(result.value[0].costEstimate.monthlyCostUsd).toBe(0);
+  });
+
+  it('filters by status=available server-side', async () => {
+    mockSend.mockResolvedValueOnce({ NetworkInterfaces: [] });
+
+    await scanner.scan(region);
+
+    const args = (DescribeNetworkInterfacesCommand as unknown as jest.Mock).mock.calls[0][0];
+    expect(args.Filters).toEqual([{ Name: 'status', Values: ['available'] }]);
+  });
+
+  it('returns Result.fail wrapping AwsAdapterError and destroys the client on error', async () => {
+    mockSend.mockRejectedValueOnce(new Error('boom'));
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect((result.error as AwsAdapterError).service).toBe('EC2');
+    expect(mockDestroy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-eni-orphaned.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-eni-orphaned.scanner.ts
@@ -1,0 +1,62 @@
+import {
+  EC2Client,
+  DescribeNetworkInterfacesCommand,
+  type NetworkInterface,
+} from '@aws-sdk/client-ec2';
+import { Result } from 'shared-kernel';
+import type { AwsRegion, WasteScannerPort, WastedResource } from 'cloud-cost-domain';
+import { OrphanedEni, OrphanedEniWastePolicy } from 'cloud-cost-domain';
+import { AwsAdapterError } from '../errors/aws-adapter.error';
+import { paginate } from '../utils/paginate';
+
+/**
+ * Rileva le ENI con Status=available (non attaccate). Nessun costo diretto
+ * (AWS non fattura le ENI inattive), ma segnala automazione/cleanup mancante.
+ */
+export class AwsEniOrphanedScanner implements WasteScannerPort {
+  readonly kind = 'eni-orphaned' as const;
+
+  constructor(
+    private readonly accountId = 'unknown',
+    private readonly policy = new OrphanedEniWastePolicy(),
+  ) {}
+
+  async scan(region: AwsRegion): Promise<Result<WastedResource[]>> {
+    const client = new EC2Client({ region: region.code });
+    try {
+      const rawEnis = await paginate<NetworkInterface>(async (cursor) => {
+        const r = await client.send(
+          new DescribeNetworkInterfacesCommand({
+            Filters: [{ Name: 'status', Values: ['available'] }],
+            NextToken: cursor,
+          }),
+        );
+        return { items: r.NetworkInterfaces ?? [], cursor: r.NextToken };
+      });
+
+      const now = new Date();
+      const enis = rawEnis
+        .map((eni) =>
+          new OrphanedEni({
+            networkInterfaceId: eni.NetworkInterfaceId!,
+            region,
+            accountId: this.accountId,
+            vpcId: eni.VpcId ?? 'unknown',
+            subnetId: eni.SubnetId ?? 'unknown',
+            status: eni.Status ?? 'available',
+            detectedAt: now,
+            tags: Object.fromEntries(
+              (eni.TagSet ?? []).map((t) => [t.Key ?? '', t.Value ?? '']),
+            ),
+          }),
+        )
+        .filter((eni) => this.policy.evaluate(eni, now).isWaste);
+
+      return Result.ok(enis);
+    } catch (err) {
+      return Result.fail(new AwsAdapterError('EC2', err as Error));
+    } finally {
+      client.destroy();
+    }
+  }
+}

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-log-group.scanner.spec.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-log-group.scanner.spec.ts
@@ -1,0 +1,92 @@
+import { CloudWatchLogsClient } from '@aws-sdk/client-cloudwatch-logs';
+import { AwsLogGroupScanner } from './aws-log-group.scanner';
+import { AwsRegion } from 'cloud-cost-domain';
+import { AwsAdapterError } from '../errors/aws-adapter.error';
+import { mockPricing } from '../testing/mock-pricing';
+
+jest.mock('@aws-sdk/client-cloudwatch-logs');
+
+const mockSend = jest.fn();
+const mockDestroy = jest.fn();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (CloudWatchLogsClient as jest.Mock).mockImplementation(() => ({
+    send: mockSend,
+    destroy: mockDestroy,
+  }));
+});
+
+const region = AwsRegion.create('us-east-1');
+const scanner = new AwsLogGroupScanner(mockPricing);
+const OLD_DATE = new Date('2024-03-01');
+
+describe('AwsLogGroupScanner', () => {
+  it('exposes its resource kind', () => {
+    expect(scanner.kind).toBe('log-group');
+  });
+
+  it('reports an old log group with no retention policy', async () => {
+    mockSend.mockResolvedValueOnce({
+      logGroups: [
+        {
+          logGroupName: '/aws/lambda/my-fn',
+          storedBytes: 1024 ** 3,
+          creationTime: OLD_DATE.getTime(),
+        },
+      ],
+    });
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.map((lg) => lg.id)).toEqual(['/aws/lambda/my-fn']);
+    expect(result.value[0].costEstimate.monthlyCostUsd).toBeCloseTo(0.03, 2);
+  });
+
+  it('does not report a log group with a retention policy', async () => {
+    mockSend.mockResolvedValueOnce({
+      logGroups: [
+        {
+          logGroupName: '/aws/lambda/with-retention',
+          storedBytes: 1024 ** 3,
+          retentionInDays: 14,
+          creationTime: OLD_DATE.getTime(),
+        },
+      ],
+    });
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toHaveLength(0);
+  });
+
+  it('does not report a freshly created log group (grace period)', async () => {
+    mockSend.mockResolvedValueOnce({
+      logGroups: [
+        {
+          logGroupName: '/aws/lambda/new-fn',
+          storedBytes: 1024 ** 3,
+          creationTime: new Date().getTime(),
+        },
+      ],
+    });
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toHaveLength(0);
+  });
+
+  it('returns Result.fail wrapping AwsAdapterError and destroys the client on error', async () => {
+    mockSend.mockRejectedValueOnce(new Error('boom'));
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect((result.error as AwsAdapterError).service).toBe('CloudWatchLogs');
+    expect(mockDestroy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-log-group.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-log-group.scanner.ts
@@ -1,0 +1,56 @@
+import {
+  CloudWatchLogsClient,
+  DescribeLogGroupsCommand,
+  type LogGroup as AwsLogGroup,
+} from '@aws-sdk/client-cloudwatch-logs';
+import { Result } from 'shared-kernel';
+import type { AwsRegion, PricingPort, WasteScannerPort, WastedResource } from 'cloud-cost-domain';
+import { LogGroup, LogGroupWastePolicy } from 'cloud-cost-domain';
+import { AwsAdapterError } from '../errors/aws-adapter.error';
+import { paginate } from '../utils/paginate';
+
+export class AwsLogGroupScanner implements WasteScannerPort {
+  readonly kind = 'log-group' as const;
+
+  constructor(
+    private readonly pricing: PricingPort,
+    private readonly accountId = 'unknown',
+    private readonly policy = new LogGroupWastePolicy(),
+  ) {}
+
+  async scan(region: AwsRegion): Promise<Result<WastedResource[]>> {
+    const client = new CloudWatchLogsClient({ region: region.code });
+    try {
+      const rawGroups = await paginate<AwsLogGroup>(async (cursor) => {
+        const r = await client.send(new DescribeLogGroupsCommand({ nextToken: cursor }));
+        return { items: r.logGroups ?? [], cursor: r.nextToken };
+      });
+
+      const pricePerGb = this.pricing.getLogGroupPricePerGbMonth(region);
+      const now = new Date();
+
+      const groups = rawGroups
+        .map((lg) => {
+          const storedBytes = lg.storedBytes ?? 0;
+          return new LogGroup({
+            logGroupName: lg.logGroupName!,
+            region,
+            accountId: this.accountId,
+            storedBytes,
+            retentionInDays: lg.retentionInDays,
+            creationTime: lg.creationTime ? new Date(lg.creationTime) : new Date(0),
+            detectedAt: now,
+            tags: {},
+            monthlyCostUsd: +((storedBytes / 1024 ** 3) * pricePerGb).toFixed(4),
+          });
+        })
+        .filter((group) => this.policy.evaluate(group, now).isWaste);
+
+      return Result.ok(groups);
+    } catch (err) {
+      return Result.fail(new AwsAdapterError('CloudWatchLogs', err as Error));
+    } finally {
+      client.destroy();
+    }
+  }
+}

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-s3-no-lifecycle.scanner.spec.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-s3-no-lifecycle.scanner.spec.ts
@@ -1,0 +1,131 @@
+import { S3Client, ListBucketsCommand } from '@aws-sdk/client-s3';
+import { CloudWatchClient, GetMetricStatisticsCommand } from '@aws-sdk/client-cloudwatch';
+import { AwsS3NoLifecycleScanner } from './aws-s3-no-lifecycle.scanner';
+import { AwsRegion } from 'cloud-cost-domain';
+import { AwsAdapterError } from '../errors/aws-adapter.error';
+import { mockPricing } from '../testing/mock-pricing';
+
+jest.mock('@aws-sdk/client-s3');
+jest.mock('@aws-sdk/client-cloudwatch');
+
+const mockS3Send = jest.fn();
+const mockS3Destroy = jest.fn();
+const mockCwSend = jest.fn();
+const mockCwDestroy = jest.fn();
+
+function noSuchLifecycleError(): Error {
+  const err = new Error('The lifecycle configuration does not exist');
+  err.name = 'NoSuchLifecycleConfiguration';
+  return err;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (S3Client as jest.Mock).mockImplementation(() => ({
+    send: mockS3Send,
+    destroy: mockS3Destroy,
+  }));
+  (CloudWatchClient as jest.Mock).mockImplementation(() => ({
+    send: mockCwSend,
+    destroy: mockCwDestroy,
+  }));
+});
+
+const region = AwsRegion.create('us-east-1');
+const scanner = new AwsS3NoLifecycleScanner(mockPricing);
+const OLD_DATE = new Date('2024-03-01');
+
+describe('AwsS3NoLifecycleScanner', () => {
+  it('exposes its resource kind', () => {
+    expect(scanner.kind).toBe('s3-no-lifecycle');
+  });
+
+  it('reports an old bucket with no lifecycle policy', async () => {
+    mockS3Send
+      .mockResolvedValueOnce({ Buckets: [{ Name: 'my-bucket', CreationDate: OLD_DATE }] })
+      .mockRejectedValueOnce(noSuchLifecycleError());
+    mockCwSend.mockResolvedValueOnce({ Datapoints: [{ Average: 1024 ** 3 }] });
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.map((b) => b.id)).toEqual(['my-bucket']);
+  });
+
+  it('does not report a bucket with a lifecycle policy configured', async () => {
+    mockS3Send
+      .mockResolvedValueOnce({ Buckets: [{ Name: 'my-bucket', CreationDate: OLD_DATE }] })
+      .mockResolvedValueOnce({ Rules: [{ ID: 'expire-old', Status: 'Enabled' }] });
+    mockCwSend.mockResolvedValueOnce({ Datapoints: [{ Average: 1024 ** 3 }] });
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toHaveLength(0);
+  });
+
+  it('does not report a freshly created bucket (grace period)', async () => {
+    mockS3Send
+      .mockResolvedValueOnce({ Buckets: [{ Name: 'new-bucket', CreationDate: new Date() }] })
+      .mockRejectedValueOnce(noSuchLifecycleError());
+    mockCwSend.mockResolvedValueOnce({ Datapoints: [{ Average: 1024 ** 3 }] });
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toHaveLength(0);
+  });
+
+  it('filters ListBuckets by BucketRegion', async () => {
+    mockS3Send.mockResolvedValueOnce({ Buckets: [] });
+
+    await scanner.scan(region);
+
+    const args = (ListBucketsCommand as unknown as jest.Mock).mock.calls[0][0];
+    expect(args.BucketRegion).toBe('us-east-1');
+    expect(mockCwSend).not.toHaveBeenCalled();
+  });
+
+  it('queries the BucketSizeBytes metric per bucket', async () => {
+    mockS3Send
+      .mockResolvedValueOnce({ Buckets: [{ Name: 'my-bucket', CreationDate: OLD_DATE }] })
+      .mockRejectedValueOnce(noSuchLifecycleError());
+    mockCwSend.mockResolvedValueOnce({ Datapoints: [] });
+
+    await scanner.scan(region);
+
+    const cwArgs = (GetMetricStatisticsCommand as unknown as jest.Mock).mock.calls[0][0];
+    expect(cwArgs.Namespace).toBe('AWS/S3');
+    expect(cwArgs.MetricName).toBe('BucketSizeBytes');
+    expect(cwArgs.Dimensions).toEqual([
+      { Name: 'BucketName', Value: 'my-bucket' },
+      { Name: 'StorageType', Value: 'StandardStorage' },
+    ]);
+  });
+
+  it('rethrows lifecycle errors that are not NoSuchLifecycleConfiguration', async () => {
+    mockS3Send
+      .mockResolvedValueOnce({ Buckets: [{ Name: 'my-bucket', CreationDate: OLD_DATE }] })
+      .mockRejectedValueOnce(new Error('access denied'));
+    mockCwSend.mockResolvedValueOnce({ Datapoints: [] });
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect((result.error as AwsAdapterError).service).toBe('S3');
+    expect(mockS3Destroy).toHaveBeenCalledTimes(1);
+    expect(mockCwDestroy).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns Result.fail wrapping AwsAdapterError and destroys both clients on error', async () => {
+    mockS3Send.mockRejectedValueOnce(new Error('boom'));
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect((result.error as AwsAdapterError).service).toBe('S3');
+    expect(mockS3Destroy).toHaveBeenCalledTimes(1);
+    expect(mockCwDestroy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-s3-no-lifecycle.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-s3-no-lifecycle.scanner.ts
@@ -1,0 +1,118 @@
+import {
+  S3Client,
+  ListBucketsCommand,
+  GetBucketLifecycleConfigurationCommand,
+  type Bucket,
+} from '@aws-sdk/client-s3';
+import {
+  CloudWatchClient,
+  GetMetricStatisticsCommand,
+} from '@aws-sdk/client-cloudwatch';
+import { Result } from 'shared-kernel';
+import type { AwsRegion, PricingPort, WasteScannerPort, WastedResource } from 'cloud-cost-domain';
+import { S3Bucket, S3NoLifecyclePolicy } from 'cloud-cost-domain';
+import { AwsAdapterError } from '../errors/aws-adapter.error';
+import { paginate } from '../utils/paginate';
+import { mapWithConcurrency } from '../utils/map-with-concurrency';
+
+const METRIC_CONCURRENCY = 5;
+const METRIC_LOOKBACK_DAYS = 2;
+/** Frazione del costo storage Standard considerata risparmio potenziale abilitando una lifecycle policy (stima euristica). */
+const ESTIMATED_SAVING_FRACTION = 0.4;
+
+/**
+ * Rileva i bucket S3 senza alcuna lifecycle policy configurata. I bucket
+ * sono globali: `ListBucketsCommand` filtra per `BucketRegion` così ogni
+ * regione scansionata vede solo i bucket che le appartengono davvero.
+ */
+export class AwsS3NoLifecycleScanner implements WasteScannerPort {
+  readonly kind = 's3-no-lifecycle' as const;
+
+  constructor(
+    private readonly pricing: PricingPort,
+    private readonly accountId = 'unknown',
+    private readonly policy = new S3NoLifecyclePolicy(),
+  ) {}
+
+  async scan(region: AwsRegion): Promise<Result<WastedResource[]>> {
+    const s3 = new S3Client({ region: region.code });
+    const cw = new CloudWatchClient({ region: region.code });
+    try {
+      const rawBuckets = await paginate<Bucket>(async (cursor) => {
+        const r = await s3.send(
+          new ListBucketsCommand({ BucketRegion: region.code, ContinuationToken: cursor }),
+        );
+        return { items: r.Buckets ?? [], cursor: r.ContinuationToken };
+      });
+
+      if (rawBuckets.length === 0) return Result.ok([]);
+
+      const pricePerGb = this.pricing.getS3StandardPricePerGbMonth(region);
+      const now = new Date();
+
+      const details = await mapWithConcurrency(rawBuckets, METRIC_CONCURRENCY, async (b) => {
+        const name = b.Name!;
+        const [hasLifecyclePolicy, sizeBytes] = await Promise.all([
+          this.hasLifecycle(s3, name),
+          this.sizeBytes(cw, name),
+        ]);
+        return { name, hasLifecyclePolicy, sizeBytes };
+      });
+
+      const buckets = rawBuckets
+        .map((b, index) => {
+          const { hasLifecyclePolicy, sizeBytes } = details[index];
+          const sizeGb = sizeBytes / 1024 ** 3;
+          return new S3Bucket({
+            bucketName: b.Name!,
+            region,
+            accountId: this.accountId,
+            sizeBytes,
+            hasLifecyclePolicy,
+            creationDate: b.CreationDate ?? new Date(0),
+            detectedAt: now,
+            tags: {},
+            monthlyCostUsd: +(sizeGb * pricePerGb * ESTIMATED_SAVING_FRACTION).toFixed(4),
+          });
+        })
+        .filter((bucket) => this.policy.evaluate(bucket, now).isWaste);
+
+      return Result.ok(buckets);
+    } catch (err) {
+      return Result.fail(new AwsAdapterError('S3', err as Error));
+    } finally {
+      s3.destroy();
+      cw.destroy();
+    }
+  }
+
+  private async hasLifecycle(client: S3Client, bucket: string): Promise<boolean> {
+    try {
+      await client.send(new GetBucketLifecycleConfigurationCommand({ Bucket: bucket }));
+      return true;
+    } catch (err) {
+      if ((err as Error).name === 'NoSuchLifecycleConfiguration') return false;
+      throw err;
+    }
+  }
+
+  private async sizeBytes(cw: CloudWatchClient, bucket: string): Promise<number> {
+    const endTime = new Date();
+    const startTime = new Date(endTime.getTime() - METRIC_LOOKBACK_DAYS * 24 * 60 * 60 * 1000);
+    const r = await cw.send(
+      new GetMetricStatisticsCommand({
+        Namespace: 'AWS/S3',
+        MetricName: 'BucketSizeBytes',
+        Dimensions: [
+          { Name: 'BucketName', Value: bucket },
+          { Name: 'StorageType', Value: 'StandardStorage' },
+        ],
+        StartTime: startTime,
+        EndTime: endTime,
+        Period: 86400,
+        Statistics: ['Average'],
+      }),
+    );
+    return r.Datapoints?.[0]?.Average ?? 0;
+  }
+}

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/testing/mock-pricing.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/testing/mock-pricing.ts
@@ -8,5 +8,7 @@ export const mockPricing: PricingPort = {
   getRdsStoragePricePerGbMonth: () => 0.115,
   getLoadBalancerPricePerMonth: () => 16.2,
   getNatGatewayPricePerMonth: () => 32.4,
+  getLogGroupPricePerGbMonth: () => 0.03,
+  getS3StandardPricePerGbMonth: () => 0.023,
   getPricesAsOf: () => '2025-06',
 };

--- a/package.json
+++ b/package.json
@@ -38,10 +38,12 @@
   },
   "dependencies": {
     "@aws-sdk/client-cloudwatch": "^3.741.0",
+    "@aws-sdk/client-cloudwatch-logs": "^3.1073.0",
     "@aws-sdk/client-ec2": "^3.741.0",
     "@aws-sdk/client-elastic-load-balancing-v2": "^3.741.0",
     "@aws-sdk/client-pricing": "^3.1070.0",
     "@aws-sdk/client-rds": "^3.741.0",
+    "@aws-sdk/client-s3": "^3.1073.0",
     "@aws-sdk/client-sts": "^3.1068.0",
     "chalk": "^4.1.2",
     "cli-table3": "^0.6.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@aws-sdk/client-cloudwatch':
         specifier: ^3.741.0
         version: 3.1064.0
+      '@aws-sdk/client-cloudwatch-logs':
+        specifier: ^3.1073.0
+        version: 3.1073.0
       '@aws-sdk/client-ec2':
         specifier: ^3.741.0
         version: 3.1064.0
@@ -23,6 +26,9 @@ importers:
       '@aws-sdk/client-rds':
         specifier: ^3.741.0
         version: 3.1064.0
+      '@aws-sdk/client-s3':
+        specifier: ^3.1073.0
+        version: 3.1073.0
       '@aws-sdk/client-sts':
         specifier: ^3.1068.0
         version: 3.1068.0
@@ -178,6 +184,12 @@ packages:
     resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
     engines: {node: '>=16.0.0'}
 
+  '@aws-crypto/crc32c@5.2.0':
+    resolution: {integrity: sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==}
+
+  '@aws-crypto/sha1-browser@5.2.0':
+    resolution: {integrity: sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==}
+
   '@aws-crypto/sha256-browser@5.2.0':
     resolution: {integrity: sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==}
 
@@ -190,6 +202,14 @@ packages:
 
   '@aws-crypto/util@5.2.0':
     resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
+
+  '@aws-sdk/checksums@3.1000.7':
+    resolution: {integrity: sha512-qh0fG/RtrFztst4+vn1HZehAvAhr5Jlq/WMP7e5KvvfF16oNVBc9CDNVdxdm19vzOY2x0qiDMFCRjhxQAusGWQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-cloudwatch-logs@3.1073.0':
+    resolution: {integrity: sha512-gkBSjPtr45W14QM+uYWsG7Wn8AqtqwxHaZo5zTTA7r6bIbB1tqYRFGEwOlBkGFQboCl0Xp/doCoHZRnaxNHn3A==}
+    engines: {node: '>=20.0.0'}
 
   '@aws-sdk/client-cloudwatch@3.1064.0':
     resolution: {integrity: sha512-65WCnGMcM9whDqsx7a39+PcgdrfJlEHCroxyEIjMSkNWBDuBl/UR8XVdYuaHfRJWOBjxKaQp4NK7j7cOKokJEw==}
@@ -211,6 +231,10 @@ packages:
     resolution: {integrity: sha512-rrdpDGsPPK4hLmXb8e698Y/AXxFFkJI21FY9euSBwcTAs8SCUCcHhJDWiSslb8GkzyVfo56296hTFoZxMr5qGw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/client-s3@3.1073.0':
+    resolution: {integrity: sha512-/Dvhrff0I4D2YUWSdm8uLKa1bfXdw9BMRDUME6ZeoTrrdQKQDeo2scLDjdpC5X2YdvTc/ZnUCR2HAvD7qXvS1w==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/client-sts@3.1068.0':
     resolution: {integrity: sha512-WCUEpfdsSSO7zsXi7GUwHR+A5HZDQNsGktFJxOm73ZU+WLlBKRDzKdWZdYOpNkgBpXxy5KCeVMvXuaq2s1zn7w==}
     engines: {node: '>=20.0.0'}
@@ -227,6 +251,10 @@ packages:
     resolution: {integrity: sha512-P5JAHvn4dTi96UsAGS67LVOqqpUNNRhnfFXqzCYtdBIGZtqBue4CXvRr9YenOO7PALj/Pn8uuyw53FBCiCYw8w==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/core@3.974.22':
+    resolution: {integrity: sha512-YofH63shc6YRdXjz80BJkpJW+Bkn0Cuu2dn4Rv7s9G2Idt58tgtzQEWxrR2xVljlVfIBeUjPuULnSVYLke3sUQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-env@3.972.45':
     resolution: {integrity: sha512-ZPsnLyrpDRmojKrBbJykASyLLVFkjyD+fWATeSuYgaqablijGOzxPxEKyrwUvNg+bgSQ7PkW2FTu65Xco19Gag==}
     engines: {node: '>=20.0.0'}
@@ -237,6 +265,10 @@ packages:
 
   '@aws-sdk/credential-provider-env@3.972.47':
     resolution: {integrity: sha512-3YoPwJczcc+MtX2xxXaYaOOWO6xKUJr1ZIIDIFuninr51BYONVVcF/CP8K2xfVRC/PztJjqKWxNGFH7BWQAw1Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.48':
+    resolution: {integrity: sha512-h6FEC95fbexUd6zxm4PdgS82bTcI2PRtUb2ZwMipb/Xr8bPwtf0G8rBo2jp7NA24Mbx2JA8/WingiYpA9RCCyw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-http@3.972.47':
@@ -251,6 +283,10 @@ packages:
     resolution: {integrity: sha512-2UtGUPy+x3lqyceHrtC1uEuVxBZbDalPF6KAFqBwYgm4edWdBrZKNnCqzDs7KynWUvEC6mrR+ojRk+ZgQz9C2w==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-http@3.972.50':
+    resolution: {integrity: sha512-lJO3OLpjvz5m/RSBQmsG/CEUGsvCy5ruxKwPQaOCqxqCMuyYT2BZwQUTDZVVwqQ9LrZKuK24JSa6r31hL/tvkg==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-ini@3.972.51':
     resolution: {integrity: sha512-f8sRTVyM+9BbzQKPlUP9dVVpgNEu65jFckNAAGzRfCrlaSi5AWUbCKEHIMcIYokv8pWblSKEqHkqKYZtwINnhw==}
     engines: {node: '>=20.0.0'}
@@ -261,6 +297,10 @@ packages:
 
   '@aws-sdk/credential-provider-ini@3.972.54':
     resolution: {integrity: sha512-Hx4gO4YRjFwitf3MVl3cDwYe1aryJthC4txVl9b+JAURovA50M2ywf9r8j1E/Q6SCTPT4qQpjOAbKYIC9CG+Vw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.972.55':
+    resolution: {integrity: sha512-TBoF4buBGYhXjdZAryayY2TrkQj2B2KfE/msG4V53XCt+w0EhEwM2JRjx8p2grJ2C6gtH5++SAwEvGMRdi0yyw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-login@3.972.50':
@@ -275,6 +315,10 @@ packages:
     resolution: {integrity: sha512-+71sluhkgPqdhbbD3UDwUpj24GCkng9HQx6z7qoBFb8dwkF4ktpOcVKDeHpgg8PvBgLYwAnUYLTEGRC/PniCiQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-login@3.972.54':
+    resolution: {integrity: sha512-hBWI3wZTdTGiuMfmPts6AWbAjFfRniOQnqx68tc2cQvRKWawFbN9wkLOVPWM1FAOyowZU73mC6Fi+rHSHNyLFw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-node@3.972.53':
     resolution: {integrity: sha512-z/JJ8Qvf2GiTn4bw+x8k7wQjxmPpNsiwZ7ls/h1cZHikrSpS0+65lB+lafnXZlxv1lqH4k6rQwh+2UsycC662g==}
     engines: {node: '>=20.0.0'}
@@ -285,6 +329,10 @@ packages:
 
   '@aws-sdk/credential-provider-node@3.972.56':
     resolution: {integrity: sha512-iI+4o0dvQQ4NHel4FMDiFy5q2gaU/ryLK3niOsoPccAt9WLFRkV4XTYPWRr9XvmBUqEzXG73S4p/8gm0Lu/W3A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.57':
+    resolution: {integrity: sha512-u6dClpzNdWf1HGWz4wwhdXi1wiOofCLniM9S4BQQGlLAN9TW7VB+ld5V533GdKrYMaFeBGFqKnj0JCYvynLqwQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-process@3.972.45':
@@ -299,6 +347,10 @@ packages:
     resolution: {integrity: sha512-tAizPm9IFo/PHn06c+LQJlzfY2AGOlyF0CUljFejrU6LcZBjnk8pmbZK3/xoIDdnIzjEdbClfvY3mXfr818ZEg==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-process@3.972.48':
+    resolution: {integrity: sha512-w6VZwojPt12WnEkAUy6Nu4K6sWCbBmR7QX390b0nE6vRvkXbrYr9Lq9VySGkfjiMjpUA87op+J4EgvRmtWIDoQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-sso@3.972.50':
     resolution: {integrity: sha512-pQ9ww4G53gwHlon1NMz25JhaBo13E9Jv+VVgjh39C/yzvby+xhSnEOb+VDYShKNCh1TbttMF/5CFCHkZrIqOcA==}
     engines: {node: '>=20.0.0'}
@@ -309,6 +361,10 @@ packages:
 
   '@aws-sdk/credential-provider-sso@3.972.53':
     resolution: {integrity: sha512-pUXE3fu4tfEDV8BksIgf4dXvuIH10FhwHMl/wu8rBD5T1sMpryQWFVitH3kdPS90wlgrGYJQ/meQTSPacyZfeg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.972.54':
+    resolution: {integrity: sha512-23uZpIpF2SIFDCa1fcWa202tK4gGeyvX6GIIAjiB8WBsvsVRBMnJ/7dCxHzxf7eZT7GToJg837LDIBnZsl/VUg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-web-identity@3.972.50':
@@ -323,12 +379,24 @@ packages:
     resolution: {integrity: sha512-JmMGlhVvSj8uSG9CpeDkJAXT35H89tc6v84iMgEIE75q4yp1MKVVKvopv6Gg28HJIR7hMNkojRF8H2m5W44wyg==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-web-identity@3.972.54':
+    resolution: {integrity: sha512-0Iv5QttS6wcATlodYKgvQj6B9Db51rx7NU9fqu0PoLeS4BIgdYMc/QK4smwLwpm5RFrs02V/eLyEFp3FklvlNQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-flexible-checksums@3.974.32':
+    resolution: {integrity: sha512-KhuzFMzUbb3oEj43CdPDbEJ/RG/RkErkmXk3J/LE8OPFNvkCn8PYPMpjOLgzAzvxBacsSyytdWf+R50q0alJ4w==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/middleware-sdk-ec2@3.972.33':
     resolution: {integrity: sha512-RJguNudY1LhEJSRhrmKlRR8e/EpfnrcvGJyJgV+tR8S0BoSJqkWgJP4LGIYTAkTF3ofhw3GaahP7dmPYQV85Sg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/middleware-sdk-rds@3.972.33':
     resolution: {integrity: sha512-PKHKk49oxEAowl01O4W0Iim3AagL57Qsk/RM+u/0ux+QrePAVyhWEvfavKKP0NBMXoIwPUC+Mnws9XRaoBQrIg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-sdk-s3@3.972.53':
+    resolution: {integrity: sha512-keWp6Z5cEIJzPwoCf/WRm0ceAeephPDDivhRsK/xXs2ZYXyypJ2/DL9G1IR0bz/s+iZC0EgzmFV4r7rlvLlxQQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/nested-clients@3.997.18':
@@ -341,6 +409,10 @@ packages:
 
   '@aws-sdk/nested-clients@3.997.21':
     resolution: {integrity: sha512-eC7Vl7Qom/BGhZjG9GEqPwdQ/fk45hg1t5LP4EUxG5d1fdshLbaxCiwh/tszUzDX/4mW40mu2QsbeJJRPBbqUw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/nested-clients@3.997.22':
+    resolution: {integrity: sha512-4IwtcYSxEIVw5hcp8ogq0CMbFNZFw7jJUetpfFUhFFeqsa1K8j2Ihg2hnxLyOp3stMZnXda6VzOmPi1AFZQXcg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/signature-v4-multi-region@3.996.33':
@@ -365,6 +437,10 @@ packages:
 
   '@aws-sdk/token-providers@3.1069.0':
     resolution: {integrity: sha512-ks4X+kngC3PA5howV7Qu1TgG4bfC4jPykKdvw3nmBSXR9yZxRJouBholFSNQ5kY3L+Fgwyw+LCjzQmNi+KR91g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1071.0':
+    resolution: {integrity: sha512-4LDW2Qob6LoLFuqYSYZq2AyTE9koSE9+i+n5UZcm10GpmQOK0zRD9L4uYlzItiTKksIWgC/qMFChAi3RvKYtMg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/types@3.973.12':
@@ -4083,6 +4159,21 @@ snapshots:
       '@aws-sdk/types': 3.973.12
       tslib: 2.8.1
 
+  '@aws-crypto/crc32c@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.13
+      tslib: 2.8.1
+
+  '@aws-crypto/sha1-browser@5.2.0':
+    dependencies:
+      '@aws-crypto/supports-web-crypto': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.13
+      '@aws-sdk/util-locate-window': 3.965.7
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
   '@aws-crypto/sha256-browser@5.2.0':
     dependencies:
       '@aws-crypto/sha256-js': 5.2.0
@@ -4107,6 +4198,30 @@ snapshots:
     dependencies:
       '@aws-sdk/types': 3.973.12
       '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-sdk/checksums@3.1000.7':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@aws-crypto/crc32c': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/core': 3.974.22
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.24.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/client-cloudwatch-logs@3.1073.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.22
+      '@aws-sdk/credential-provider-node': 3.972.57
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.24.6
+      '@smithy/fetch-http-handler': 5.4.6
+      '@smithy/node-http-handler': 4.7.7
+      '@smithy/types': 4.14.3
       tslib: 2.8.1
 
   '@aws-sdk/client-cloudwatch@3.1064.0':
@@ -4177,6 +4292,23 @@ snapshots:
       '@smithy/types': 4.14.3
       tslib: 2.8.1
 
+  '@aws-sdk/client-s3@3.1073.0':
+    dependencies:
+      '@aws-crypto/sha1-browser': 5.2.0
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.22
+      '@aws-sdk/credential-provider-node': 3.972.57
+      '@aws-sdk/middleware-flexible-checksums': 3.974.32
+      '@aws-sdk/middleware-sdk-s3': 3.972.53
+      '@aws-sdk/signature-v4-multi-region': 3.996.35
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.24.6
+      '@smithy/fetch-http-handler': 5.4.6
+      '@smithy/node-http-handler': 4.7.7
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
   '@aws-sdk/client-sts@3.1068.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
@@ -4224,6 +4356,17 @@ snapshots:
       bowser: 2.14.1
       tslib: 2.8.1
 
+  '@aws-sdk/core@3.974.22':
+    dependencies:
+      '@aws-sdk/types': 3.973.13
+      '@aws-sdk/xml-builder': 3.972.30
+      '@aws/lambda-invoke-store': 0.2.4
+      '@smithy/core': 3.24.6
+      '@smithy/signature-v4': 5.4.6
+      '@smithy/types': 4.14.3
+      bowser: 2.14.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-env@3.972.45':
     dependencies:
       '@aws-sdk/core': 3.974.19
@@ -4243,6 +4386,14 @@ snapshots:
   '@aws-sdk/credential-provider-env@3.972.47':
     dependencies:
       '@aws-sdk/core': 3.974.21
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.24.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.48':
+    dependencies:
+      '@aws-sdk/core': 3.974.22
       '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.24.6
       '@smithy/types': 4.14.3
@@ -4271,6 +4422,16 @@ snapshots:
   '@aws-sdk/credential-provider-http@3.972.49':
     dependencies:
       '@aws-sdk/core': 3.974.21
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.24.6
+      '@smithy/fetch-http-handler': 5.4.6
+      '@smithy/node-http-handler': 4.7.7
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.50':
+    dependencies:
+      '@aws-sdk/core': 3.974.22
       '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.24.6
       '@smithy/fetch-http-handler': 5.4.6
@@ -4326,6 +4487,22 @@ snapshots:
       '@smithy/types': 4.14.3
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-ini@3.972.55':
+    dependencies:
+      '@aws-sdk/core': 3.974.22
+      '@aws-sdk/credential-provider-env': 3.972.48
+      '@aws-sdk/credential-provider-http': 3.972.50
+      '@aws-sdk/credential-provider-login': 3.972.54
+      '@aws-sdk/credential-provider-process': 3.972.48
+      '@aws-sdk/credential-provider-sso': 3.972.54
+      '@aws-sdk/credential-provider-web-identity': 3.972.54
+      '@aws-sdk/nested-clients': 3.997.22
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.24.6
+      '@smithy/credential-provider-imds': 4.3.8
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-login@3.972.50':
     dependencies:
       '@aws-sdk/core': 3.974.19
@@ -4348,6 +4525,15 @@ snapshots:
     dependencies:
       '@aws-sdk/core': 3.974.21
       '@aws-sdk/nested-clients': 3.997.21
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.24.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.54':
+    dependencies:
+      '@aws-sdk/core': 3.974.22
+      '@aws-sdk/nested-clients': 3.997.22
       '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.24.6
       '@smithy/types': 4.14.3
@@ -4395,6 +4581,20 @@ snapshots:
       '@smithy/types': 4.14.3
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-node@3.972.57':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.48
+      '@aws-sdk/credential-provider-http': 3.972.50
+      '@aws-sdk/credential-provider-ini': 3.972.55
+      '@aws-sdk/credential-provider-process': 3.972.48
+      '@aws-sdk/credential-provider-sso': 3.972.54
+      '@aws-sdk/credential-provider-web-identity': 3.972.54
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.24.6
+      '@smithy/credential-provider-imds': 4.3.8
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-process@3.972.45':
     dependencies:
       '@aws-sdk/core': 3.974.19
@@ -4414,6 +4614,14 @@ snapshots:
   '@aws-sdk/credential-provider-process@3.972.47':
     dependencies:
       '@aws-sdk/core': 3.974.21
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.24.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.48':
+    dependencies:
+      '@aws-sdk/core': 3.974.22
       '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.24.6
       '@smithy/types': 4.14.3
@@ -4449,6 +4657,16 @@ snapshots:
       '@smithy/types': 4.14.3
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-sso@3.972.54':
+    dependencies:
+      '@aws-sdk/core': 3.974.22
+      '@aws-sdk/nested-clients': 3.997.22
+      '@aws-sdk/token-providers': 3.1071.0
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.24.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-web-identity@3.972.50':
     dependencies:
       '@aws-sdk/core': 3.974.19
@@ -4476,6 +4694,20 @@ snapshots:
       '@smithy/types': 4.14.3
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-web-identity@3.972.54':
+    dependencies:
+      '@aws-sdk/core': 3.974.22
+      '@aws-sdk/nested-clients': 3.997.22
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.24.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-flexible-checksums@3.974.32':
+    dependencies:
+      '@aws-sdk/checksums': 3.1000.7
+      tslib: 2.8.1
+
   '@aws-sdk/middleware-sdk-ec2@3.972.33':
     dependencies:
       '@aws-sdk/core': 3.974.19
@@ -4491,6 +4723,15 @@ snapshots:
       '@aws-sdk/types': 3.973.12
       '@smithy/core': 3.24.6
       '@smithy/signature-v4': 5.4.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-sdk-s3@3.972.53':
+    dependencies:
+      '@aws-sdk/core': 3.974.22
+      '@aws-sdk/signature-v4-multi-region': 3.996.35
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.24.6
       '@smithy/types': 4.14.3
       tslib: 2.8.1
 
@@ -4525,6 +4766,19 @@ snapshots:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
       '@aws-sdk/core': 3.974.21
+      '@aws-sdk/signature-v4-multi-region': 3.996.35
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.24.6
+      '@smithy/fetch-http-handler': 5.4.6
+      '@smithy/node-http-handler': 4.7.7
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.997.22':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.22
       '@aws-sdk/signature-v4-multi-region': 3.996.35
       '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.24.6
@@ -4576,6 +4830,15 @@ snapshots:
     dependencies:
       '@aws-sdk/core': 3.974.21
       '@aws-sdk/nested-clients': 3.997.21
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.24.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1071.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.22
+      '@aws-sdk/nested-clients': 3.997.22
       '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.24.6
       '@smithy/types': 4.14.3


### PR DESCRIPTION
# 🚀 Nuovi Resource Checks — Log Groups, Orphaned ENI, S3 Lifecycle

Aggiunti tre nuovi check per ampliare la copertura di risorse AWS analizzabili da Cloudrift:

- `log-group`
- `eni-orphaned`
- `s3-no-lifecycle`

L’obiettivo è migliorare il rilevamento di sprechi, problemi di hygiene e opportunità di ottimizzazione lato storage e networking.

---

## 🔹 CloudWatch Log Groups (`log-group`)

Aggiunto supporto per il rilevamento di **CloudWatch Log Groups senza retention policy**.

Caratteristiche:

- Scanner basato su:

```ts
@aws-sdk/client-cloudwatch-logs
```

- Individua log group con retention assente / infinita
- Identifica costi di storage potenzialmente in crescita nel tempo

Note:

- L’implementazione segue il pattern suggerito in:

```md
adding-a-resource.md
```

---

## 🔹 Orphaned Elastic Network Interfaces (`eni-orphaned`)

Aggiunto rilevamento di **ENI orfane**.

Criterio di detection:

- `Status = available`

Scanner basato su:

```ts
@aws-sdk/client-ec2
```

Caratteristiche:

- Nessuna dipendenza aggiuntiva (riuso adapter EC2 esistente)
- Costo diretto considerato:

```txt
$0
```

Questo check è principalmente orientato a:

- hygiene infrastrutturale
- cleanup
- riduzione di risorse inutilizzate

### Nota tecnica

Le ENI non espongono una `creation date` tramite AWS API.

Conseguenza:

- nessun grace period applicabile
- stesso comportamento adottato per `elastic-ip`

---

## 🔹 S3 Buckets senza Lifecycle (`s3-no-lifecycle`)

Aggiunto rilevamento di bucket **S3 privi di lifecycle policy**.

Scanner basato su:

```ts
@aws-sdk/client-s3
```

Metriche storage via:

```ts
CloudWatch → BucketSizeBytes
```

Categoria:

- `optimization`

Metadata:

- `estimated: true`

Motivazione:

Il risparmio è **euristico** e non deterministico (a differenza di casi come `gp2 → gp3`).

---

## 🔹 Dettagli Tecnici Degni di Nota

### Bucket Region Filtering

Utilizzo di:

```ts
ListBucketsCommand
```

con filtering per:

```txt
BucketRegion
```

Motivazione:

I bucket S3 sono risorse globali.

Senza questo filtro:

- lo stesso bucket verrebbe scansionato **N volte**
- dove N = numero di regioni analizzate

Il filtro evita duplicazioni di scan e falsi positivi.

---

## 🔹 Workspace Dependencies

Aggiunte nuove dipendenze via:

```bash
pnpm add -w
```

Nuovi package:

- `@aws-sdk/client-cloudwatch-logs`
- `@aws-sdk/client-s3`

Nota:

Il root package resta un workspace **Nx single-package**, quindi le dipendenze sono state aggiunte a livello root.

---

## 📚 Documentation

Aggiornata documentazione in **EN** e **IT**:

- README
- Tabella risorse supportate
- Tabella permessi IAM

Nuovi permessi richiesti:

```txt
logs:DescribeLogGroups
s3:ListAllMyBuckets
s3:GetBucketLifecycleConfiguration
ec2:DescribeNetworkInterfaces
```

---

## 🧪 Quality Assurance

Verifiche completate con successo:

- Lint ✅
- Build ✅
- Typecheck ✅
- Test suite completa ✅

Copertura test:

- Infrastructure: **143 test**
- Domain: **169 test**
- CLI: **42 test**

Totale: **tutti verdi**