### PR TITLE
feat(cloud-cost): New Resource Checks — DynamoDB Overprovisioned & El…

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,10 @@
 | **S3 Buckets (no lifecycle)** | No lifecycle configuration — rightsizing candidate | Saving: ~40% of Standard storage cost (estimate — verify access patterns before acting) |
 | **Lambda Functions (underutilized)** | (Near-)zero invocations over 7 days | $0 (hygiene flag — pay-per-use Lambda has no direct cost when unused) |
 | **EFS File Systems (unused)** | No mount targets, or mounted with zero I/O in the last 48h | $0.30/GB-month (Standard storage) |
+| **DynamoDB Tables (overprovisioned)** | PROVISIONED mode, read/write capacity utilization < 10% over 7 days — rightsizing candidate | Saving: ~50% of the provisioned RCU/WCU monthly cost (estimate — verify traffic spikes before acting) |
+| **ElastiCache Clusters (idle)** | Zero client connections in the last 48h, requires `--live-pricing` | Full node-hour cost (node billed regardless of usage) |
 
-Every finding is also tagged `waste` or `optimization`: `waste` is money being spent now and feeds the headline total and the CI gate; `optimization` (gp2→gp3, EC2/RDS underutilized, S3 no-lifecycle, Lambda underutilized) is a saving opportunity that keeps the resource, shown separately and never gated. `EC2/RDS Instances (underutilized)` and `S3 Buckets (no lifecycle)` are additionally *estimates* — verify before acting.
+Every finding is also tagged `waste` or `optimization`: `waste` is money being spent now and feeds the headline total and the CI gate; `optimization` (gp2→gp3, EC2/RDS underutilized, S3 no-lifecycle, Lambda underutilized, DynamoDB overprovisioned) is a saving opportunity that keeps the resource, shown separately and never gated. `EC2/RDS Instances (underutilized)`, `S3 Buckets (no lifecycle)` and `DynamoDB Tables (overprovisioned)` are additionally *estimates* — verify before acting.
 
 > **Honest caveat (Lambda):** we only check invocation count over the lookback window, nothing else. We do **not** rightsize memory allocation — that requires Lambda Insights (extra cost, must be enabled per-function), which isn't part of a zero-extra-IAM read-only scan. A function with zero invocations has, by definition, $0 direct cost (pay-per-use); the value of this finding is hygiene (dead code, unnecessary IAM roles/event sources), not a dollar saving. It also won't catch idle **Provisioned Concurrency**, which *is* billed regardless of invocations — out of scope for now.
 
@@ -351,6 +353,9 @@ The AWS principal needs the following read-only permissions:
     "s3:GetBucketLifecycleConfiguration",
     "lambda:ListFunctions",
     "elasticfilesystem:DescribeFileSystems",
+    "dynamodb:ListTables",
+    "dynamodb:DescribeTable",
+    "elasticache:DescribeCacheClusters",
     "sts:GetCallerIdentity"
   ],
   "Resource": "*"
@@ -455,8 +460,10 @@ No changes to `AnalyzeCloudWasteUseCase`, the summary, or the report DTO are nee
 | **S3 Buckets (no lifecycle)** | Nessuna lifecycle configuration — candidato a rightsizing | Risparmio: ~40% del costo storage Standard (stima — verificare i pattern di accesso prima di agire) |
 | **Lambda Functions (underutilized)** | (Quasi) zero invocazioni in 7 giorni | $0 (segnalazione di igiene — Lambda pay-per-use non ha costo diretto se inutilizzata) |
 | **EFS File Systems (unused)** | Nessun mount target, oppure montato con zero I/O nelle ultime 48h | $0,30/GB-mese (storage Standard) |
+| **DynamoDB Tables (overprovisioned)** | Modalità PROVISIONED, utilizzo capacità read/write < 10% in 7 giorni — candidato a rightsizing | Risparmio: ~50% del costo mensile RCU/WCU provisioned (stima — verificare picchi di traffico prima di agire) |
+| **ElastiCache Clusters (idle)** | Zero connessioni client nelle ultime 48h, richiede `--live-pricing` | Costo pieno node-hour (il nodo è fatturato indipendentemente dall'uso) |
 
-Ogni finding è anche etichettato `waste` o `optimization`: `waste` è denaro speso ora e contribuisce al totale principale e al gate CI; `optimization` (gp2→gp3, EC2/RDS underutilized, S3 no-lifecycle, Lambda underutilized) è un'opportunità di risparmio che mantiene la risorsa, mostrata a parte e mai usata come gate. `EC2/RDS Instances (underutilized)` e `S3 Buckets (no lifecycle)` sono inoltre delle *stime* — da verificare prima di agire.
+Ogni finding è anche etichettato `waste` o `optimization`: `waste` è denaro speso ora e contribuisce al totale principale e al gate CI; `optimization` (gp2→gp3, EC2/RDS underutilized, S3 no-lifecycle, Lambda underutilized, DynamoDB overprovisioned) è un'opportunità di risparmio che mantiene la risorsa, mostrata a parte e mai usata come gate. `EC2/RDS Instances (underutilized)`, `S3 Buckets (no lifecycle)` e `DynamoDB Tables (overprovisioned)` sono inoltre delle *stime* — da verificare prima di agire.
 
 > **Nota onesta (Lambda):** controlliamo solo il numero di invocazioni nella finestra di osservazione, nient'altro. **Non** facciamo rightsizing della memoria — richiederebbe Lambda Insights (costo extra, da attivare per ogni funzione), fuori scope per uno scan read-only senza permessi IAM aggiuntivi. Una funzione con zero invocazioni ha per definizione $0 di costo diretto (pay-per-use); il valore di questo finding è igiene (codice morto, ruoli IAM/event source inutili), non un risparmio in dollari. Non rileva nemmeno la **Provisioned Concurrency** idle, che invece *è* fatturata indipendentemente dalle invocazioni — fuori scope per ora.
 
@@ -793,6 +800,9 @@ Il principal AWS deve avere le seguenti permission in sola lettura:
     "s3:GetBucketLifecycleConfiguration",
     "lambda:ListFunctions",
     "elasticfilesystem:DescribeFileSystems",
+    "dynamodb:ListTables",
+    "dynamodb:DescribeTable",
+    "elasticache:DescribeCacheClusters",
     "sts:GetCallerIdentity"
   ],
   "Resource": "*"

