### PR TITLE
feat(docs):update documentation

### DIFF
--- a/docs/en/architecture.md
+++ b/docs/en/architecture.md
@@ -34,7 +34,7 @@ What it does **not** buy on its own is multi-cloud: see [Towards multi-cloud](#t
 │   entities, policies,   │   │   Result, DomainError)    │
 │   ports)                │   └───────────────────────────┘
 └──────▲──────────────────┘
-       │ implements WasteScannerPort (×10)
+       │ implements WasteScannerPort (×18)
 ┌──────┴──────────────────────────────────────────────────┐
 │        libs/cloud-cost/infrastructure/aws-adapter       │
 │   (AWS SDK v3 scanners, pricing, STS account resolver)  │
@@ -100,6 +100,13 @@ export const RESOURCE_KINDS = [
   'ebs-idle',
   'ec2-underutilized',
   'rds-underutilized',
+  'log-group',
+  'eni-orphaned',
+  's3-no-lifecycle',
+  'lambda-underutilized',
+  'efs-unused',
+  'dynamodb-overprovisioned',
+  'elasticache-idle',
 ] as const;
 
 export type ResourceKind = (typeof RESOURCE_KINDS)[number];
@@ -139,7 +146,7 @@ export const RESOURCE_KIND_META: Record<ResourceKind, ResourceKindMeta> = {
 
 #### Entities
 
-The 11 entities (`EbsVolume`, `ElasticIp`, `RdsInstance`, `LoadBalancer`, `Ec2Instance`, `EbsSnapshot`, `NatGateway`, `Gp2Volume`, `IdleEbsVolume`, `UnderutilizedEc2Instance`, `RdsUnderutilizedInstance`) implement `WastedResource` and carry the observed **facts** the decisions need: `LoadBalancer.registeredTargetCount`, `NatGateway.bytesOutLastWindow`, `EbsSnapshot.sourceVolumeExists` / `boundToAmiId`, `Ec2Instance.stoppedSince`, `IdleEbsVolume`'s summed `VolumeReadOps`/`VolumeWriteOps`, `UnderutilizedEc2Instance.maxCpuPercent`, `RdsUnderutilizedInstance.maxCpuPercent`. `Gp2Volume`, `UnderutilizedEc2Instance` and `RdsUnderutilizedInstance` are savings opportunities rather than deletable waste: their `costEstimate` carries the estimated monthly *saving*, not a cost being paid.
+The 18 entities (`EbsVolume`, `ElasticIp`, `RdsInstance`, `LoadBalancer`, `Ec2Instance`, `EbsSnapshot`, `NatGateway`, `Gp2Volume`, `IdleEbsVolume`, `UnderutilizedEc2Instance`, `RdsUnderutilizedInstance`, `LogGroup`, `OrphanedEni`, `S3Bucket`, `UnderutilizedLambdaFunction`, `EfsFileSystem`, `OverprovisionedDynamoDbTable`, `IdleElastiCacheCluster`) implement `WastedResource` and carry the observed **facts** the decisions need: `LoadBalancer.registeredTargetCount`, `NatGateway.bytesOutLastWindow`, `EbsSnapshot.sourceVolumeExists` / `boundToAmiId`, `Ec2Instance.stoppedSince`, `IdleEbsVolume`'s summed `VolumeReadOps`/`VolumeWriteOps`, `UnderutilizedEc2Instance.maxCpuPercent`, `RdsUnderutilizedInstance.maxCpuPercent`, `LogGroup.hasRetentionPolicy()`, `OrphanedEni.isOrphaned()` (`Status === 'available'`), `S3Bucket.hasLifecyclePolicy()`, `UnderutilizedLambdaFunction.invocationsLastWindow`, `EfsFileSystem.numberOfMountTargets` / `ioBytesLastWindow`, `OverprovisionedDynamoDbTable.avgReadUtilizationPercent` / `avgWriteUtilizationPercent`, `IdleElastiCacheCluster.connectionsLastWindow`. `Gp2Volume`, `UnderutilizedEc2Instance`, `RdsUnderutilizedInstance`, `S3Bucket`, `UnderutilizedLambdaFunction` and `OverprovisionedDynamoDbTable` are savings opportunities rather than deletable waste: their `costEstimate` carries the estimated monthly *saving* (or, for the Lambda hygiene flag, a flat $0), not a cost being paid.
 
 #### Waste Policies — where the business knowledge lives
 
@@ -163,8 +170,15 @@ Each concrete policy adds the type-specific criterion:
 | `Ec2UnderutilizedPolicy`  | running instance, max CPU% ≤ `ec2CpuPercent` (default 5) over the window | grace on `launchTime`; only registered when `--live-pricing` is on (needs a per-instance-type price) |
 | `RdsUnderutilizedPolicy`  | available instance, max CPU% ≤ `rdsCpuPercent` (default 5) over the window | grace on `instanceCreateTime`; only registered when `--live-pricing` is on (needs a per-instance-class price) |
 | `Gp2UpgradePolicy`        | in-use gp2 volume (savings, not waste)    | only `status=in-use` (unattached gp2 stays with `ebs-volume`); grace on `createTime` |
+| `LogGroupWastePolicy`     | no retention policy configured            | grace on `creationTime`                                                          |
+| `OrphanedEniWastePolicy`  | `Status === 'available'` (not attached)   | — (ENIs have no creation date); $0 cost — hygiene, not a saving                  |
+| `S3NoLifecyclePolicy`     | no lifecycle configuration                | grace on `creationDate`; advisory saving (`estimated: true`)                     |
+| `LambdaUnderutilizedPolicy` | invocations ≤ `lambdaInvocationsMin` (default 0) over the window | grace on `lastModified`; $0 cost — pay-per-use Lambda has no direct cost when idle |
+| `EfsUnusedPolicy`         | no mount targets, or mounted with I/O ≤ `efsIoBytesMin` (default 0) over the window | grace on `creationTime`                                  |
+| `DynamoDbOverprovisionedPolicy` | read **and** write utilization < `dynamoCapacityUtilizationPercent` (default 10%) over the window | grace on `creationDateTime`; advisory saving (`estimated: true`) |
+| `ElastiCacheIdlePolicy`   | zero connections in the window            | grace on `createTime`; only registered when `--live-pricing` is on (needs a per-node-type price) |
 
-`EbsIdlePolicy`, `Ec2UnderutilizedPolicy` and `RdsUnderutilizedPolicy` take their thresholds as constructor parameters (`ebsIdleMaxOps`, `ec2CpuPercent`, `rdsCpuPercent`), configurable via `config.thresholds`. Policies are pure domain logic: tested without AWS, with their parameters coming from the CLI (`--min-age-days`, `--ignore-tag`) and the config file (`thresholds`).
+`EbsIdlePolicy`, `Ec2UnderutilizedPolicy`, `RdsUnderutilizedPolicy`, `LambdaUnderutilizedPolicy`, `EfsUnusedPolicy` and `DynamoDbOverprovisionedPolicy` take their thresholds as constructor parameters (`ebsIdleMaxOps`, `ec2CpuPercent`, `rdsCpuPercent`, `lambdaInvocationsMin`, `efsIoBytesMin`, `dynamoCapacityUtilizationPercent`), configurable via `config.thresholds`. Policies are pure domain logic: tested without AWS, with their parameters coming from the CLI (`--min-age-days`, `--ignore-tag`) and the config file (`thresholds`).
 
 #### Ports
 
@@ -205,7 +219,7 @@ Specifics:
 
 ### 5. `apps/cli` — Entry point and composition root
 
-`analyze-waste.command.ts` loads the config file, resolves CLI options (regions, min-age, account ID) and orchestrates the run; it delegates the actual instantiation of concrete implementations to `analyze-waste.composition.ts` through the injectable `AnalyzeDeps.createAnalysis` seam (the same seam `analyze-waste.command.spec.ts` fakes to test without AWS). `analyze-waste.composition.ts` is the only place where concrete implementations are instantiated: it builds the price table, the policies (with config + CLI parameters) and 9 of the 11 scanners, injecting them into the use case. The other two, `AwsEc2UnderutilizedScanner` and `AwsRdsUnderutilizedScanner`, are registered only when `--live-pricing` is set: their savings estimate needs a per-instance-type/class price that the static table doesn't carry, so without live pricing there is nothing reliable to report and the scanners are left out rather than registered with a zero estimate. Back in `analyze-waste.command.ts`, the result is handed to the formatters. The four formatters (console table, PDF, JSON, Markdown) share the `resource-presenters.ts` registry, typed `Record<ResourceKind, ResourcePresenter<…>>`: forgetting the presenter for a new kind is a compile error. The output format is selected by `--format` (`table` | `json` | `markdown`); `markdown` targets CI / PR comments.
+`analyze-waste.command.ts` loads the config file, resolves CLI options (regions, min-age, account ID) and orchestrates the run; it delegates the actual instantiation of concrete implementations to `analyze-waste.composition.ts` through the injectable `AnalyzeDeps.createAnalysis` seam (the same seam `analyze-waste.command.spec.ts` fakes to test without AWS). `analyze-waste.composition.ts` is the only place where concrete implementations are instantiated: it builds the price table, the policies (with config + CLI parameters) and 15 of the 18 scanners, injecting them into the use case. The other three — `AwsEc2UnderutilizedScanner`, `AwsRdsUnderutilizedScanner` and `AwsElastiCacheIdleScanner` — are registered only when `--live-pricing` is set: their cost estimate needs a per-instance-type/class/node-type price that the static table doesn't carry (too many distinct types to maintain), so without live pricing there is nothing reliable to report and the scanners are left out rather than registered with a zero estimate. Back in `analyze-waste.command.ts`, the result is handed to the formatters. The four formatters (console table, PDF, JSON, Markdown) share the `resource-presenters.ts` registry, typed `Record<ResourceKind, ResourcePresenter<…>>`: forgetting the presenter for a new kind is a compile error. The output format is selected by `--format` (`table` | `json` | `markdown`); `markdown` targets CI / PR comments.
 
 ---
 
@@ -234,7 +248,7 @@ The only AWS-specific type crossing the inbound boundary is `AwsRegion`. Introdu
 
 Two options, to be chosen when the real requirement exists:
 
-- **Additional kinds in the same context** — `'gcp-persistent-disk'`, `'gcp-static-ip'`, … join the `ResourceKind` union with their own entities (`PersistentDisk`, not a fake `EbsVolume`), policies and scanners (`libs/cloud-cost/infrastructure/gcp-adapter`). The right fit if the product remains "one unified waste report". The coordinator's `Promise.all` scales from 11 to N scanners without changes.
+- **Additional kinds in the same context** — `'gcp-persistent-disk'`, `'gcp-static-ip'`, … join the `ResourceKind` union with their own entities (`PersistentDisk`, not a fake `EbsVolume`), policies and scanners (`libs/cloud-cost/infrastructure/gcp-adapter`). The right fit if the product remains "one unified waste report". The coordinator's `Promise.all` scales from 18 to N scanners without changes.
 - **Separate bounded context** — `libs/gcp-cost/` with its own domain, if the semantics diverge too much. Shares only `shared/kernel`. The `libs/<context>/` structure already allows it.
 
 The first option is the recommended one as long as the report stays unified: the marginal cost of a GCP kind is identical to that of an AWS kind (entity + policy + scanner + presenter).

--- a/docs/en/how-it-works.md
+++ b/docs/en/how-it-works.md
@@ -24,25 +24,30 @@ user: cloudrift analyze -r us-east-1 eu-west-1 [--format json|markdown] [--pdf] 
           ▼
      analyze-waste.composition.ts  (composition root: builds pricing + scanners)
      4. Pricing: static table ← live API (--live-pricing) ← config.prices (wins)
-     5. Instantiates policies (config + flags) and 9 of the 11 scanners
-        (the other two, EC2/RDS underutilized, only with --live-pricing)
+     5. Instantiates policies (config + flags) and 15 of the 18 scanners
+        (the other three — EC2/RDS underutilized, ElastiCache idle —
+         only with --live-pricing: per-type price not in the static table)
           │
           ▼
      AnalyzeCloudWasteUseCase.execute({ regions })
-     Runs the registered scanners in parallel (Promise.all),
+     Runs the registered scanners in parallel (Promise.all, one per ResourceKind),
      each scanner iterates the regions sequentially
           │
-     ┌────┬────┬────┬────┬────┬────┬────┬────┬────┬────┬────┐
-     ▼    ▼    ▼    ▼    ▼    ▼    ▼    ▼    ▼    ▼    ▼    │ (one per ResourceKind)
-   EBS  EIP  RDS  ELB  EC2  Snap  NAT  gp2  EBS  EC2  RDS  │
-  scan  scan scan scan scan scan scan scan  idle under- under-│
-     │    │    │    │    │    │    │    │   scan util*  util* │
-     ▼    ▼    ▼    ▼    ▼    ▼    ▼    ▼    ▼    ▼    ▼
-  EC2  EC2  RDS ELBv2 EC2* EC2** EC2+CW EC2 EC2+CW EC2+CW RDS+CW
-  API  API  API  API  API  API   API   API  API   +Pricing +Pricing
-          │        (* 2 calls; ** 3 calls; CW=CloudWatch, max 5 concurrent)
-          │        (EC2/RDS underutilized: registered only with --live-pricing —
-          │         need a per-instance-type/class price the static table lacks)
+     ┌─────────────┬─────────────┬─────────────┬─────────────┬─────────────┐
+     ▼             ▼             ▼             ▼             ▼             ▼
+   EC2 API       RDS API      ELBv2 API     S3+CW API    Lambda+CW     EFS+CW API
+  (volumes,     (instances,   (target       (buckets,    API          (file systems,
+   instances,    underutil.*)  groups/      lifecycle)   (functions,   mount targets,
+   snapshots,                  health)                    invocations)  I/O)
+   NAT, ENI,
+   underutil.*)
+     │
+     ▼
+  DynamoDB API           CloudWatch Logs API     ElastiCache+CW+Pricing API
+  (tables, capacity)     (log groups, retention)  (clusters, connections)*
+          │        (* CW=CloudWatch, max 5 concurrent; on-demand-priced scanners
+          │         — EC2/RDS underutilized, ElastiCache idle — registered only
+          │         with --live-pricing, since the static table has no per-type price)
           ▼
      Each scanner applies the domain waste policy
      (grace period, exclusion tag, type-specific criteria)
@@ -105,11 +110,13 @@ const policyOptions = { minAgeDays, ignoreTag: options.ignoreTag };
 const scanners: WasteScannerPort[] = [
   new AwsEbsVolumeScanner(pricing, accountId, new EbsVolumeWastePolicy(policyOptions)),
   new AwsElasticIpScanner(pricing, accountId, new ElasticIpWastePolicy(policyOptions)),
-  // … the other 6 always-registered scanners (rds, lb, ec2, snapshot, nat, gp2-upgrade, ebs-idle)
+  // … the other 13 always-registered scanners (rds, lb, ec2, snapshot, nat, gp2-upgrade,
+  // ebs-idle, log-group, eni-orphaned, s3-no-lifecycle, lambda-underutilized, efs-unused,
+  // dynamodb-overprovisioned)
 ];
 
-// EC2 underutilized needs a per-instance-type price (only available live):
-// registered conditionally, not part of the base 9.
+// EC2/RDS underutilized and ElastiCache idle need a per-type price (only available live):
+// registered conditionally, not part of the base 15.
 if (livePricingAdapter) {
   scanners.push(new AwsEc2UnderutilizedScanner(livePricingAdapter, accountId, new Ec2UnderutilizedPolicy(policyOptions)));
 }
@@ -196,6 +203,22 @@ Lists `running` instances, fetches `CPUUtilization` (`Average`, `Maximum`) over 
 
 Same pattern as `AwsEc2UnderutilizedScanner`, applied to RDS. Lists `available` instances (server-side filter, disjoint from `AwsRdsInstanceScanner`, which filters on `stopped`), fetches `CPUUtilization` from the `AWS/RDS` namespace (`Average`, `Maximum`) over the same configurable window (`config.utilizationWindowHours`), and resolves the monthly price **on demand** from the AWS Pricing API (it implements `RdsInstancePricingSource` by duck typing against `AwsPricingApiAdapter`, which maps the `DescribeDBInstances` engine — e.g. `postgres` — to the Pricing API's `databaseEngine` value — `PostgreSQL` — and uses `deploymentOption` for Single-AZ/Multi-AZ; engines with no mapping, such as Aurora, resolve to `undefined`). Without `--live-pricing` the scanner isn't registered, for the same reason as the EC2 scanner. Same savings estimate (half the monthly cost, `RIGHTSIZE_SAVING_FRACTION = 0.5`) and the same `estimated: true` flag: low CPU alone doesn't confirm storage I/O or connections are equally idle.
 
+#### `AwsS3NoLifecycleScanner` — Region-filtered global resource
+
+S3 buckets are **global**, not per-region: `ListBucketsCommand({ BucketRegion: region.code })` uses the (2024+) region filter so each region scan only ever sees the buckets that actually belong to it — without it, the same bucket would be reported once per scanned region. For each bucket it calls `GetBucketLifecycleConfiguration`, treating the `NoSuchLifecycleConfiguration` error name as "no policy" (any other error propagates and fails the scan), and reads `BucketSizeBytes` from CloudWatch (`AWS/S3`, daily metric, `StorageType=StandardStorage`). The estimated saving is a flat fraction (`ESTIMATED_SAVING_FRACTION = 0.4`) of the current Standard storage cost — advisory, since we don't know which objects are actually cold.
+
+#### `AwsEfsUnusedScanner` — No `DescribeMountTargets` needed
+
+`DescribeFileSystems` already returns `NumberOfMountTargets` and `SizeInBytes` per file system, so unlike a naive implementation this scanner needs no second API call to know whether a file system is reachable. CloudWatch (`DataReadIOBytes` + `DataWriteIOBytes`, summed) is only queried for file systems that **do** have a mount target — an orphan file system (zero mount targets) is waste by definition and the metric call is skipped entirely.
+
+#### `AwsDynamoDbOverprovisionedScanner` — Two-level fan-out
+
+The only scanner that needs a fan-out **before** CloudWatch: `ListTables` returns table names only, so a `DescribeTable` call per name (capped via `mapWithConcurrency`) resolves the `BillingModeSummary`/`ProvisionedThroughput` needed to decide if a table is even `PROVISIONED` (vs. `PAY_PER_REQUEST`, which is skipped — there's no fixed capacity to be "over"). Only then does it fetch `ConsumedReadCapacityUnits`/`ConsumedWriteCapacityUnits` for the provisioned tables. Utilization is `consumed / windowSeconds / provisioned`; the policy flags a table only when **both** read and write utilization are below threshold (a table read-heavy and write-light is correctly sized for its heavier dimension, not overprovisioned).
+
+#### `AwsElastiCacheIdleScanner` — Real cost, live-pricing gated like EC2/RDS
+
+Lists clusters, sums `CurrConnections` over the window — zero connections is an unambiguous idle signal (unlike CPU-based heuristics, no threshold tuning needed). Unlike Lambda (genuinely $0 when idle), an ElastiCache node is billed per node-hour regardless of usage, so this is real money — but the node-type price space is as large as EC2's, hence the same on-demand Pricing API resolution (`getElastiCacheNodePricePerMonth`, duck-typed like `Ec2InstancePricingSource`) and the same `--live-pricing` gate. Because the price, once resolved, is exact rather than a heuristic fraction, the kind is `estimated: false` and category `waste` — the only live-pricing-gated scanner that isn't advisory.
+
 ---
 
 ### Entities and Value Objects
@@ -211,6 +234,9 @@ EbsSnapshot.boundToAmiId                   // → not deletable
 Ec2Instance.stoppedSince                   // → grace period on the actual stop
 IdleEbsVolume.totalOps()                   // readOps + writeOps → EbsIdlePolicy
 UnderutilizedEc2Instance.maxCpuPercent     // → Ec2UnderutilizedPolicy
+EfsFileSystem.numberOfMountTargets         // → hasNoMountTargets()
+OverprovisionedDynamoDbTable.avgReadUtilizationPercent  // consumed/provisioned/window
+IdleElastiCacheCluster.connectionsLastWindow            // → isIdle()
 ```
 
 `CostEstimate.of(monthlyCostUsd, description)` is the only factory: price computation lives in the infrastructure (`StaticPriceTableAdapter` + `prices.json`), never in the domain.
@@ -255,7 +281,7 @@ All three share one `PriceTable` shape (`region → { key: USD }` with a `defaul
 - **`config.prices`** are the user's negotiated/enterprise rates and win over both. They are the only way to make the report match the actual bill — even live prices are AWS *list* prices, not your invoice.
 - `getPricesAsOf()` reflects the layer used: the static date, the live fetch date, or `… + custom overrides`.
 
-**Exception: `AwsEc2UnderutilizedScanner` and `AwsRdsUnderutilizedScanner`.** Per-instance-type/class prices aren't in `prices.json` (too many types to maintain) and aren't pre-warmed by `warmUp()`. The two scanners instead call `AwsPricingApiAdapter.getEc2InstancePricePerMonth(region, instanceType)` / `getRdsInstancePricePerMonth(region, instanceClass, engine, deploymentOption)` directly, on demand, for each distinct instance type/class found — which is why these are the only two scanners that need `--live-pricing` to even be registered, rather than degrading gracefully to a static fallback like the others.
+**Exception: `AwsEc2UnderutilizedScanner`, `AwsRdsUnderutilizedScanner` and `AwsElastiCacheIdleScanner`.** Per-instance-type/class/node-type prices aren't in `prices.json` (too many distinct types to maintain) and aren't pre-warmed by `warmUp()`. These three scanners instead call `AwsPricingApiAdapter.getEc2InstancePricePerMonth(region, instanceType)` / `getRdsInstancePricePerMonth(region, instanceClass, engine, deploymentOption)` / `getElastiCacheNodePricePerMonth(region, cacheNodeType)` directly, on demand, for each distinct type found — which is why these are the only three scanners that need `--live-pricing` to even be registered, rather than degrading gracefully to a static fallback like the others. DynamoDB is not an exception here: RCU/WCU prices are uniform per region (not per-table-type), so they live in `prices.json` like any other static price.
 
 ## CI/CD integration
 

--- a/docs/en/testing.md
+++ b/docs/en/testing.md
@@ -34,7 +34,7 @@ Policies live in one file, [`libs/cloud-cost/domain/src/policies/resource-waste-
 
 ### Infra — scanners
 
-One spec per scanner under [`libs/cloud-cost/infrastructure/aws-adapter/src/scanners/`](../../libs/cloud-cost/infrastructure/aws-adapter/src/scanners/), with the AWS SDK client mocked. Each covers: the candidate filter (e.g. `DescribeVolumes` with `Filters=[status=available]`), pagination, concurrency, SDK errors, and `destroy()` on the client. The four CloudWatch-based scanners (`aws-ebs-idle`, `aws-ec2-underutilized`, `aws-nat-gateway`, `aws-rds-underutilized`) additionally assert the exact `Namespace`, `Period`, `Statistics` and `Dimensions` sent to `GetMetricStatistics` — this is the contract the manual verification script below leans on.
+One spec per scanner under [`libs/cloud-cost/infrastructure/aws-adapter/src/scanners/`](../../libs/cloud-cost/infrastructure/aws-adapter/src/scanners/), with the AWS SDK client mocked. Each covers: the candidate filter (e.g. `DescribeVolumes` with `Filters=[status=available]`), pagination, concurrency, SDK errors, and `destroy()` on the client. Nine scanners are CloudWatch-based (`aws-ebs-idle`, `aws-ec2-underutilized`, `aws-nat-gateway`, `aws-rds-underutilized`, `aws-efs-unused`, `aws-lambda-underutilized`, `aws-s3-no-lifecycle`, `aws-dynamodb-overprovisioned`, `aws-elasticache-idle`) and additionally assert the exact `Namespace`, `Period`, `Statistics` and `Dimensions` sent to `GetMetricStatistics` — this is the contract the manual verification script below leans on for the four it currently covers (`aws-ebs-idle`, `aws-ec2-underutilized`, `aws-nat-gateway`, `aws-rds-underutilized`); the other five aren't wired into that script yet.
 
 ### CLI e2e
 
@@ -42,7 +42,7 @@ One spec per scanner under [`libs/cloud-cost/infrastructure/aws-adapter/src/scan
 
 ## Manual verification against a real AWS account
 
-Mocked SDK calls verify the *shape* of a query; they cannot verify that the shape actually matches what AWS returns for real resources. [`scripts/verify-against-aws.mjs`](../../scripts/verify-against-aws.mjs) closes that gap: it runs all 11 scanners against a real AWS account and prints what they find, next to the static query descriptor that the corresponding scanner spec already enforces in CI.
+Mocked SDK calls verify the *shape* of a query; they cannot verify that the shape actually matches what AWS returns for real resources. [`scripts/verify-against-aws.mjs`](../../scripts/verify-against-aws.mjs) closes that gap: it runs 11 of the 18 scanners — everything shipped before v0.4.0 — against a real AWS account and prints what they find, next to the static query descriptor that the corresponding scanner spec already enforces in CI. The 7 scanners added in v0.4.0 (`log-group`, `eni-orphaned`, `s3-no-lifecycle`, `lambda-underutilized`, `efs-unused`, `dynamodb-overprovisioned`, `elasticache-idle`) aren't wired into this script yet.
 
 It is **not** run by `pnpm test` or by CI — it calls real AWS APIs and must be run by hand against a **sandbox** account.
 

--- a/docs/it/architettura.md
+++ b/docs/it/architettura.md
@@ -33,7 +33,7 @@ Ciò che **non** compra da sola è il multi-cloud: vedi la sezione [Verso il mul
 │  (WastedResource, entità│   │  (Entity, ValueObject,    │
 │   waste policies, ports)│   │   Result, DomainError)    │
 └──────▲──────────────────┘   └───────────────────────────┘
-       │ implementa WasteScannerPort (×10)
+       │ implementa WasteScannerPort (×18)
 ┌──────┴──────────────────────────────────────────────────┐
 │        libs/cloud-cost/infrastructure/aws-adapter       │
 │   (scanner AWS SDK v3, pricing, STS account resolver)   │
@@ -99,6 +99,13 @@ export const RESOURCE_KINDS = [
   'ebs-idle',
   'ec2-underutilized',
   'rds-underutilized',
+  'log-group',
+  'eni-orphaned',
+  's3-no-lifecycle',
+  'lambda-underutilized',
+  'efs-unused',
+  'dynamodb-overprovisioned',
+  'elasticache-idle',
 ] as const;
 
 export type ResourceKind = (typeof RESOURCE_KINDS)[number];
@@ -138,7 +145,7 @@ export const RESOURCE_KIND_META: Record<ResourceKind, ResourceKindMeta> = {
 
 #### Entità
 
-Le 11 entità (`EbsVolume`, `ElasticIp`, `RdsInstance`, `LoadBalancer`, `Ec2Instance`, `EbsSnapshot`, `NatGateway`, `Gp2Volume`, `IdleEbsVolume`, `UnderutilizedEc2Instance`, `RdsUnderutilizedInstance`) implementano `WastedResource` e portano i **fatti** osservati necessari alle decisioni: `LoadBalancer.registeredTargetCount`, `NatGateway.bytesOutLastWindow`, `EbsSnapshot.sourceVolumeExists` / `boundToAmiId`, `Ec2Instance.stoppedSince`, la somma di `VolumeReadOps`/`VolumeWriteOps` di `IdleEbsVolume`, `UnderutilizedEc2Instance.maxCpuPercent`, `RdsUnderutilizedInstance.maxCpuPercent`. `Gp2Volume`, `UnderutilizedEc2Instance` e `RdsUnderutilizedInstance` sono opportunità di risparmio più che spreco da cancellare: il loro `costEstimate` porta il *risparmio* mensile stimato, non un costo effettivamente pagato.
+Le 18 entità (`EbsVolume`, `ElasticIp`, `RdsInstance`, `LoadBalancer`, `Ec2Instance`, `EbsSnapshot`, `NatGateway`, `Gp2Volume`, `IdleEbsVolume`, `UnderutilizedEc2Instance`, `RdsUnderutilizedInstance`, `LogGroup`, `OrphanedEni`, `S3Bucket`, `UnderutilizedLambdaFunction`, `EfsFileSystem`, `OverprovisionedDynamoDbTable`, `IdleElastiCacheCluster`) implementano `WastedResource` e portano i **fatti** osservati necessari alle decisioni: `LoadBalancer.registeredTargetCount`, `NatGateway.bytesOutLastWindow`, `EbsSnapshot.sourceVolumeExists` / `boundToAmiId`, `Ec2Instance.stoppedSince`, la somma di `VolumeReadOps`/`VolumeWriteOps` di `IdleEbsVolume`, `UnderutilizedEc2Instance.maxCpuPercent`, `RdsUnderutilizedInstance.maxCpuPercent`, `LogGroup.hasRetentionPolicy()`, `OrphanedEni.isOrphaned()` (`Status === 'available'`), `S3Bucket.hasLifecyclePolicy()`, `UnderutilizedLambdaFunction.invocationsLastWindow`, `EfsFileSystem.numberOfMountTargets` / `ioBytesLastWindow`, `OverprovisionedDynamoDbTable.avgReadUtilizationPercent` / `avgWriteUtilizationPercent`, `IdleElastiCacheCluster.connectionsLastWindow`. `Gp2Volume`, `UnderutilizedEc2Instance`, `RdsUnderutilizedInstance`, `S3Bucket`, `UnderutilizedLambdaFunction` e `OverprovisionedDynamoDbTable` sono opportunità di risparmio più che spreco da cancellare: il loro `costEstimate` porta il *risparmio* mensile stimato (o, per la segnalazione di igiene Lambda, un flat $0), non un costo effettivamente pagato.
 
 #### Waste Policies — dove vive la conoscenza di business
 
@@ -162,8 +169,15 @@ Ogni policy concreta aggiunge il criterio specifico del tipo:
 | `Ec2UnderutilizedPolicy`  | istanza running, CPU massima ≤ `ec2CpuPercent` (default 5) nella finestra | grace su `launchTime`; registrata solo con `--live-pricing` attivo (serve un prezzo per instance type) |
 | `RdsUnderutilizedPolicy`  | istanza available, CPU massima ≤ `rdsCpuPercent` (default 5) nella finestra | grace su `instanceCreateTime`; registrata solo con `--live-pricing` attivo (serve un prezzo per instance class) |
 | `Gp2UpgradePolicy`        | volume gp2 in uso (risparmio, non spreco) | solo `status=in-use` (i gp2 staccati restano a `ebs-volume`); grace su `createTime` |
+| `LogGroupWastePolicy`     | nessuna retention policy configurata      | grace su `creationTime`                                                          |
+| `OrphanedEniWastePolicy`  | `Status === 'available'` (non attaccata)  | — (le ENI non hanno data di creazione); costo $0 — igiene, non risparmio          |
+| `S3NoLifecyclePolicy`     | nessuna lifecycle configuration           | grace su `creationDate`; risparmio stimato (`estimated: true`)                   |
+| `LambdaUnderutilizedPolicy` | invocazioni ≤ `lambdaInvocationsMin` (default 0) nella finestra | grace su `lastModified`; costo $0 — Lambda pay-per-use non ha costo diretto se inattiva |
+| `EfsUnusedPolicy`         | nessun mount target, oppure montato con I/O ≤ `efsIoBytesMin` (default 0) nella finestra | grace su `creationTime`                                |
+| `DynamoDbOverprovisionedPolicy` | utilizzo read **e** write < `dynamoCapacityUtilizationPercent` (default 10%) nella finestra | grace su `creationDateTime`; risparmio stimato (`estimated: true`) |
+| `ElastiCacheIdlePolicy`   | zero connessioni nella finestra           | grace su `createTime`; registrata solo con `--live-pricing` attivo (serve un prezzo per node type) |
 
-`EbsIdlePolicy`, `Ec2UnderutilizedPolicy` e `RdsUnderutilizedPolicy` ricevono le soglie come parametri del costruttore (`ebsIdleMaxOps`, `ec2CpuPercent`, `rdsCpuPercent`), configurabili via `config.thresholds`.
+`EbsIdlePolicy`, `Ec2UnderutilizedPolicy`, `RdsUnderutilizedPolicy`, `LambdaUnderutilizedPolicy`, `EfsUnusedPolicy` e `DynamoDbOverprovisionedPolicy` ricevono le soglie come parametri del costruttore (`ebsIdleMaxOps`, `ec2CpuPercent`, `rdsCpuPercent`, `lambdaInvocationsMin`, `efsIoBytesMin`, `dynamoCapacityUtilizationPercent`), configurabili via `config.thresholds`.
 
 Le policy sono pura logica di dominio: si testano senza AWS, e i loro parametri arrivano dalla CLI (`--min-age-days`, `--ignore-tag`).
 
@@ -206,7 +220,7 @@ Particolarità:
 
 ### 5. `apps/cli` — Entry point e composition root
 
-`analyze-waste.command.ts` carica il file di config, risolve le opzioni CLI (regioni, min-age, account ID) e orchestra l'esecuzione; delega l'istanziazione effettiva delle implementazioni concrete a `analyze-waste.composition.ts` tramite il seam iniettabile `AnalyzeDeps.createAnalysis` (lo stesso seam che `analyze-waste.command.spec.ts` finge per testare senza AWS). `analyze-waste.composition.ts` è l'unico punto in cui le implementazioni concrete vengono istanziate: costruisce il listino prezzi, le policy (con i parametri da config + CLI) e 9 degli 11 scanner, iniettandoli nel use case. Gli altri due, `AwsEc2UnderutilizedScanner` e `AwsRdsUnderutilizedScanner`, vengono registrati solo se `--live-pricing` è attivo: la loro stima di risparmio richiede un prezzo per instance type/classe che il listino statico non contiene, quindi senza prezzi live non c'è nulla di affidabile da riportare e gli scanner vengono esclusi piuttosto che registrati con una stima a zero. Tornati in `analyze-waste.command.ts`, il risultato passa ai formatter. I quattro formatter (tabella console, PDF, JSON, Markdown) condividono il registry `resource-presenters.ts`, tipizzato `Record<ResourceKind, ResourcePresenter<…>>`: dimenticare il presenter di un nuovo kind è un errore di compilazione. Il formato di output si sceglie con `--format` (`table` | `json` | `markdown`); `markdown` è pensato per CI / commenti PR.
+`analyze-waste.command.ts` carica il file di config, risolve le opzioni CLI (regioni, min-age, account ID) e orchestra l'esecuzione; delega l'istanziazione effettiva delle implementazioni concrete a `analyze-waste.composition.ts` tramite il seam iniettabile `AnalyzeDeps.createAnalysis` (lo stesso seam che `analyze-waste.command.spec.ts` finge per testare senza AWS). `analyze-waste.composition.ts` è l'unico punto in cui le implementazioni concrete vengono istanziate: costruisce il listino prezzi, le policy (con i parametri da config + CLI) e 15 dei 18 scanner, iniettandoli nel use case. Gli altri tre — `AwsEc2UnderutilizedScanner`, `AwsRdsUnderutilizedScanner` e `AwsElastiCacheIdleScanner` — vengono registrati solo se `--live-pricing` è attivo: la loro stima di costo richiede un prezzo per instance type/classe/node type che il listino statico non contiene (troppi tipi distinti da mantenere), quindi senza prezzi live non c'è nulla di affidabile da riportare e gli scanner vengono esclusi piuttosto che registrati con una stima a zero. Tornati in `analyze-waste.command.ts`, il risultato passa ai formatter. I quattro formatter (tabella console, PDF, JSON, Markdown) condividono il registry `resource-presenters.ts`, tipizzato `Record<ResourceKind, ResourcePresenter<…>>`: dimenticare il presenter di un nuovo kind è un errore di compilazione. Il formato di output si sceglie con `--format` (`table` | `json` | `markdown`); `markdown` è pensato per CI / commenti PR.
 
 ---
 
@@ -235,7 +249,7 @@ L'unico tipo AWS-specifico che attraversa il confine inbound è `AwsRegion`. Si 
 
 Due opzioni, da scegliere quando esisterà il requisito reale:
 
-- **Kind aggiuntivi nello stesso contesto** — `'gcp-persistent-disk'`, `'gcp-static-ip'`, … entrano nella union `ResourceKind` con le loro entità (`PersistentDisk`, non un finto `EbsVolume`), policy e scanner (`libs/cloud-cost/infrastructure/gcp-adapter`). Adatta se il prodotto resta "un report di spreco unificato". Il `Promise.all` del coordinatore scala da 11 a N scanner senza modifiche.
+- **Kind aggiuntivi nello stesso contesto** — `'gcp-persistent-disk'`, `'gcp-static-ip'`, … entrano nella union `ResourceKind` con le loro entità (`PersistentDisk`, non un finto `EbsVolume`), policy e scanner (`libs/cloud-cost/infrastructure/gcp-adapter`). Adatta se il prodotto resta "un report di spreco unificato". Il `Promise.all` del coordinatore scala da 18 a N scanner senza modifiche.
 - **Bounded context separato** — `libs/gcp-cost/` con il proprio domain, se le semantiche divergono troppo. Condivide solo `shared/kernel`. La struttura `libs/<context>/` lo prevede già.
 
 La prima opzione è quella raccomandata finché il report resta unificato: il costo marginale di un kind GCP è identico a quello di un kind AWS (entità + policy + scanner + presenter).

--- a/docs/it/funzionamento.md
+++ b/docs/it/funzionamento.md
@@ -24,25 +24,30 @@ utente: cloudrift analyze -r us-east-1 eu-west-1 [--format json|markdown] [--pdf
           ▼
      analyze-waste.composition.ts  (composition root: costruisce pricing + scanner)
      4. Pricing: tabella statica ← live API (--live-pricing) ← config.prices (vincono)
-     5. Istanzia policy (config + flag) e 9 degli 11 scanner
-        (gli altri due, EC2/RDS underutilized, solo con --live-pricing)
+     5. Istanzia policy (config + flag) e 15 dei 18 scanner
+        (gli altri tre — EC2/RDS underutilized, ElastiCache idle —
+         solo con --live-pricing: prezzo per tipo non nel listino statico)
           │
           ▼
      AnalyzeCloudWasteUseCase.execute({ regions })
-     Esegue gli scanner registrati in parallelo (Promise.all),
+     Esegue gli scanner registrati in parallelo (Promise.all, uno per ResourceKind),
      ogni scanner itera le regioni in sequenza
           │
-     ┌────┬────┬────┬────┬────┬────┬────┬────┬────┬────┬────┐
-     ▼    ▼    ▼    ▼    ▼    ▼    ▼    ▼    ▼    ▼    ▼    │ (uno per ResourceKind)
-   EBS  EIP  RDS  ELB  EC2  Snap  NAT  gp2  EBS  EC2  RDS  │
-  scan  scan scan scan scan scan scan scan  idle under- under-│
-     │    │    │    │    │    │    │    │   scan util*  util* │
-     ▼    ▼    ▼    ▼    ▼    ▼    ▼    ▼    ▼    ▼    ▼
-  EC2  EC2  RDS ELBv2 EC2* EC2** EC2+CW EC2 EC2+CW EC2+CW RDS+CW
-  API  API  API  API  API  API   API   API  API   +Pricing +Pricing
-          │        (* 2 chiamate; ** 3 chiamate; CW=CloudWatch, max 5 concorrenti)
-          │        (EC2/RDS underutilized: registrati solo con --live-pricing — serve
-          │         un prezzo per instance type/classe che il listino statico non ha)
+     ┌─────────────┬─────────────┬─────────────┬─────────────┬─────────────┐
+     ▼             ▼             ▼             ▼             ▼             ▼
+   EC2 API       RDS API      ELBv2 API     S3+CW API    Lambda+CW     EFS+CW API
+  (volumi,      (istanze,     (target       (bucket,     API          (file system,
+   istanze,      underutil.*)  group/       lifecycle)   (funzioni,    mount target,
+   snapshot,                   health)                    invocazioni)  I/O)
+   NAT, ENI,
+   underutil.*)
+     │
+     ▼
+  DynamoDB API           CloudWatch Logs API     ElastiCache+CW+Pricing API
+  (tabelle, capacità)    (log group, retention)  (cluster, connessioni)*
+          │        (* CW=CloudWatch, max 5 concorrenti; scanner con prezzo on-demand
+          │         — EC2/RDS underutilized, ElastiCache idle — registrati solo
+          │         con --live-pricing, perché il listino statico non ha un prezzo per tipo)
           ▼
      Ogni scanner applica la waste policy di dominio
      (grace period, tag di esclusione, criteri specifici)
@@ -105,11 +110,13 @@ const policyOptions = { minAgeDays, ignoreTag: options.ignoreTag };
 const scanners: WasteScannerPort[] = [
   new AwsEbsVolumeScanner(pricing, accountId, new EbsVolumeWastePolicy(policyOptions)),
   new AwsElasticIpScanner(pricing, accountId, new ElasticIpWastePolicy(policyOptions)),
-  // … gli altri 6 scanner sempre registrati (rds, lb, ec2, snapshot, nat, gp2-upgrade, ebs-idle)
+  // … gli altri 13 scanner sempre registrati (rds, lb, ec2, snapshot, nat, gp2-upgrade,
+  // ebs-idle, log-group, eni-orphaned, s3-no-lifecycle, lambda-underutilized, efs-unused,
+  // dynamodb-overprovisioned)
 ];
 
-// EC2 underutilized richiede un prezzo per instance type (disponibile solo live):
-// registrato condizionalmente, non fa parte dei 9 di base.
+// EC2/RDS underutilized e ElastiCache idle richiedono un prezzo per tipo (disponibile
+// solo live): registrati condizionalmente, non fanno parte dei 15 di base.
 if (livePricingAdapter) {
   scanners.push(new AwsEc2UnderutilizedScanner(livePricingAdapter, accountId, new Ec2UnderutilizedPolicy(policyOptions)));
 }
@@ -196,6 +203,22 @@ Elenca le istanze `running`, recupera `CPUUtilization` (`Average`, `Maximum`) su
 
 Stesso pattern di `AwsEc2UnderutilizedScanner`, applicato a RDS. Elenca le istanze `available` (filtro server-side, disgiunto da `AwsRdsInstanceScanner` che filtra su `stopped`), recupera `CPUUtilization` dal namespace `AWS/RDS` (`Average`, `Maximum`) sulla stessa finestra configurabile (`config.utilizationWindowHours`), e risolve il prezzo mensile **on demand** dall'AWS Pricing API (implementa `RdsInstancePricingSource` per duck typing contro `AwsPricingApiAdapter`, che mappa l'engine di `DescribeDBInstances` — es. `postgres` — al valore `databaseEngine` del Pricing API — `PostgreSQL` — e usa `deploymentOption` per Single-AZ/Multi-AZ; engine senza mappatura, come Aurora, restituiscono `undefined`). Senza `--live-pricing` lo scanner non viene registrato, per lo stesso motivo dello scanner EC2. Stessa stima di risparmio (metà del costo mensile, `RIGHTSIZE_SAVING_FRACTION = 0.5`) e stesso flag `estimated: true`: una CPU bassa non conferma che storage I/O o connessioni siano altrettanto inutilizzati.
 
+#### `AwsS3NoLifecycleScanner` — Risorsa globale filtrata per regione
+
+I bucket S3 sono **globali**, non per-regione: `ListBucketsCommand({ BucketRegion: region.code })` usa il filtro per regione (disponibile dal 2024+) così ogni scan regionale vede solo i bucket che gli appartengono davvero — senza di esso, lo stesso bucket verrebbe segnalato una volta per ogni regione scansionata. Per ogni bucket chiama `GetBucketLifecycleConfiguration`, trattando l'errore con nome `NoSuchLifecycleConfiguration` come "nessuna policy" (qualunque altro errore si propaga e fa fallire lo scan), e legge `BucketSizeBytes` da CloudWatch (`AWS/S3`, metrica giornaliera, `StorageType=StandardStorage`). Il risparmio stimato è una frazione fissa (`ESTIMATED_SAVING_FRACTION = 0.4`) del costo storage Standard corrente — advisory, perché non sappiamo quali oggetti siano davvero freddi.
+
+#### `AwsEfsUnusedScanner` — Non serve `DescribeMountTargets`
+
+`DescribeFileSystems` restituisce già `NumberOfMountTargets` e `SizeInBytes` per ogni file system, quindi a differenza di un'implementazione naive questo scanner non ha bisogno di una seconda chiamata API per sapere se un file system è raggiungibile. CloudWatch (`DataReadIOBytes` + `DataWriteIOBytes`, sommati) viene interrogato solo per i file system che **hanno** un mount target — un file system orfano (zero mount target) è spreco per definizione e la chiamata alla metrica viene saltata del tutto.
+
+#### `AwsDynamoDbOverprovisionedScanner` — Fan-out a due livelli
+
+L'unico scanner che ha bisogno di un fan-out **prima** di CloudWatch: `ListTables` restituisce solo i nomi delle tabelle, quindi una chiamata `DescribeTable` per nome (limitata via `mapWithConcurrency`) risolve `BillingModeSummary`/`ProvisionedThroughput`, necessari per decidere se una tabella sia anche solo `PROVISIONED` (vs `PAY_PER_REQUEST`, che viene saltata — non c'è capacità fissa di cui essere "in eccesso"). Solo a quel punto recupera `ConsumedReadCapacityUnits`/`ConsumedWriteCapacityUnits` per le tabelle provisioned. L'utilizzo è `consumato / secondiFinestra / provisioned`; la policy segnala una tabella solo quando **sia** l'utilizzo read **sia** quello write sono sotto soglia (una tabella read-heavy e write-light è dimensionata correttamente per la sua dimensione più pesante, non overprovisioned).
+
+#### `AwsElastiCacheIdleScanner` — Costo reale, gated su live-pricing come EC2/RDS
+
+Elenca i cluster, somma `CurrConnections` nella finestra — zero connessioni è un segnale di idle inequivocabile (a differenza delle euristiche basate su CPU, non serve calibrare una soglia). A differenza di Lambda (genuinamente $0 se inattiva), un nodo ElastiCache è fatturato per ora indipendentemente dall'uso, quindi qui si tratta di soldi reali — ma lo spazio dei node type è ampio quanto quello EC2, da cui la stessa risoluzione on-demand dalla Pricing API (`getElastiCacheNodePricePerMonth`, duck-typed come `Ec2InstancePricingSource`) e lo stesso gate `--live-pricing`. Poiché il prezzo, una volta risolto, è esatto e non una frazione euristica, il kind è `estimated: false` e categoria `waste` — l'unico scanner gated su live-pricing che non è advisory.
+
 ---
 
 ### Entità e Value Object
@@ -211,6 +234,9 @@ EbsSnapshot.boundToAmiId                   // → non cancellabile
 Ec2Instance.stoppedSince                   // → grace period sullo stop reale
 IdleEbsVolume.totalOps()                   // readOps + writeOps → EbsIdlePolicy
 UnderutilizedEc2Instance.maxCpuPercent     // → Ec2UnderutilizedPolicy
+EfsFileSystem.numberOfMountTargets         // → hasNoMountTargets()
+OverprovisionedDynamoDbTable.avgReadUtilizationPercent  // consumato/provisioned/finestra
+IdleElastiCacheCluster.connectionsLastWindow            // → isIdle()
 ```
 
 `CostEstimate.of(monthlyCostUsd, description)` è l'unico factory: il calcolo dei prezzi vive nell'infrastruttura (`StaticPriceTableAdapter` + `prices.json`), mai nel domain.
@@ -255,7 +281,7 @@ Tutte e tre condividono la stessa forma `PriceTable` (`regione → { chiave: USD
 - **`config.prices`** sono le tariffe negoziate/aziendali dell'utente e vincono su entrambi. Sono l'unico modo per far combaciare il report con la bolletta reale — anche i prezzi live sono prezzi di *listino* AWS, non la tua fattura.
 - `getPricesAsOf()` riflette il livello usato: la data dello statico, quella del fetch live, o `… + custom overrides`.
 
-**Eccezione: `AwsEc2UnderutilizedScanner` e `AwsRdsUnderutilizedScanner`.** I prezzi per instance type/classe non sono in `prices.json` (troppi tipi da mantenere) e non vengono pre-caricati da `warmUp()`. I due scanner chiamano invece direttamente `AwsPricingApiAdapter.getEc2InstancePricePerMonth(region, instanceType)` / `getRdsInstancePricePerMonth(region, instanceClass, engine, deploymentOption)`, on demand, per ogni instance type/classe distinto trovato — per questo sono gli unici due scanner che richiedono `--live-pricing` per essere registrati affatto, invece di degradare al listino statico come gli altri.
+**Eccezione: `AwsEc2UnderutilizedScanner`, `AwsRdsUnderutilizedScanner` e `AwsElastiCacheIdleScanner`.** I prezzi per instance type/classe/node type non sono in `prices.json` (troppi tipi distinti da mantenere) e non vengono pre-caricati da `warmUp()`. Questi tre scanner chiamano invece direttamente `AwsPricingApiAdapter.getEc2InstancePricePerMonth(region, instanceType)` / `getRdsInstancePricePerMonth(region, instanceClass, engine, deploymentOption)` / `getElastiCacheNodePricePerMonth(region, cacheNodeType)`, on demand, per ogni tipo distinto trovato — per questo sono gli unici tre scanner che richiedono `--live-pricing` per essere registrati affatto, invece di degradare al listino statico come gli altri. DynamoDB non è un'eccezione: i prezzi RCU/WCU sono uniformi per regione (non per-tipo-di-tabella), quindi stanno in `prices.json` come qualunque altro prezzo statico.
 
 ## Integrazione CI/CD
 

--- a/docs/it/test.md
+++ b/docs/it/test.md
@@ -34,7 +34,7 @@ Le policy vivono in un unico file, [`libs/cloud-cost/domain/src/policies/resourc
 
 ### Infra — scanner
 
-Uno spec per scanner in [`libs/cloud-cost/infrastructure/aws-adapter/src/scanners/`](../../libs/cloud-cost/infrastructure/aws-adapter/src/scanners/), con il client SDK AWS mockato. Ognuno copre: il filtro dei candidati (es. `DescribeVolumes` con `Filters=[status=available]`), paginazione, concorrenza, errori dell'SDK e `destroy()` sul client. I quattro scanner basati su CloudWatch (`aws-ebs-idle`, `aws-ec2-underutilized`, `aws-nat-gateway`, `aws-rds-underutilized`) asseriscono in più l'esatto `Namespace`, `Period`, `Statistics` e `Dimensions` inviati a `GetMetricStatistics` — è il contratto su cui si appoggia lo script di verifica manuale descritto sotto.
+Uno spec per scanner in [`libs/cloud-cost/infrastructure/aws-adapter/src/scanners/`](../../libs/cloud-cost/infrastructure/aws-adapter/src/scanners/), con il client SDK AWS mockato. Ognuno copre: il filtro dei candidati (es. `DescribeVolumes` con `Filters=[status=available]`), paginazione, concorrenza, errori dell'SDK e `destroy()` sul client. Nove scanner sono basati su CloudWatch (`aws-ebs-idle`, `aws-ec2-underutilized`, `aws-nat-gateway`, `aws-rds-underutilized`, `aws-efs-unused`, `aws-lambda-underutilized`, `aws-s3-no-lifecycle`, `aws-dynamodb-overprovisioned`, `aws-elasticache-idle`) e asseriscono in più l'esatto `Namespace`, `Period`, `Statistics` e `Dimensions` inviati a `GetMetricStatistics` — è il contratto su cui si appoggia lo script di verifica manuale descritto sotto per i quattro che copre attualmente (`aws-ebs-idle`, `aws-ec2-underutilized`, `aws-nat-gateway`, `aws-rds-underutilized`); gli altri cinque non sono ancora cablati in quello script.
 
 ### CLI e2e
 
@@ -42,7 +42,7 @@ Uno spec per scanner in [`libs/cloud-cost/infrastructure/aws-adapter/src/scanner
 
 ## Verifica manuale contro un account AWS reale
 
-Le chiamate SDK mockate verificano la *forma* di una query; non possono verificare che quella forma corrisponda davvero a ciò che AWS restituisce per risorse reali. [`scripts/verify-against-aws.mjs`](../../scripts/verify-against-aws.mjs) chiude questo gap: esegue tutti gli 11 scanner contro un account AWS reale e stampa cosa trovano, accanto al descrittore statico della query già asserito in CI dallo spec dello scanner corrispondente.
+Le chiamate SDK mockate verificano la *forma* di una query; non possono verificare che quella forma corrisponda davvero a ciò che AWS restituisce per risorse reali. [`scripts/verify-against-aws.mjs`](../../scripts/verify-against-aws.mjs) chiude questo gap: esegue 11 dei 18 scanner — tutto ciò che è stato pubblicato prima della v0.4.0 — contro un account AWS reale e stampa cosa trovano, accanto al descrittore statico della query già asserito in CI dallo spec dello scanner corrispondente. I 7 scanner aggiunti nella v0.4.0 (`log-group`, `eni-orphaned`, `s3-no-lifecycle`, `lambda-underutilized`, `efs-unused`, `dynamodb-overprovisioned`, `elasticache-idle`) non sono ancora cablati in questo script.
 
 **Non** viene eseguito da `pnpm test` né dalla CI — chiama API AWS reali e va lanciato a mano contro un account **sandbox**.
 


### PR DESCRIPTION
# 📚 Aggiornamento Documentazione v0.4.0 — Architettura, Testing e Funzionamento

Aggiornata la documentazione tecnica per allinearla all’attuale stato del progetto (**18 scanner totali**) e correggere vari riferimenti rimasti indietro rispetto alle release recenti.

Nessun codice applicativo modificato: aggiornamenti esclusivamente documentali.

---

## 🔹 Aggiornamento Documentazione Testing

Aggiornata la documentazione di testing per riflettere correttamente la crescita degli scanner basati su CloudWatch.

### Scanner CloudWatch-based

Il riferimento ai **“4 scanner basati su CloudWatch”** non era più corretto.

Il numero attuale è **9 scanner**:

- `aws-ebs-idle`
- `aws-ec2-underutilized`
- `aws-nat-gateway`
- `aws-rds-underutilized`
- `aws-efs-unused`
- `aws-lambda-underutilized`
- `aws-s3-no-lifecycle`
- `aws-dynamodb-overprovisioned`
- `aws-elasticache-idle`

### Nota su `verify-against-aws.mjs`

È stato chiarito che, ad oggi, lo script di verifica AWS reale esegue assert espliciti solo sui **4 scanner originali**.

---

## 🔹 Manual Verification Script

Aggiornata la sezione dedicata alla verifica manuale.

Lo script ora viene descritto come copertura di:

```txt
11 scanner su 18
```

Sono inoltre elencati esplicitamente i **7 scanner introdotti in v0.4.0** non ancora collegati allo script.

### Nota

Lo script `verify-against-aws.mjs` **non è stato modificato**.

L’estensione della copertura è stata volutamente rimandata a una decisione separata.

---

## 🔹 Sezioni lasciate invariate

Sono state lasciate inalterate:

- tabella della seeding checklist
- lista illustrativa degli entity spec

Motivazione:

- riflettono esattamente ciò che lo script verifica oggi
- nessuna nuova riga necessaria finché lo script non verrà esteso

---

# 🏗️ Aggiornamento `architecture.md` / `architettura.md`

Aggiornati:

- `docs/en/architecture.md`
- `docs/it/architettura.md`

---

## 🔹 Resource Kinds

Aggiornamento conteggio:

- `RESOURCE_KINDS`: **11 → 18**
- `WasteScannerPort`: **10 → 18**

---

## 🔹 Policy Table

Estesa la tabella delle policy con 7 nuove policy:

- `LogGroupWastePolicy`
- `OrphanedEniWastePolicy`
- `S3NoLifecyclePolicy`
- `LambdaUnderutilizedPolicy`
- `EfsUnusedPolicy`
- `DynamoDbOverprovisionedPolicy`
- `ElastiCacheIdlePolicy`

---

## 🔹 Composition Root

Aggiornata la sezione relativa al composition root.

Prima:

```txt
9 di 11 scanner sempre attivi, 2 gated
```

Ora:

```txt
15 di 18 scanner sempre attivi, 3 gated
```

Scanner gated dietro:

```bash
--live-pricing
```

Include ora anche:

- `AwsElastiCacheIdleScanner`

---

# ⚙️ Aggiornamento `how-it-works.md` / `funzionamento.md`

Aggiornati:

- `docs/en/how-it-works.md`
- `docs/it/funzionamento.md`

---

## 🔹 Diagramma Architetturale

Il diagramma ASCII precedente rappresentava ogni scanner singolarmente.

Con 18 scanner, la rappresentazione manuale non era più mantenibile.

Per questo è stato semplificato:

- raggruppamento per servizio AWS
- rimozione dei 18 box individuali

Il diagramma continua comunque a comunicare le informazioni chiave:

- parallelismo
- servizi interrogati
- scanner gated

---

## 🔹 Nuove Sottosezioni Scanner

Aggiunte sottosezioni dedicate agli scanner con peculiarità architetturali rilevanti.

### `AwsS3NoLifecycleScanner`

Punto chiave:

- filtro region-aware su una risorsa globale

Evita scansioni duplicate dei bucket S3.

---

### `AwsEfsUnusedScanner`

Punto chiave:

- non richiede `DescribeMountTargets`

Le informazioni necessarie sono già disponibili in:

```ts
DescribeFileSystems
```

---

### `AwsDynamoDbOverprovisionedScanner`

Punto chiave:

- unico scanner con fan-out a due livelli

Pipeline:

```txt
ListTables → DescribeTable
```

---

### `AwsElastiCacheIdleScanner`

Punto chiave:

- costo esatto calcolabile
- scanner gated da live pricing

Motivazione:

- elevata cardinalità dei node type

---

## 🔹 Pricing Resolution

Aggiornata la sezione di pricing.

### On-demand pricing

L’eccezione di pricing dinamico ora include:

- EC2
- RDS
- ElastiCache

Tutti richiedono:

```bash
--live-pricing
```

### Pricing statico DynamoDB

Chiarito che DynamoDB resta nel listino statico.

Motivazione:

- RCU e WCU hanno prezzo uniforme
- non esiste pricing per instance type

---

## 🧪 Quality Assurance

Verifiche completate con successo:

- Build ✅
- Test suite ✅
- Lint ✅
- Typecheck ✅

Risultato:

- nessuna modifica al codice applicativo
- aggiornamento documentazione completamente allineato allo stato attuale del progetto