--- a/apps/cli/src/commands/analyze-waste.composition.ts
+++ b/apps/cli/src/commands/analyze-waste.composition.ts
@@ -17,6 +17,8 @@ import {
   S3NoLifecyclePolicy,
   LambdaUnderutilizedPolicy,
   EfsUnusedPolicy,
+  DynamoDbOverprovisionedPolicy,
+  ElastiCacheIdlePolicy,
 } from 'cloud-cost-domain';
 import type {
   AwsRegion,
@@ -43,6 +45,8 @@ import {
   AwsS3NoLifecycleScanner,
   AwsLambdaUnderutilizedScanner,
   AwsEfsUnusedScanner,
+  AwsDynamoDbOverprovisionedScanner,
+  AwsElastiCacheIdleScanner,
   StaticPriceTableAdapter,
   TablePricingAdapter,
   AwsPricingApiAdapter,
@@ -171,11 +175,22 @@ function buildScanners(
       new EfsUnusedPolicy(policyOptions, ctx.config.thresholds?.efsIoBytesMin ?? 0),
       cloudwatchWindowHours,
     ),
+    new AwsDynamoDbOverprovisionedScanner(
+      pricing,
+      accountId,
+      new DynamoDbOverprovisionedPolicy(
+        policyOptions,
+        ctx.config.thresholds?.dynamoCapacityUtilizationPercent ?? 10,
+      ),
+      utilizationWindowHours,
+    ),
   ];
 
-  // Advisory, gated su --live-pricing: il prezzo per instance type/classe RDS
-  // non rientra nel listino statico (cardinalità troppo alta), quindi senza
-  // prezzi live non c'è risparmio stimabile e gli scanner restano disattivati.
+  // Gated su --live-pricing: il prezzo per instance type/classe RDS/node type
+  // ElastiCache non rientra nel listino statico (cardinalità troppo alta),
+  // quindi senza prezzi live non c'è risparmio stimabile e gli scanner
+  // restano disattivati (EC2/RDS sono advisory; ElastiCache è spreco certo
+  // una volta noto il prezzo, ma resta comunque gated sulla stessa risorsa).
   if (livePricingAdapter) {
     scanners.push(
       new AwsEc2UnderutilizedScanner(
@@ -189,6 +204,12 @@ function buildScanners(
         accountId,
         new RdsUnderutilizedPolicy(policyOptions, ctx.config.thresholds?.rdsCpuPercent ?? 5),
         utilizationWindowHours,
+      ),
+      new AwsElastiCacheIdleScanner(
+        livePricingAdapter,
+        accountId,
+        new ElastiCacheIdlePolicy(policyOptions),
+        cloudwatchWindowHours,
       ),
     );
   }

--- a/apps/cli/src/config/cloudrift.config.spec.ts
+++ b/apps/cli/src/config/cloudrift.config.spec.ts
@@ -104,6 +104,18 @@ describe('parseConfig', () => {
     if (!result.ok) expect(result.error.message).toContain('efsIoBytesMin');
   });
 
+  it('parses thresholds.dynamoCapacityUtilizationPercent', () => {
+    const result = parseConfig(JSON.stringify({ thresholds: { dynamoCapacityUtilizationPercent: 15 } }));
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value.thresholds?.dynamoCapacityUtilizationPercent).toBe(15);
+  });
+
+  it('rejects a thresholds.dynamoCapacityUtilizationPercent outside 0-100', () => {
+    const result = parseConfig(JSON.stringify({ thresholds: { dynamoCapacityUtilizationPercent: 150 } }));
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toContain('dynamoCapacityUtilizationPercent');
+  });
+
   it('returns empty config for an empty object', () => {
     const result = parseConfig('{}');
     expect(result.ok).toBe(true);

--- a/apps/cli/src/config/cloudrift.config.ts
+++ b/apps/cli/src/config/cloudrift.config.ts
@@ -51,6 +51,8 @@ export interface CloudriftConfig {
     lambdaInvocationsMin?: number;
     /** Byte I/O totali sotto cui un file system EFS montato è "idle". Default 0. */
     efsIoBytesMin?: number;
+    /** Utilizzo massimo (%) di RCU/WCU sotto cui una tabella DynamoDB è "overprovisioned". Default 10. */
+    dynamoCapacityUtilizationPercent?: number;
   };
 }
 
@@ -194,8 +196,14 @@ export function parseConfig(
       errors.push('thresholds must be an object');
     } else {
       const thresholds: NonNullable<CloudriftConfig['thresholds']> = {};
-      const { ebsIdleMaxOps, ec2CpuPercent, rdsCpuPercent, lambdaInvocationsMin, efsIoBytesMin } =
-        obj.thresholds;
+      const {
+        ebsIdleMaxOps,
+        ec2CpuPercent,
+        rdsCpuPercent,
+        lambdaInvocationsMin,
+        efsIoBytesMin,
+        dynamoCapacityUtilizationPercent,
+      } = obj.thresholds;
       if (ebsIdleMaxOps !== undefined) {
         if (typeof ebsIdleMaxOps === 'number' && Number.isFinite(ebsIdleMaxOps) && ebsIdleMaxOps >= 0) {
           thresholds.ebsIdleMaxOps = ebsIdleMaxOps;
@@ -243,6 +251,18 @@ export function parseConfig(
           thresholds.efsIoBytesMin = efsIoBytesMin;
         } else {
           errors.push('thresholds.efsIoBytesMin must be a non-negative number');
+        }
+      }
+      if (dynamoCapacityUtilizationPercent !== undefined) {
+        if (
+          typeof dynamoCapacityUtilizationPercent === 'number' &&
+          Number.isFinite(dynamoCapacityUtilizationPercent) &&
+          dynamoCapacityUtilizationPercent >= 0 &&
+          dynamoCapacityUtilizationPercent <= 100
+        ) {
+          thresholds.dynamoCapacityUtilizationPercent = dynamoCapacityUtilizationPercent;
+        } else {
+          errors.push('thresholds.dynamoCapacityUtilizationPercent must be a number between 0 and 100');
         }
       }
       config.thresholds = thresholds;

--- a/apps/cli/src/formatters/resource-presenters.ts
+++ b/apps/cli/src/formatters/resource-presenters.ts
@@ -212,6 +212,36 @@ export const presenters: PresenterMap = {
     recommend: (fs) =>
       `Delete unused EFS ${fs.id} in ${fs.region.code} — ${fs.wasteReason}`,
   },
+  'dynamodb-overprovisioned': {
+    title: 'DynamoDB Tables — Overprovisioned (rightsizing candidate, verify before acting)',
+    head: ['Table', 'Region', 'RCU', 'WCU', 'Read %', 'Write %', 'Window'],
+    colWidths: [150, 72, 50, 50, 70, 70, 60, 80],
+    row: (t) => [
+      t.id,
+      t.region.code,
+      `${t.readCapacityUnits}`,
+      `${t.writeCapacityUnits}`,
+      `${t.avgReadUtilizationPercent.toFixed(1)}%`,
+      `${t.avgWriteUtilizationPercent.toFixed(1)}%`,
+      `${t.windowDays}d`,
+    ],
+    recommend: (t) =>
+      `Review DynamoDB table ${t.id} in ${t.region.code} for rightsizing — ${t.wasteReason}`,
+  },
+  'elasticache-idle': {
+    title: 'ElastiCache Clusters — Idle (zero connections)',
+    head: ['Cluster ID', 'Region', 'Node Type', 'Nodes', 'Created'],
+    colWidths: [140, 72, 90, 50, 84, 80],
+    row: (c) => [
+      c.id,
+      c.region.code,
+      c.cacheNodeType,
+      `${c.numCacheNodes}`,
+      c.createTime.toISOString().split('T')[0],
+    ],
+    recommend: (c) =>
+      `Delete idle ElastiCache cluster ${c.id} (${c.cacheNodeType}) in ${c.region.code} — ${c.wasteReason}`,
+  },
 };
 
 export function presenterFor(kind: ResourceKind): ResourcePresenter {

--- a/libs/cloud-cost/domain/src/entities/idle-elasticache-cluster.entity.spec.ts
+++ b/libs/cloud-cost/domain/src/entities/idle-elasticache-cluster.entity.spec.ts
@@ -1,0 +1,52 @@
+import { IdleElastiCacheCluster } from './idle-elasticache-cluster.entity';
+import type { IdleElastiCacheClusterProps } from './idle-elasticache-cluster.entity';
+import { AwsRegion } from '../value-objects/aws-region.value-object';
+
+const region = AwsRegion.create('eu-west-1');
+
+function makeCluster(overrides: Partial<IdleElastiCacheClusterProps> = {}): IdleElastiCacheCluster {
+  return new IdleElastiCacheCluster({
+    cacheClusterId: 'my-cluster',
+    region,
+    accountId: '123456789012',
+    cacheNodeType: 'cache.t3.micro',
+    numCacheNodes: 1,
+    connectionsLastWindow: 0,
+    metricWindowHours: 48,
+    createTime: new Date('2024-03-01'),
+    detectedAt: new Date('2026-06-09'),
+    tags: { Env: 'dev' },
+    monthlyCostUsd: 12.41,
+    ...overrides,
+  });
+}
+
+describe('IdleElastiCacheCluster', () => {
+  it('exposes correct id and fields', () => {
+    const cluster = makeCluster();
+    expect(cluster.id).toBe('my-cluster');
+    expect(cluster.cacheNodeType).toBe('cache.t3.micro');
+    expect(cluster.tags).toEqual({ Env: 'dev' });
+  });
+
+  it('isIdle returns true when no connections were observed', () => {
+    expect(makeCluster({ connectionsLastWindow: 0 }).isIdle()).toBe(true);
+  });
+
+  it('isIdle returns false when connections were observed', () => {
+    expect(makeCluster({ connectionsLastWindow: 5 }).isIdle()).toBe(false);
+  });
+
+  it('exposes kind and wasteReason', () => {
+    expect(makeCluster().kind).toBe('elasticache-idle');
+    expect(makeCluster().wasteReason).toContain('48h');
+  });
+
+  it('costEstimate returns the stored monthlyCostUsd', () => {
+    expect(makeCluster().costEstimate.monthlyCostUsd).toBe(12.41);
+  });
+
+  it('costEstimate description references the node type', () => {
+    expect(makeCluster().costEstimate.description).toContain('cache.t3.micro');
+  });
+});

--- a/libs/cloud-cost/domain/src/entities/idle-elasticache-cluster.entity.ts
+++ b/libs/cloud-cost/domain/src/entities/idle-elasticache-cluster.entity.ts
@@ -1,0 +1,51 @@
+import { Entity } from 'shared-kernel';
+import { AwsRegion } from '../value-objects/aws-region.value-object';
+import { CostEstimate } from '../value-objects/cost-estimate.value-object';
+import type { WastedResource } from '../wasted-resource';
+
+export interface IdleElastiCacheClusterProps {
+  cacheClusterId: string;
+  region: AwsRegion;
+  accountId: string;
+  cacheNodeType: string;
+  numCacheNodes: number;
+  /** Somma di CurrConnections nella finestra di osservazione. */
+  connectionsLastWindow: number;
+  metricWindowHours: number;
+  createTime: Date;
+  detectedAt: Date;
+  tags: Record<string, string>;
+  monthlyCostUsd: number;
+}
+
+export class IdleElastiCacheCluster extends Entity<string> implements WastedResource {
+  private readonly props: Readonly<IdleElastiCacheClusterProps>;
+
+  constructor(props: IdleElastiCacheClusterProps) {
+    super(props.cacheClusterId);
+    this.props = Object.freeze({ ...props });
+  }
+
+  get region(): AwsRegion { return this.props.region; }
+  get accountId(): string { return this.props.accountId; }
+  get cacheNodeType(): string { return this.props.cacheNodeType; }
+  get numCacheNodes(): number { return this.props.numCacheNodes; }
+  get connectionsLastWindow(): number { return this.props.connectionsLastWindow; }
+  get metricWindowHours(): number { return this.props.metricWindowHours; }
+  get createTime(): Date { return this.props.createTime; }
+  get detectedAt(): Date { return this.props.detectedAt; }
+  get tags(): Record<string, string> { return this.props.tags; }
+
+  get kind(): 'elasticache-idle' { return 'elasticache-idle'; }
+  get wasteReason(): string {
+    return `zero connections in last ${this.props.metricWindowHours}h`;
+  }
+
+  isIdle(): boolean {
+    return this.props.connectionsLastWindow === 0;
+  }
+
+  get costEstimate(): CostEstimate {
+    return CostEstimate.of(this.props.monthlyCostUsd, `Idle ${this.props.cacheNodeType} ElastiCache cluster`);
+  }
+}

--- a/libs/cloud-cost/domain/src/entities/overprovisioned-dynamodb-table.entity.spec.ts
+++ b/libs/cloud-cost/domain/src/entities/overprovisioned-dynamodb-table.entity.spec.ts
@@ -1,0 +1,58 @@
+import { OverprovisionedDynamoDbTable } from './overprovisioned-dynamodb-table.entity';
+import type { OverprovisionedDynamoDbTableProps } from './overprovisioned-dynamodb-table.entity';
+import { AwsRegion } from '../value-objects/aws-region.value-object';
+
+const region = AwsRegion.create('eu-west-1');
+const WINDOW_DAYS = 7;
+const WINDOW_SECONDS = WINDOW_DAYS * 24 * 60 * 60;
+
+function makeTable(overrides: Partial<OverprovisionedDynamoDbTableProps> = {}): OverprovisionedDynamoDbTable {
+  return new OverprovisionedDynamoDbTable({
+    tableName: 'my-table',
+    region,
+    accountId: '123456789012',
+    readCapacityUnits: 100,
+    writeCapacityUnits: 100,
+    consumedReadCapacityUnits: 0,
+    consumedWriteCapacityUnits: 0,
+    windowDays: WINDOW_DAYS,
+    creationDateTime: new Date('2024-03-01'),
+    detectedAt: new Date('2026-06-09'),
+    tags: { Env: 'dev' },
+    monthlyCostUsd: 12.5,
+    ...overrides,
+  });
+}
+
+describe('OverprovisionedDynamoDbTable', () => {
+  it('exposes correct id and fields', () => {
+    const table = makeTable();
+    expect(table.id).toBe('my-table');
+    expect(table.readCapacityUnits).toBe(100);
+    expect(table.tags).toEqual({ Env: 'dev' });
+  });
+
+  it('computes avgReadUtilizationPercent from consumed/provisioned/window', () => {
+    const consumed = 50 * WINDOW_SECONDS; // avg 50 RCU/s consumed vs 100 RCU provisioned = 50%
+    expect(makeTable({ consumedReadCapacityUnits: consumed }).avgReadUtilizationPercent).toBeCloseTo(50, 1);
+  });
+
+  it('computes avgWriteUtilizationPercent from consumed/provisioned/window', () => {
+    const consumed = 10 * WINDOW_SECONDS; // avg 10 WCU/s consumed vs 100 WCU provisioned = 10%
+    expect(makeTable({ consumedWriteCapacityUnits: consumed }).avgWriteUtilizationPercent).toBeCloseTo(10, 1);
+  });
+
+  it('utilization is zero when provisioned capacity is zero', () => {
+    expect(makeTable({ readCapacityUnits: 0 }).avgReadUtilizationPercent).toBe(0);
+  });
+
+  it('exposes kind and wasteReason', () => {
+    expect(makeTable().kind).toBe('dynamodb-overprovisioned');
+    expect(makeTable().wasteReason).toContain('read');
+    expect(makeTable().wasteReason).toContain('write');
+  });
+
+  it('costEstimate returns the stored monthlyCostUsd', () => {
+    expect(makeTable().costEstimate.monthlyCostUsd).toBe(12.5);
+  });
+});

--- a/libs/cloud-cost/domain/src/entities/overprovisioned-dynamodb-table.entity.ts
+++ b/libs/cloud-cost/domain/src/entities/overprovisioned-dynamodb-table.entity.ts
@@ -1,0 +1,72 @@
+import { Entity } from 'shared-kernel';
+import { AwsRegion } from '../value-objects/aws-region.value-object';
+import { CostEstimate } from '../value-objects/cost-estimate.value-object';
+import type { WastedResource } from '../wasted-resource';
+
+export interface OverprovisionedDynamoDbTableProps {
+  tableName: string;
+  region: AwsRegion;
+  accountId: string;
+  readCapacityUnits: number;
+  writeCapacityUnits: number;
+  /** Somma di ConsumedReadCapacityUnits nella finestra di osservazione. */
+  consumedReadCapacityUnits: number;
+  /** Somma di ConsumedWriteCapacityUnits nella finestra di osservazione. */
+  consumedWriteCapacityUnits: number;
+  windowDays: number;
+  creationDateTime: Date;
+  detectedAt: Date;
+  tags: Record<string, string>;
+  /** Risparmio mensile stimato da un downsize della capacità provisioned. */
+  monthlyCostUsd: number;
+}
+
+/**
+ * Tabella DynamoDB in modalità PROVISIONED con capacità RCU/WCU consumata
+ * ben sotto quella allocata. Advisory (categoria optimization, stima): la
+ * CPU bassa non garantisce che il traffico sia sempre basso (picchi non
+ * coperti dalla finestra), va verificato prima di un downsize.
+ */
+export class OverprovisionedDynamoDbTable extends Entity<string> implements WastedResource {
+  private readonly props: Readonly<OverprovisionedDynamoDbTableProps>;
+
+  constructor(props: OverprovisionedDynamoDbTableProps) {
+    super(props.tableName);
+    this.props = Object.freeze({ ...props });
+  }
+
+  get region(): AwsRegion { return this.props.region; }
+  get accountId(): string { return this.props.accountId; }
+  get readCapacityUnits(): number { return this.props.readCapacityUnits; }
+  get writeCapacityUnits(): number { return this.props.writeCapacityUnits; }
+  get windowDays(): number { return this.props.windowDays; }
+  get creationDateTime(): Date { return this.props.creationDateTime; }
+  get detectedAt(): Date { return this.props.detectedAt; }
+  get tags(): Record<string, string> { return this.props.tags; }
+
+  get kind(): 'dynamodb-overprovisioned' { return 'dynamodb-overprovisioned'; }
+  get wasteReason(): string {
+    return `read ${this.avgReadUtilizationPercent.toFixed(1)}% / write ${this.avgWriteUtilizationPercent.toFixed(1)}% utilization over ${this.props.windowDays}d (verify traffic spikes before downsizing)`;
+  }
+
+  private utilizationPercent(consumed: number, provisioned: number): number {
+    if (provisioned <= 0) return 0;
+    const windowSeconds = this.props.windowDays * 24 * 60 * 60;
+    return (consumed / windowSeconds / provisioned) * 100;
+  }
+
+  get avgReadUtilizationPercent(): number {
+    return this.utilizationPercent(this.props.consumedReadCapacityUnits, this.props.readCapacityUnits);
+  }
+
+  get avgWriteUtilizationPercent(): number {
+    return this.utilizationPercent(this.props.consumedWriteCapacityUnits, this.props.writeCapacityUnits);
+  }
+
+  get costEstimate(): CostEstimate {
+    return CostEstimate.of(
+      this.props.monthlyCostUsd,
+      `${this.props.readCapacityUnits} RCU / ${this.props.writeCapacityUnits} WCU overprovisioned`,
+    );
+  }
+}

--- a/libs/cloud-cost/domain/src/group-by-kind.ts
+++ b/libs/cloud-cost/domain/src/group-by-kind.ts
@@ -15,6 +15,8 @@ import type { OrphanedEni } from './entities/orphaned-eni.entity';
 import type { S3Bucket } from './entities/s3-bucket.entity';
 import type { UnderutilizedLambdaFunction } from './entities/underutilized-lambda-function.entity';
 import type { EfsFileSystem } from './entities/efs-file-system.entity';
+import type { OverprovisionedDynamoDbTable } from './entities/overprovisioned-dynamodb-table.entity';
+import type { IdleElastiCacheCluster } from './entities/idle-elasticache-cluster.entity';
 
 /**
  * Mappa kind → entità concreta. Permette ai consumer (formatter, frontend)
@@ -37,6 +39,8 @@ export interface ResourceKindMap {
   's3-no-lifecycle': S3Bucket;
   'lambda-underutilized': UnderutilizedLambdaFunction;
   'efs-unused': EfsFileSystem;
+  'dynamodb-overprovisioned': OverprovisionedDynamoDbTable;
+  'elasticache-idle': IdleElastiCacheCluster;
 }
 
 export type FindingsByKind = {

--- a/libs/cloud-cost/domain/src/index.ts
+++ b/libs/cloud-cost/domain/src/index.ts
@@ -48,6 +48,10 @@ export { UnderutilizedLambdaFunction } from './entities/underutilized-lambda-fun
 export type { UnderutilizedLambdaFunctionProps } from './entities/underutilized-lambda-function.entity';
 export { EfsFileSystem } from './entities/efs-file-system.entity';
 export type { EfsFileSystemProps } from './entities/efs-file-system.entity';
+export { OverprovisionedDynamoDbTable } from './entities/overprovisioned-dynamodb-table.entity';
+export type { OverprovisionedDynamoDbTableProps } from './entities/overprovisioned-dynamodb-table.entity';
+export { IdleElastiCacheCluster } from './entities/idle-elasticache-cluster.entity';
+export type { IdleElastiCacheClusterProps } from './entities/idle-elasticache-cluster.entity';
 
 // Value Objects
 export { AwsRegion, InvalidAwsRegionError } from './value-objects/aws-region.value-object';
@@ -79,6 +83,8 @@ export {
   S3NoLifecyclePolicy,
   LambdaUnderutilizedPolicy,
   EfsUnusedPolicy,
+  DynamoDbOverprovisionedPolicy,
+  ElastiCacheIdlePolicy,
 } from './policies/resource-waste-policies';
 
 // Outbound Ports

--- a/libs/cloud-cost/domain/src/policies/resource-waste-policies.spec.ts
+++ b/libs/cloud-cost/domain/src/policies/resource-waste-policies.spec.ts
@@ -15,6 +15,8 @@ import {
   S3NoLifecyclePolicy,
   LambdaUnderutilizedPolicy,
   EfsUnusedPolicy,
+  DynamoDbOverprovisionedPolicy,
+  ElastiCacheIdlePolicy,
 } from './resource-waste-policies';
 import { DEFAULT_IGNORE_TAG, DEFAULT_MIN_AGE_DAYS } from './waste-policy';
 import { EbsVolume } from '../entities/ebs-volume.entity';
@@ -35,6 +37,8 @@ import { OrphanedEni } from '../entities/orphaned-eni.entity';
 import { S3Bucket } from '../entities/s3-bucket.entity';
 import { UnderutilizedLambdaFunction } from '../entities/underutilized-lambda-function.entity';
 import { EfsFileSystem } from '../entities/efs-file-system.entity';
+import { OverprovisionedDynamoDbTable } from '../entities/overprovisioned-dynamodb-table.entity';
+import { IdleElastiCacheCluster } from '../entities/idle-elasticache-cluster.entity';
 import type { EbsSnapshotProps } from '../entities/ebs-snapshot.entity';
 import type { Ec2InstanceProps } from '../entities/ec2-instance.entity';
 import { AwsRegion } from '../value-objects/aws-region.value-object';
@@ -716,5 +720,90 @@ describe('EfsUnusedPolicy', () => {
     expect(lenient.evaluate(makeFs({ numberOfMountTargets: 1, ioBytesLastWindow: 512 }), now).isWaste).toBe(
       true,
     );
+  });
+});
+
+describe('DynamoDbOverprovisionedPolicy', () => {
+  const policy = new DynamoDbOverprovisionedPolicy();
+  const WINDOW_DAYS = 7;
+  const WINDOW_SECONDS = WINDOW_DAYS * 24 * 60 * 60;
+
+  function makeTable(
+    overrides: {
+      consumedReadCapacityUnits?: number;
+      consumedWriteCapacityUnits?: number;
+      creationDateTime?: Date;
+    } = {},
+  ): OverprovisionedDynamoDbTable {
+    return new OverprovisionedDynamoDbTable({
+      tableName: 'my-table',
+      region,
+      accountId: '123456789012',
+      readCapacityUnits: 100,
+      writeCapacityUnits: 100,
+      consumedReadCapacityUnits: overrides.consumedReadCapacityUnits ?? 0,
+      consumedWriteCapacityUnits: overrides.consumedWriteCapacityUnits ?? 0,
+      windowDays: WINDOW_DAYS,
+      creationDateTime: overrides.creationDateTime ?? oldDate,
+      detectedAt: now,
+      tags: {},
+      monthlyCostUsd: 12.5,
+    });
+  }
+
+  it('flags an old table with near-zero utilization', () => {
+    expect(policy.evaluate(makeTable(), now).isWaste).toBe(true);
+  });
+
+  it('does not flag a table with read utilization above threshold', () => {
+    const consumed = 50 * WINDOW_SECONDS; // 50% read utilization
+    expect(policy.evaluate(makeTable({ consumedReadCapacityUnits: consumed }), now).isWaste).toBe(false);
+  });
+
+  it('does not flag a table with write utilization above threshold', () => {
+    const consumed = 50 * WINDOW_SECONDS; // 50% write utilization
+    expect(policy.evaluate(makeTable({ consumedWriteCapacityUnits: consumed }), now).isWaste).toBe(false);
+  });
+
+  it('does not flag a freshly created table (grace period)', () => {
+    expect(policy.evaluate(makeTable({ creationDateTime: yesterday }), now).isWaste).toBe(false);
+  });
+
+  it('honours a custom utilization threshold', () => {
+    const lenient = new DynamoDbOverprovisionedPolicy({}, 60);
+    const consumed = 50 * WINDOW_SECONDS; // 50% utilization, below the 60% custom threshold
+    expect(lenient.evaluate(makeTable({ consumedReadCapacityUnits: consumed }), now).isWaste).toBe(true);
+  });
+});
+
+describe('ElastiCacheIdlePolicy', () => {
+  const policy = new ElastiCacheIdlePolicy();
+
+  function makeCluster(connectionsLastWindow: number, createTime = oldDate): IdleElastiCacheCluster {
+    return new IdleElastiCacheCluster({
+      cacheClusterId: 'my-cluster',
+      region,
+      accountId: '123456789012',
+      cacheNodeType: 'cache.t3.micro',
+      numCacheNodes: 1,
+      connectionsLastWindow,
+      metricWindowHours: 48,
+      createTime,
+      detectedAt: now,
+      tags: {},
+      monthlyCostUsd: 12.41,
+    });
+  }
+
+  it('flags an old cluster with zero connections', () => {
+    expect(policy.evaluate(makeCluster(0), now).isWaste).toBe(true);
+  });
+
+  it('does not flag a cluster with active connections', () => {
+    expect(policy.evaluate(makeCluster(5), now).isWaste).toBe(false);
+  });
+
+  it('does not flag a freshly created cluster (grace period)', () => {
+    expect(policy.evaluate(makeCluster(0, yesterday), now).isWaste).toBe(false);
   });
 });

--- a/libs/cloud-cost/domain/src/policies/resource-waste-policies.ts
+++ b/libs/cloud-cost/domain/src/policies/resource-waste-policies.ts
@@ -15,6 +15,8 @@ import type { OrphanedEni } from '../entities/orphaned-eni.entity';
 import type { S3Bucket } from '../entities/s3-bucket.entity';
 import type { UnderutilizedLambdaFunction } from '../entities/underutilized-lambda-function.entity';
 import type { EfsFileSystem } from '../entities/efs-file-system.entity';
+import type { OverprovisionedDynamoDbTable } from '../entities/overprovisioned-dynamodb-table.entity';
+import type { IdleElastiCacheCluster } from '../entities/idle-elasticache-cluster.entity';
 
 export class EbsVolumeWastePolicy extends WastePolicy<EbsVolume> {
   protected judge(volume: EbsVolume, now: Date): WasteVerdict {
@@ -195,6 +197,40 @@ export class EfsUnusedPolicy extends WastePolicy<EfsFileSystem> {
       return notWaste(`created less than ${this.minAgeDays}d ago`);
     }
     return fs.hasNoMountTargets() ? waste('no mount targets') : waste(`zero I/O in last ${fs.metricWindowHours}h`);
+  }
+}
+
+export class DynamoDbOverprovisionedPolicy extends WastePolicy<OverprovisionedDynamoDbTable> {
+  /** maxUtilizationPercent: soglia di utilizzo massimo (read e write) sotto cui la tabella è overprovisioned. */
+  constructor(options: WastePolicyOptions = {}, private readonly maxUtilizationPercent = 10) {
+    super(options);
+  }
+
+  protected judge(table: OverprovisionedDynamoDbTable, now: Date): WasteVerdict {
+    if (
+      table.avgReadUtilizationPercent >= this.maxUtilizationPercent ||
+      table.avgWriteUtilizationPercent >= this.maxUtilizationPercent
+    ) {
+      return notWaste('utilization above threshold');
+    }
+    // Una tabella appena creata potrebbe non aver ancora accumulato traffico reale.
+    if (this.isWithinGracePeriod(table.creationDateTime, now)) {
+      return notWaste(`created less than ${this.minAgeDays}d ago`);
+    }
+    return waste(
+      `read ${table.avgReadUtilizationPercent.toFixed(1)}% / write ${table.avgWriteUtilizationPercent.toFixed(1)}% over ${table.windowDays}d`,
+    );
+  }
+}
+
+export class ElastiCacheIdlePolicy extends WastePolicy<IdleElastiCacheCluster> {
+  protected judge(cluster: IdleElastiCacheCluster, now: Date): WasteVerdict {
+    if (!cluster.isIdle()) return notWaste('has client connections');
+    // Un cluster appena creato potrebbe non aver ancora ricevuto connessioni.
+    if (this.isWithinGracePeriod(cluster.createTime, now)) {
+      return notWaste(`created less than ${this.minAgeDays}d ago`);
+    }
+    return waste(`zero connections in last ${cluster.metricWindowHours}h`);
   }
 }
 

--- a/libs/cloud-cost/domain/src/ports/outbound/pricing.port.ts
+++ b/libs/cloud-cost/domain/src/ports/outbound/pricing.port.ts
@@ -10,6 +10,8 @@ export interface PricingPort {
   getLogGroupPricePerGbMonth(region: AwsRegion): number;
   getS3StandardPricePerGbMonth(region: AwsRegion): number;
   getEfsStandardPricePerGbMonth(region: AwsRegion): number;
+  getDynamoDbRcuPricePerHour(region: AwsRegion): number;
+  getDynamoDbWcuPricePerHour(region: AwsRegion): number;
   /** Data (YYYY-MM) dell'ultima verifica dei prezzi: va mostrata in ogni report. */
   getPricesAsOf(): string;
 }

--- a/libs/cloud-cost/domain/src/wasted-resource.ts
+++ b/libs/cloud-cost/domain/src/wasted-resource.ts
@@ -18,6 +18,8 @@ export const RESOURCE_KINDS = [
   's3-no-lifecycle',
   'lambda-underutilized',
   'efs-unused',
+  'dynamodb-overprovisioned',
+  'elasticache-idle',
 ] as const;
 
 export type ResourceKind = (typeof RESOURCE_KINDS)[number];
@@ -63,6 +65,12 @@ export const RESOURCE_KIND_META: Record<ResourceKind, ResourceKindMeta> = {
   's3-no-lifecycle': { label: 'S3 Buckets (no lifecycle)', category: 'optimization', estimated: true },
   'lambda-underutilized': { label: 'Lambda Functions (underutilized)', category: 'optimization', estimated: false },
   'efs-unused': { label: 'EFS File Systems (unused)', category: 'waste', estimated: false },
+  'dynamodb-overprovisioned': {
+    label: 'DynamoDB Tables (overprovisioned)',
+    category: 'optimization',
+    estimated: true,
+  },
+  'elasticache-idle': { label: 'ElastiCache Clusters (idle)', category: 'waste', estimated: false },
 };
 
 /** Etichette leggibili, derivate da RESOURCE_KIND_META (unica fonte). */

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/index.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/index.ts
@@ -16,6 +16,9 @@ export { AwsEniOrphanedScanner } from './scanners/aws-eni-orphaned.scanner';
 export { AwsS3NoLifecycleScanner } from './scanners/aws-s3-no-lifecycle.scanner';
 export { AwsLambdaUnderutilizedScanner } from './scanners/aws-lambda-underutilized.scanner';
 export { AwsEfsUnusedScanner } from './scanners/aws-efs-unused.scanner';
+export { AwsDynamoDbOverprovisionedScanner } from './scanners/aws-dynamodb-overprovisioned.scanner';
+export { AwsElastiCacheIdleScanner } from './scanners/aws-elasticache-idle.scanner';
+export type { ElastiCacheNodePricingSource } from './scanners/aws-elasticache-idle.scanner';
 export { AwsAdapterError } from './errors/aws-adapter.error';
 export {
   StaticPriceTableAdapter,

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/pricing/aws-pricing-api.adapter.spec.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/pricing/aws-pricing-api.adapter.spec.ts
@@ -146,3 +146,29 @@ describe('AwsPricingApiAdapter.getRdsInstancePricePerMonth', () => {
     expect(mockSend).not.toHaveBeenCalled();
   });
 });
+
+describe('AwsPricingApiAdapter.getElastiCacheNodePricePerMonth', () => {
+  it('resolves an unambiguous hourly price to monthly for a known node type', async () => {
+    mockSend.mockResolvedValue({ PriceList: [priceListItem('0.0340000000')] });
+
+    const adapter = new AwsPricingApiAdapter();
+    const price = await adapter.getElastiCacheNodePricePerMonth(euWest1, 'cache.t3.medium');
+
+    expect(price).toBe(+(0.034 * 730).toFixed(4));
+    const filters = (mockSend.mock.calls[0][0] as GetProductsCommand).input.Filters ?? [];
+    expect(filters).toEqual(
+      expect.arrayContaining([
+        { Type: 'TERM_MATCH', Field: 'instanceType', Value: 'cache.t3.medium' },
+        { Type: 'TERM_MATCH', Field: 'productFamily', Value: 'Cache Instance' },
+      ]),
+    );
+  });
+
+  it('returns undefined for a region with no known location mapping', async () => {
+    const adapter = new AwsPricingApiAdapter();
+    const price = await adapter.getElastiCacheNodePricePerMonth(unknownRegion, 'cache.t3.medium');
+
+    expect(price).toBeUndefined();
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+});

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/pricing/aws-pricing-api.adapter.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/pricing/aws-pricing-api.adapter.ts
@@ -221,6 +221,31 @@ export class AwsPricingApiAdapter {
   }
 
   /**
+   * Prezzo on-demand mensile per un node type ElastiCache, risolto on-demand
+   * come `getEc2InstancePricePerMonth` (stessa motivazione: cardinalità dei
+   * node type troppo alta per il prefetch).
+   */
+  async getElastiCacheNodePricePerMonth(
+    region: AwsRegion,
+    cacheNodeType: string,
+  ): Promise<number | undefined> {
+    const location = REGION_TO_LOCATION[region.code];
+    if (!location) return undefined;
+    return this.fetchPrice(
+      {
+        key: `elasticache-${cacheNodeType}`,
+        serviceCode: 'AmazonElastiCache',
+        filters: [
+          { Field: 'instanceType', Value: cacheNodeType },
+          { Field: 'productFamily', Value: 'Cache Instance' },
+        ],
+        unit: 'hourly',
+      },
+      location,
+    );
+  }
+
+  /**
    * Restituisce il prezzo per una spec **solo se i prodotti restituiti
    * concordano su un unico valore**. Filtri ambigui (più valori distinti) ⇒
    * `undefined`, per non rischiare un prezzo sbagliato (peggio del listino).

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/pricing/prices.json
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/pricing/prices.json
@@ -20,7 +20,9 @@
     "nat-gateway":   32.400,
     "cw-logs":       0.030,
     "s3-standard":   0.023,
-    "efs-standard":  0.300
+    "efs-standard":  0.300,
+    "dynamodb-rcu":  0.00013,
+    "dynamodb-wcu":  0.00065
   },
   "us-east-1": {
     "ebs-gp2":       0.100,
@@ -32,7 +34,9 @@
     "nat-gateway":   32.400,
     "cw-logs":       0.030,
     "s3-standard":   0.023,
-    "efs-standard":  0.300
+    "efs-standard":  0.300,
+    "dynamodb-rcu":  0.00013,
+    "dynamodb-wcu":  0.00065
   },
   "us-west-2": {
     "ebs-gp2":       0.100,
@@ -44,7 +48,9 @@
     "nat-gateway":   32.400,
     "cw-logs":       0.030,
     "s3-standard":   0.023,
-    "efs-standard":  0.300
+    "efs-standard":  0.300,
+    "dynamodb-rcu":  0.00013,
+    "dynamodb-wcu":  0.00065
   },
   "eu-west-1": {
     "ebs-gp2":       0.110,
@@ -56,7 +62,9 @@
     "nat-gateway":   36.720,
     "cw-logs":       0.033,
     "s3-standard":   0.024,
-    "efs-standard":  0.330
+    "efs-standard":  0.330,
+    "dynamodb-rcu":  0.00013,
+    "dynamodb-wcu":  0.00065
   },
   "eu-central-1": {
     "ebs-gp2":       0.119,
@@ -68,7 +76,9 @@
     "nat-gateway":   38.880,
     "cw-logs":       0.033,
     "s3-standard":   0.0245,
-    "efs-standard":  0.330
+    "efs-standard":  0.330,
+    "dynamodb-rcu":  0.00013,
+    "dynamodb-wcu":  0.00065
   },
   "ap-southeast-1": {
     "ebs-gp2":       0.114,
@@ -81,7 +91,9 @@
     "nat-gateway":   36.792,
     "cw-logs":       0.033,
     "s3-standard":   0.025,
-    "efs-standard":  0.340
+    "efs-standard":  0.340,
+    "dynamodb-rcu":  0.00013,
+    "dynamodb-wcu":  0.00065
   },
   "ap-northeast-1": {
     "ebs-gp2":       0.120,
@@ -93,6 +105,8 @@
     "nat-gateway":   38.880,
     "cw-logs":       0.033,
     "s3-standard":   0.025,
-    "efs-standard":  0.340
+    "efs-standard":  0.340,
+    "dynamodb-rcu":  0.00013,
+    "dynamodb-wcu":  0.00065
   }
 }

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/pricing/table-pricing.adapter.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/pricing/table-pricing.adapter.ts
@@ -75,6 +75,14 @@ export class TablePricingAdapter implements PricingPort {
     return this.lookup(region, 'efs-standard') ?? 0;
   }
 
+  getDynamoDbRcuPricePerHour(region: AwsRegion): number {
+    return this.lookup(region, 'dynamodb-rcu') ?? 0;
+  }
+
+  getDynamoDbWcuPricePerHour(region: AwsRegion): number {
+    return this.lookup(region, 'dynamodb-wcu') ?? 0;
+  }
+
   getPricesAsOf(): string {
     return this.pricesAsOf;
   }

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-dynamodb-overprovisioned.scanner.spec.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-dynamodb-overprovisioned.scanner.spec.ts
@@ -1,0 +1,128 @@
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { CloudWatchClient, GetMetricStatisticsCommand } from '@aws-sdk/client-cloudwatch';
+import { AwsDynamoDbOverprovisionedScanner } from './aws-dynamodb-overprovisioned.scanner';
+import { AwsRegion } from 'cloud-cost-domain';
+import { AwsAdapterError } from '../errors/aws-adapter.error';
+import { mockPricing } from '../testing/mock-pricing';
+
+jest.mock('@aws-sdk/client-dynamodb');
+jest.mock('@aws-sdk/client-cloudwatch');
+
+const mockDynamoSend = jest.fn();
+const mockDynamoDestroy = jest.fn();
+const mockCwSend = jest.fn();
+const mockCwDestroy = jest.fn();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (DynamoDBClient as jest.Mock).mockImplementation(() => ({
+    send: mockDynamoSend,
+    destroy: mockDynamoDestroy,
+  }));
+  (CloudWatchClient as jest.Mock).mockImplementation(() => ({
+    send: mockCwSend,
+    destroy: mockCwDestroy,
+  }));
+});
+
+const region = AwsRegion.create('us-east-1');
+const scanner = new AwsDynamoDbOverprovisionedScanner(mockPricing);
+const OLD_DATE = new Date('2024-03-01');
+
+function describeTableResponse(overrides: Record<string, unknown> = {}) {
+  return {
+    Table: {
+      TableName: 'my-table',
+      CreationDateTime: OLD_DATE,
+      BillingModeSummary: { BillingMode: 'PROVISIONED' },
+      ProvisionedThroughput: { ReadCapacityUnits: 100, WriteCapacityUnits: 100 },
+      ...overrides,
+    },
+  };
+}
+
+describe('AwsDynamoDbOverprovisionedScanner', () => {
+  it('exposes its resource kind', () => {
+    expect(scanner.kind).toBe('dynamodb-overprovisioned');
+  });
+
+  it('reports an old provisioned table with near-zero consumed capacity', async () => {
+    mockDynamoSend.mockResolvedValueOnce({ TableNames: ['my-table'] });
+    mockDynamoSend.mockResolvedValueOnce(describeTableResponse());
+    mockCwSend.mockResolvedValue({ Datapoints: [{ Sum: 0 }] });
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.map((t) => t.id)).toEqual(['my-table']);
+  });
+
+  it('does not report a PAY_PER_REQUEST table', async () => {
+    mockDynamoSend.mockResolvedValueOnce({ TableNames: ['on-demand-table'] });
+    mockDynamoSend.mockResolvedValueOnce(
+      describeTableResponse({
+        BillingModeSummary: { BillingMode: 'PAY_PER_REQUEST' },
+        ProvisionedThroughput: { ReadCapacityUnits: 0, WriteCapacityUnits: 0 },
+      }),
+    );
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toHaveLength(0);
+    expect(mockCwSend).not.toHaveBeenCalled();
+  });
+
+  it('does not report a table with read utilization above threshold', async () => {
+    mockDynamoSend.mockResolvedValueOnce({ TableNames: ['busy-table'] });
+    mockDynamoSend.mockResolvedValueOnce(describeTableResponse({ TableName: 'busy-table' }));
+    const consumed = 50 * 168 * 3600; // ~50% of 100 RCU over a 168h window
+    mockCwSend.mockResolvedValueOnce({ Datapoints: [{ Sum: consumed }] });
+    mockCwSend.mockResolvedValueOnce({ Datapoints: [{ Sum: 0 }] });
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toHaveLength(0);
+  });
+
+  it('does not report a freshly created table (grace period)', async () => {
+    mockDynamoSend.mockResolvedValueOnce({ TableNames: ['new-table'] });
+    mockDynamoSend.mockResolvedValueOnce(
+      describeTableResponse({ TableName: 'new-table', CreationDateTime: new Date() }),
+    );
+    mockCwSend.mockResolvedValue({ Datapoints: [{ Sum: 0 }] });
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toHaveLength(0);
+  });
+
+  it('queries Consumed{Read,Write}CapacityUnits per table', async () => {
+    mockDynamoSend.mockResolvedValueOnce({ TableNames: ['my-table'] });
+    mockDynamoSend.mockResolvedValueOnce(describeTableResponse());
+    mockCwSend.mockResolvedValue({ Datapoints: [{ Sum: 0 }] });
+
+    await scanner.scan(region);
+
+    const metricNames = (GetMetricStatisticsCommand as unknown as jest.Mock).mock.calls.map(
+      (call) => call[0].MetricName,
+    );
+    expect(metricNames).toEqual(
+      expect.arrayContaining(['ConsumedReadCapacityUnits', 'ConsumedWriteCapacityUnits']),
+    );
+  });
+
+  it('returns Result.fail wrapping AwsAdapterError and destroys both clients on error', async () => {
+    mockDynamoSend.mockRejectedValueOnce(new Error('boom'));
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect((result.error as AwsAdapterError).service).toBe('DynamoDB');
+    expect(mockDynamoDestroy).toHaveBeenCalledTimes(1);
+    expect(mockCwDestroy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-dynamodb-overprovisioned.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-dynamodb-overprovisioned.scanner.ts
@@ -1,0 +1,138 @@
+import {
+  DynamoDBClient,
+  ListTablesCommand,
+  DescribeTableCommand,
+  type TableDescription,
+} from '@aws-sdk/client-dynamodb';
+import {
+  CloudWatchClient,
+  GetMetricStatisticsCommand,
+} from '@aws-sdk/client-cloudwatch';
+import { Result } from 'shared-kernel';
+import type { AwsRegion, PricingPort, WasteScannerPort, WastedResource } from 'cloud-cost-domain';
+import { OverprovisionedDynamoDbTable, DynamoDbOverprovisionedPolicy } from 'cloud-cost-domain';
+import { AwsAdapterError } from '../errors/aws-adapter.error';
+import { paginate } from '../utils/paginate';
+import { mapWithConcurrency } from '../utils/map-with-concurrency';
+
+const DEFAULT_WINDOW_HOURS = 168;
+const DESCRIBE_CONCURRENCY = 5;
+const CLOUDWATCH_CONCURRENCY = 5;
+/** Risparmio stimato da un downsize della capacità provisioned (advisory, da verificare). */
+const RIGHTSIZE_SAVING_FRACTION = 0.5;
+
+function isProvisioned(table: TableDescription): boolean {
+  if (table.BillingModeSummary?.BillingMode) {
+    return table.BillingModeSummary.BillingMode === 'PROVISIONED';
+  }
+  return (table.ProvisionedThroughput?.ReadCapacityUnits ?? 0) > 0;
+}
+
+/**
+ * Rileva tabelle DynamoDB in modalità PROVISIONED con capacità RCU/WCU
+ * consumata ben sotto quella allocata. `ListTables` restituisce solo i nomi:
+ * serve un `DescribeTable` per tabella (fan-out) per leggere la capacità
+ * provisioned, poi CloudWatch per quella consumata.
+ */
+export class AwsDynamoDbOverprovisionedScanner implements WasteScannerPort {
+  readonly kind = 'dynamodb-overprovisioned' as const;
+
+  constructor(
+    private readonly pricing: PricingPort,
+    private readonly accountId = 'unknown',
+    private readonly policy = new DynamoDbOverprovisionedPolicy(),
+    private readonly windowHours = DEFAULT_WINDOW_HOURS,
+  ) {}
+
+  async scan(region: AwsRegion): Promise<Result<WastedResource[]>> {
+    const dynamodb = new DynamoDBClient({ region: region.code });
+    const cw = new CloudWatchClient({ region: region.code });
+    try {
+      const tableNames = await paginate<string>(async (cursor) => {
+        const r = await dynamodb.send(new ListTablesCommand({ ExclusiveStartTableName: cursor }));
+        return { items: r.TableNames ?? [], cursor: r.LastEvaluatedTableName };
+      });
+
+      if (tableNames.length === 0) return Result.ok([]);
+
+      const descriptions = await mapWithConcurrency(tableNames, DESCRIBE_CONCURRENCY, async (name) => {
+        const r = await dynamodb.send(new DescribeTableCommand({ TableName: name }));
+        return r.Table!;
+      });
+
+      const provisionedTables = descriptions.filter(isProvisioned);
+      if (provisionedTables.length === 0) return Result.ok([]);
+
+      const endTime = new Date();
+      const startTime = new Date(endTime.getTime() - this.windowHours * 60 * 60 * 1000);
+      const periodSeconds = this.windowHours * 3600;
+
+      const consumed = await mapWithConcurrency(
+        provisionedTables,
+        CLOUDWATCH_CONCURRENCY,
+        async (table) => {
+          const [read, write] = await Promise.all([
+            this.sumMetric(cw, table.TableName!, 'ConsumedReadCapacityUnits', startTime, endTime, periodSeconds),
+            this.sumMetric(cw, table.TableName!, 'ConsumedWriteCapacityUnits', startTime, endTime, periodSeconds),
+          ]);
+          return { read, write };
+        },
+      );
+
+      const rcuPrice = this.pricing.getDynamoDbRcuPricePerHour(region);
+      const wcuPrice = this.pricing.getDynamoDbWcuPricePerHour(region);
+      const now = new Date();
+
+      const tables = provisionedTables
+        .map((table, index) => {
+          const rcu = table.ProvisionedThroughput?.ReadCapacityUnits ?? 0;
+          const wcu = table.ProvisionedThroughput?.WriteCapacityUnits ?? 0;
+          const monthlyProvisionedCost = (rcu * rcuPrice + wcu * wcuPrice) * 730;
+          return new OverprovisionedDynamoDbTable({
+            tableName: table.TableName!,
+            region,
+            accountId: this.accountId,
+            readCapacityUnits: rcu,
+            writeCapacityUnits: wcu,
+            consumedReadCapacityUnits: consumed[index].read,
+            consumedWriteCapacityUnits: consumed[index].write,
+            windowDays: +(this.windowHours / 24).toFixed(1),
+            creationDateTime: table.CreationDateTime ?? new Date(0),
+            detectedAt: now,
+            tags: {},
+            monthlyCostUsd: +(monthlyProvisionedCost * RIGHTSIZE_SAVING_FRACTION).toFixed(4),
+          });
+        })
+        .filter((table) => this.policy.evaluate(table, now).isWaste);
+
+      return Result.ok(tables);
+    } catch (err) {
+      return Result.fail(new AwsAdapterError('DynamoDB', err as Error));
+    } finally {
+      dynamodb.destroy();
+      cw.destroy();
+    }
+  }
+
+  private async sumMetric(
+    cw: CloudWatchClient,
+    tableName: string,
+    metricName: string,
+    startTime: Date,
+    endTime: Date,
+    periodSeconds: number,
+  ): Promise<number> {
+    const r = await cw.send(
+      new GetMetricStatisticsCommand({
+        Namespace: 'AWS/DynamoDB',
+        MetricName: metricName,
+        Dimensions: [{ Name: 'TableName', Value: tableName }],
+        StartTime: startTime,
+        EndTime: endTime,
+        Period: periodSeconds,
+        Statistics: ['Sum'],
+      }),
+    );
+    return r.Datapoints?.[0]?.Sum ?? 0;
+  }
+}

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-elasticache-idle.scanner.spec.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-elasticache-idle.scanner.spec.ts
@@ -1,0 +1,116 @@
+import { ElastiCacheClient } from '@aws-sdk/client-elasticache';
+import { CloudWatchClient, GetMetricStatisticsCommand } from '@aws-sdk/client-cloudwatch';
+import { AwsElastiCacheIdleScanner } from './aws-elasticache-idle.scanner';
+import { AwsRegion } from 'cloud-cost-domain';
+import { AwsAdapterError } from '../errors/aws-adapter.error';
+
+jest.mock('@aws-sdk/client-elasticache');
+jest.mock('@aws-sdk/client-cloudwatch');
+
+const mockEcSend = jest.fn();
+const mockEcDestroy = jest.fn();
+const mockCwSend = jest.fn();
+const mockCwDestroy = jest.fn();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (ElastiCacheClient as jest.Mock).mockImplementation(() => ({
+    send: mockEcSend,
+    destroy: mockEcDestroy,
+  }));
+  (CloudWatchClient as jest.Mock).mockImplementation(() => ({
+    send: mockCwSend,
+    destroy: mockCwDestroy,
+  }));
+});
+
+const region = AwsRegion.create('us-east-1');
+const mockPricingSource = { getElastiCacheNodePricePerMonth: jest.fn().mockResolvedValue(12.41) };
+const scanner = new AwsElastiCacheIdleScanner(mockPricingSource);
+const OLD_DATE = new Date('2024-03-01');
+
+describe('AwsElastiCacheIdleScanner', () => {
+  it('exposes its resource kind', () => {
+    expect(scanner.kind).toBe('elasticache-idle');
+  });
+
+  it('reports an old cluster with zero connections', async () => {
+    mockEcSend.mockResolvedValueOnce({
+      CacheClusters: [
+        { CacheClusterId: 'my-cluster', CacheNodeType: 'cache.t3.micro', NumCacheNodes: 1, CacheClusterCreateTime: OLD_DATE },
+      ],
+    });
+    mockCwSend.mockResolvedValueOnce({ Datapoints: [] });
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.map((c) => c.id)).toEqual(['my-cluster']);
+    expect(result.value[0].costEstimate.monthlyCostUsd).toBeCloseTo(12.41, 2);
+  });
+
+  it('does not report a cluster with active connections', async () => {
+    mockEcSend.mockResolvedValueOnce({
+      CacheClusters: [
+        { CacheClusterId: 'busy-cluster', CacheNodeType: 'cache.t3.micro', NumCacheNodes: 1, CacheClusterCreateTime: OLD_DATE },
+      ],
+    });
+    mockCwSend.mockResolvedValueOnce({ Datapoints: [{ Sum: 42 }] });
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toHaveLength(0);
+  });
+
+  it('does not report a freshly created cluster (grace period)', async () => {
+    mockEcSend.mockResolvedValueOnce({
+      CacheClusters: [
+        { CacheClusterId: 'new-cluster', CacheNodeType: 'cache.t3.micro', NumCacheNodes: 1, CacheClusterCreateTime: new Date() },
+      ],
+    });
+    mockCwSend.mockResolvedValueOnce({ Datapoints: [] });
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toHaveLength(0);
+  });
+
+  it('skips CloudWatch entirely when no clusters exist', async () => {
+    mockEcSend.mockResolvedValueOnce({ CacheClusters: [] });
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    expect(mockCwSend).not.toHaveBeenCalled();
+  });
+
+  it('queries the CurrConnections metric per cluster', async () => {
+    mockEcSend.mockResolvedValueOnce({
+      CacheClusters: [
+        { CacheClusterId: 'my-cluster', CacheNodeType: 'cache.t3.micro', NumCacheNodes: 1, CacheClusterCreateTime: OLD_DATE },
+      ],
+    });
+    mockCwSend.mockResolvedValueOnce({ Datapoints: [] });
+
+    await scanner.scan(region);
+
+    const cwArgs = (GetMetricStatisticsCommand as unknown as jest.Mock).mock.calls[0][0];
+    expect(cwArgs.Namespace).toBe('AWS/ElastiCache');
+    expect(cwArgs.MetricName).toBe('CurrConnections');
+    expect(cwArgs.Dimensions).toEqual([{ Name: 'CacheClusterId', Value: 'my-cluster' }]);
+  });
+
+  it('returns Result.fail wrapping AwsAdapterError and destroys both clients on error', async () => {
+    mockEcSend.mockRejectedValueOnce(new Error('boom'));
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect((result.error as AwsAdapterError).service).toBe('ElastiCache');
+    expect(mockEcDestroy).toHaveBeenCalledTimes(1);
+    expect(mockCwDestroy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-elasticache-idle.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-elasticache-idle.scanner.ts
@@ -1,0 +1,124 @@
+import {
+  ElastiCacheClient,
+  DescribeCacheClustersCommand,
+  type CacheCluster,
+} from '@aws-sdk/client-elasticache';
+import {
+  CloudWatchClient,
+  GetMetricStatisticsCommand,
+} from '@aws-sdk/client-cloudwatch';
+import { Result } from 'shared-kernel';
+import type { AwsRegion, WasteScannerPort, WastedResource } from 'cloud-cost-domain';
+import { IdleElastiCacheCluster, ElastiCacheIdlePolicy } from 'cloud-cost-domain';
+import { AwsAdapterError } from '../errors/aws-adapter.error';
+import { paginate } from '../utils/paginate';
+import { mapWithConcurrency } from '../utils/map-with-concurrency';
+
+const DEFAULT_LOOKBACK_HOURS = 48;
+const CLOUDWATCH_CONCURRENCY = 5;
+
+/**
+ * Il prezzo per node type è risolto on-demand dalla Pricing API (la
+ * cardinalità dei node type è troppo alta per il listino statico/il
+ * prefetch di `warmUp`): `AwsPricingApiAdapter` soddisfa questa interfaccia
+ * per duck typing.
+ */
+export interface ElastiCacheNodePricingSource {
+  getElastiCacheNodePricePerMonth(region: AwsRegion, cacheNodeType: string): Promise<number | undefined>;
+}
+
+/**
+ * Rileva cluster ElastiCache con zero connessioni client nella finestra
+ * osservata. A differenza di Lambda, un nodo ElastiCache è fatturato per
+ * ora indipendentemente dall'uso: zero connessioni è spreco reale, non solo
+ * igiene. Richiede `--live-pricing`: senza un prezzo per node type, non c'è
+ * risparmio stimabile.
+ */
+export class AwsElastiCacheIdleScanner implements WasteScannerPort {
+  readonly kind = 'elasticache-idle' as const;
+
+  constructor(
+    private readonly pricing: ElastiCacheNodePricingSource,
+    private readonly accountId = 'unknown',
+    private readonly policy = new ElastiCacheIdlePolicy(),
+    private readonly windowHours = DEFAULT_LOOKBACK_HOURS,
+  ) {}
+
+  async scan(region: AwsRegion): Promise<Result<WastedResource[]>> {
+    const elasticache = new ElastiCacheClient({ region: region.code });
+    const cw = new CloudWatchClient({ region: region.code });
+    try {
+      const rawClusters = await paginate<CacheCluster>(async (cursor) => {
+        const r = await elasticache.send(new DescribeCacheClustersCommand({ Marker: cursor }));
+        return { items: r.CacheClusters ?? [], cursor: r.Marker };
+      });
+
+      if (rawClusters.length === 0) return Result.ok([]);
+
+      const endTime = new Date();
+      const startTime = new Date(endTime.getTime() - this.windowHours * 60 * 60 * 1000);
+      const periodSeconds = this.windowHours * 3600;
+
+      const connections = await mapWithConcurrency(rawClusters, CLOUDWATCH_CONCURRENCY, (cluster) =>
+        this.sumConnections(cw, cluster.CacheClusterId!, startTime, endTime, periodSeconds),
+      );
+
+      const nodeTypes = [...new Set(rawClusters.map((c) => c.CacheNodeType ?? 'unknown'))];
+      const priceEntries = await mapWithConcurrency(nodeTypes, CLOUDWATCH_CONCURRENCY, async (nodeType) => ({
+        nodeType,
+        price: (await this.pricing.getElastiCacheNodePricePerMonth(region, nodeType)) ?? 0,
+      }));
+      const priceByType = new Map(priceEntries.map((e) => [e.nodeType, e.price]));
+
+      const now = new Date();
+      const clusters = rawClusters
+        .map((cluster, index) => {
+          const cacheNodeType = cluster.CacheNodeType ?? 'unknown';
+          const numCacheNodes = cluster.NumCacheNodes ?? 1;
+          const monthlyPrice = (priceByType.get(cacheNodeType) ?? 0) * numCacheNodes;
+          return new IdleElastiCacheCluster({
+            cacheClusterId: cluster.CacheClusterId!,
+            region,
+            accountId: this.accountId,
+            cacheNodeType,
+            numCacheNodes,
+            connectionsLastWindow: connections[index],
+            metricWindowHours: this.windowHours,
+            createTime: cluster.CacheClusterCreateTime ?? new Date(0),
+            detectedAt: now,
+            tags: {},
+            monthlyCostUsd: +monthlyPrice.toFixed(4),
+          });
+        })
+        .filter((cluster) => this.policy.evaluate(cluster, now).isWaste);
+
+      return Result.ok(clusters);
+    } catch (err) {
+      return Result.fail(new AwsAdapterError('ElastiCache', err as Error));
+    } finally {
+      elasticache.destroy();
+      cw.destroy();
+    }
+  }
+
+  private async sumConnections(
+    cw: CloudWatchClient,
+    cacheClusterId: string,
+    startTime: Date,
+    endTime: Date,
+    periodSeconds: number,
+  ): Promise<number> {
+    const r = await cw.send(
+      new GetMetricStatisticsCommand({
+        Namespace: 'AWS/ElastiCache',
+        MetricName: 'CurrConnections',
+        Dimensions: [{ Name: 'CacheClusterId', Value: cacheClusterId }],
+        StartTime: startTime,
+        EndTime: endTime,
+        Period: periodSeconds,
+        Statistics: ['Sum'],
+      }),
+    );
+    return r.Datapoints?.[0]?.Sum ?? 0;
+  }
+}

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/testing/mock-pricing.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/testing/mock-pricing.ts
@@ -11,5 +11,7 @@ export const mockPricing: PricingPort = {
   getLogGroupPricePerGbMonth: () => 0.03,
   getS3StandardPricePerGbMonth: () => 0.023,
   getEfsStandardPricePerGbMonth: () => 0.3,
+  getDynamoDbRcuPricePerHour: () => 0.00013,
+  getDynamoDbWcuPricePerHour: () => 0.00065,
   getPricesAsOf: () => '2025-06',
 };

--- a/package.json
+++ b/package.json
@@ -39,9 +39,11 @@
   "dependencies": {
     "@aws-sdk/client-cloudwatch": "^3.741.0",
     "@aws-sdk/client-cloudwatch-logs": "^3.1073.0",
+    "@aws-sdk/client-dynamodb": "^3.1073.0",
     "@aws-sdk/client-ec2": "^3.741.0",
     "@aws-sdk/client-efs": "^3.1073.0",
     "@aws-sdk/client-elastic-load-balancing-v2": "^3.741.0",
+    "@aws-sdk/client-elasticache": "^3.1073.0",
     "@aws-sdk/client-lambda": "^3.1073.0",
     "@aws-sdk/client-pricing": "^3.1070.0",
     "@aws-sdk/client-rds": "^3.741.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@aws-sdk/client-cloudwatch-logs':
         specifier: ^3.1073.0
         version: 3.1073.0
+      '@aws-sdk/client-dynamodb':
+        specifier: ^3.1073.0
+        version: 3.1073.0
       '@aws-sdk/client-ec2':
         specifier: ^3.741.0
         version: 3.1064.0
@@ -23,6 +26,9 @@ importers:
       '@aws-sdk/client-elastic-load-balancing-v2':
         specifier: ^3.741.0
         version: 3.1064.0
+      '@aws-sdk/client-elasticache':
+        specifier: ^3.1073.0
+        version: 3.1073.0
       '@aws-sdk/client-lambda':
         specifier: ^3.1073.0
         version: 3.1073.0
@@ -221,6 +227,10 @@ packages:
     resolution: {integrity: sha512-65WCnGMcM9whDqsx7a39+PcgdrfJlEHCroxyEIjMSkNWBDuBl/UR8XVdYuaHfRJWOBjxKaQp4NK7j7cOKokJEw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/client-dynamodb@3.1073.0':
+    resolution: {integrity: sha512-2GUPeI0drcms+LOoSC2DfVLCUWQxjjUm4jN08MrVh40XnIRQZ9PxCjFCqAj6yMRXPAzze925MMXEXBQC7IS6jw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/client-ec2@3.1064.0':
     resolution: {integrity: sha512-h+4U5iMCZzVZrHIRH7PspAx6AOjWQthVDQd9Hhtis6Xxa49OMrghJANPsbiL3AvghriekAYeIlPlS4BjbM/ifg==}
     engines: {node: '>=20.0.0'}
@@ -231,6 +241,10 @@ packages:
 
   '@aws-sdk/client-elastic-load-balancing-v2@3.1064.0':
     resolution: {integrity: sha512-OEq9iZYL4QVsHf+kP4Aws5jM6SVPLJ9FZ70MCOr3I/m4XQRhZ+i9uCDqpJPz4sm+iQZQ3MkYTfIyXtCungeHmQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-elasticache@3.1073.0':
+    resolution: {integrity: sha512-gvEySkOJSdRCT0wfj872A80Hd5YowFsOqeaJDdW/rGzhC59pa1KwzaA9w/1rwqzZ6AmH7tY3TdCYtqLlWqBH/Q==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/client-lambda@3.1073.0':
@@ -395,6 +409,18 @@ packages:
 
   '@aws-sdk/credential-provider-web-identity@3.972.54':
     resolution: {integrity: sha512-0Iv5QttS6wcATlodYKgvQj6B9Db51rx7NU9fqu0PoLeS4BIgdYMc/QK4smwLwpm5RFrs02V/eLyEFp3FklvlNQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/dynamodb-codec@3.973.22':
+    resolution: {integrity: sha512-QBs7/nWHsPA0wTEqhU5iPgaDjeZzQHhmwJr6Q0f56rW3Fk8ExJQgXFzEg/l48iDwJVUIMLjPqhw7dNP3cShUxA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/endpoint-cache@3.972.8':
+    resolution: {integrity: sha512-bBmkG0Dnhfq0/T4Z0PpUr7HkncBVaWvvCbvafeaUM+yC9wa8GGjLJmonq0QL17REB9WivgGeYgWQ5A80Uw5UnQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-endpoint-discovery@3.972.19':
+    resolution: {integrity: sha512-FMgyzUq3Jh+ONRYxryBRNdBd+FUX8PwRl07ccQknNdoms6KCeAEusCkl6whqpDrPQ6OH0ddeSifKyqYSs2DLIw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/middleware-flexible-checksums@3.974.32':
@@ -3504,6 +3530,9 @@ packages:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
 
+  mnemonist@0.38.3:
+    resolution: {integrity: sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==}
+
   ms@2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
 
@@ -3563,6 +3592,9 @@ packages:
   object.assign@4.1.7:
     resolution: {integrity: sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==}
     engines: {node: '>= 0.4'}
+
+  obliterator@1.6.1:
+    resolution: {integrity: sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==}
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
@@ -4252,6 +4284,21 @@ snapshots:
       '@smithy/types': 4.14.3
       tslib: 2.8.1
 
+  '@aws-sdk/client-dynamodb@3.1073.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.22
+      '@aws-sdk/credential-provider-node': 3.972.57
+      '@aws-sdk/dynamodb-codec': 3.973.22
+      '@aws-sdk/middleware-endpoint-discovery': 3.972.19
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.24.6
+      '@smithy/fetch-http-handler': 5.4.6
+      '@smithy/node-http-handler': 4.7.7
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
   '@aws-sdk/client-ec2@3.1064.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
@@ -4286,6 +4333,19 @@ snapshots:
       '@aws-sdk/core': 3.974.19
       '@aws-sdk/credential-provider-node': 3.972.53
       '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.24.6
+      '@smithy/fetch-http-handler': 5.4.6
+      '@smithy/node-http-handler': 4.7.7
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/client-elasticache@3.1073.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.22
+      '@aws-sdk/credential-provider-node': 3.972.57
+      '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.24.6
       '@smithy/fetch-http-handler': 5.4.6
       '@smithy/node-http-handler': 4.7.7
@@ -4738,6 +4798,26 @@ snapshots:
     dependencies:
       '@aws-sdk/core': 3.974.22
       '@aws-sdk/nested-clients': 3.997.22
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.24.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/dynamodb-codec@3.973.22':
+    dependencies:
+      '@aws-sdk/core': 3.974.22
+      '@smithy/core': 3.24.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/endpoint-cache@3.972.8':
+    dependencies:
+      mnemonist: 0.38.3
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-endpoint-discovery@3.972.19':
+    dependencies:
+      '@aws-sdk/endpoint-cache': 3.972.8
       '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.24.6
       '@smithy/types': 4.14.3
@@ -8716,6 +8796,10 @@ snapshots:
 
   minipass@7.1.3: {}
 
+  mnemonist@0.38.3:
+    dependencies:
+      obliterator: 1.6.1
+
   ms@2.1.2: {}
 
   ms@2.1.3: {}
@@ -8881,6 +8965,8 @@ snapshots:
       es-object-atoms: 1.1.1
       has-symbols: 1.1.0
       object-keys: 1.1.1
+
+  obliterator@1.6.1: {}
 
   once@1.4.0:
     dependencies:


### PR DESCRIPTION
# 🚀 Nuovi Resource Checks — DynamoDB Overprovisioned & ElastiCache Idle

Aggiunti due nuovi check per estendere ulteriormente la copertura di Cloudrift:

- `dynamodb-overprovisioned`
- `elasticache-idle`

I nuovi scanner coprono rispettivamente casi di **overprovisioning compute/storage** e **waste infrastrutturale diretto**.

---

## 🔹 DynamoDB Overprovisioned (`dynamodb-overprovisioned`)

Aggiunto il rilevamento di tabelle **DynamoDB in modalità PROVISIONED** con capacità allocata significativamente superiore al consumo reale.

Un table viene considerato candidato se:

- utilizzo medio di **RCU** sotto soglia
- utilizzo medio di **WCU** sotto soglia

Soglia default:

```txt
10%
```

Categoria:

- `optimization`

Metadata:

- `estimated: true`

Il risparmio viene stimato in modo euristico come:

```txt
50%
```

Approccio analogo a:

- `ec2-underutilized`
- `rds-underutilized`

---

## 🔹 Nota Tecnica — Fan-out aggiuntivo

Questo scanner richiede un passaggio extra rispetto alla maggior parte degli altri scanner.

### Step 1

Recupero lista tabelle tramite:

```ts
ListTables
```

Limite:

- AWS restituisce solo i nomi delle tabelle

### Step 2

Per ogni tabella viene eseguito:

```ts
DescribeTable
```

Necessario per ottenere:

- `ProvisionedThroughput`
- capacità RCU
- capacità WCU

Solo dopo è possibile calcolare il rapporto tra:

- capacità provisioned
- consumo reale osservato

---

## 🔹 Pricing Strategy (DynamoDB)

Il pricing utilizza una strategia **statica**.

Motivazione:

- RCU e WCU hanno pricing uniforme
- non esiste una variabilità per “instance type” come EC2 / RDS

Conseguenza:

- nessun live pricing necessario
- nessun gating CLI richiesto

---

## 🔹 ElastiCache Idle (`elasticache-idle`)

Aggiunto il rilevamento di cluster **ElastiCache inattivi**.

Un cluster è considerato idle se:

- ha **zero connessioni client**
- nelle ultime **48 ore**

Categoria:

- `waste`

Questo check rappresenta un caso di:

- costo reale
- waste deterministico

---

## 🔹 Cost Calculation (ElastiCache)

Il costo è calcolabile in modo esatto una volta noto il prezzo del node type.

Tuttavia esiste un vincolo pratico.

### Node Type Cardinality

La cardinalità dei node type ElastiCache è troppo elevata per essere mantenuta in un listino statico.

Per questo motivo lo scanner è gated dietro:

```bash
--live-pricing
```

Stesso comportamento di:

- `ec2-underutilized`
- `rds-underutilized`

---

## 🔹 Live Pricing

Riutilizzato:

```ts
AwsPricingApiAdapter
```

Aggiunto nuovo metodo:

```ts
getElastiCacheNodePricePerMonth()
```

Responsabilità:

- risoluzione prezzo mensile del node type
- calcolo costo reale del cluster idle

---

## 🔹 Configurazione

Aggiunta nuova soglia configurabile in:

```ts
cloudrift.config.ts
```

### DynamoDB

```ts
thresholds.dynamoCapacityUtilizationPercent
```

Definisce la soglia minima di utilizzo capacità sotto cui una tabella viene considerata overprovisioned.

---

## 📚 Documentation

Aggiornata documentazione in **EN** e **IT**:

- README
- Tabella risorse supportate
- Tabella permessi IAM

Nuovi permessi richiesti:

```txt
dynamodb:ListTables
dynamodb:DescribeTable
elasticache:DescribeCacheClusters
```

---

## 🧪 Quality Assurance

Verifiche completate con successo:

- Lint ✅
- Build ✅
- Typecheck ✅
- Test suite completa ✅

Copertura test:

- 208 test
- 173 test
- 48 test

Totale: **tutti verdi**