### PR TITLE
fix(pdf-cost): fix pdf link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 > ⚠️ **Disclaimer:** cloudrift is a read-only analysis tool: it reports estimated waste and recommendations only — it never deletes, modifies, or stops any AWS resource. All findings should be validated by your infrastructure team before taking action. The maintainers assume no liability for actions taken based on this report.
 >
-> **Contact:** [raffaelevasini@gmail.com](mailto:raffaelevasini@gmail.com) · [LinkedIn](https://www.linkedin.com/in/raffaele-vasini-87937470/)
+> **Contact:** [raffaelevasini@gmail.com](mailto:raffaelevasini@gmail.com) · <a href="https://www.linkedin.com/in/raffaele-vasini-87937470/" target="_blank" rel="noopener noreferrer">LinkedIn</a>
 
 ### What it detects
 
@@ -446,7 +446,7 @@ No changes to `AnalyzeCloudWasteUseCase`, the summary, or the report DTO are nee
 
 > ⚠️ **Disclaimer:** cloudrift è uno strumento di analisi in sola lettura: segnala solo spreco stimato e raccomandazioni — non cancella, modifica o ferma alcuna risorsa AWS. Ogni finding deve essere validato dal tuo team infrastrutturale prima di agire. I maintainer non si assumono alcuna responsabilità per le azioni intraprese sulla base di questo report.
 >
-> **Contatti:** [raffaelevasini@gmail.com](mailto:raffaelevasini@gmail.com) · [LinkedIn](https://www.linkedin.com/in/raffaele-vasini-87937470/)
+> **Contatti:** [raffaelevasini@gmail.com](mailto:raffaelevasini@gmail.com) · <a href="https://www.linkedin.com/in/raffaele-vasini-87937470/" target="_blank" rel="noopener noreferrer">LinkedIn</a>
 
 ### Cosa rileva
 

--- a/apps/cli/src/formatters/waste-report.markdown-formatter.ts
+++ b/apps/cli/src/formatters/waste-report.markdown-formatter.ts
@@ -34,7 +34,8 @@ function footer(meta: { pricesAsOf: string }): string {
   return (
     `---\n<sub>Estimates use AWS list prices as of ${meta.pricesAsOf}; actual billing may differ.</sub>\n\n` +
     `<sub>${REPORT_DISCLAIMER}</sub>\n\n` +
-    `<sub>Contact: ${REPORT_CONTACT.email} · [LinkedIn](${REPORT_CONTACT.linkedin})</sub>`
+    `<sub>Contact: ${REPORT_CONTACT.email} · ` +
+      `<a href="${REPORT_CONTACT.linkedin}" target="_blank" rel="noopener noreferrer">LinkedIn</a></sub>`
   );
 }
 

--- a/apps/cli/src/formatters/waste-report.pdf-formatter.ts
+++ b/apps/cli/src/formatters/waste-report.pdf-formatter.ts
@@ -149,7 +149,17 @@ function drawSummaryPage(
     .text(REPORT_DISCLAIMER, MARGIN, y, { width: CONTENT_W });
   y += doc.heightOfString(REPORT_DISCLAIMER, { width: CONTENT_W }) + 6;
   doc.font('Helvetica').fontSize(7).fillColor(C.muted)
-    .text(`Contact: ${REPORT_CONTACT.email} · ${REPORT_CONTACT.linkedin}`, MARGIN, y, { lineBreak: false });
+    .text('Contact: ', MARGIN, y, { continued: true, lineBreak: false })
+    .fillColor(C.primary)
+    .text(REPORT_CONTACT.email, {
+      continued: true,
+      link: `mailto:${REPORT_CONTACT.email}`,
+      underline: true,
+    })
+    .fillColor(C.muted)
+    .text(' · ', { continued: true, lineBreak: false })
+    .fillColor(C.primary)
+    .text('LinkedIn', { link: REPORT_CONTACT.linkedin, underline: true });
 }
 
 function drawMetricBox(


### PR DESCRIPTION
# 🔗 Contact Links Improvements (README, Markdown & PDF)

Improved contact-link handling across all report surfaces and documentation.

---

## 🔹 README.md (EN + IT)

The LinkedIn link now uses:

```html
<a target="_blank" rel="noopener noreferrer">
```

This works correctly on renderers that honor embedded HTML (npm, documentation sites, etc.).

### Note

GitHub may still strip or ignore the `target` attribute when rendering content on github.com as part of its anti-tabnabbing protections.

This is harmless in either case:

* Renderers that support `target="_blank"` will open a new tab.
* GitHub will gracefully fall back to its default behavior.

---

## 🔹 Markdown Reports

Applied the same treatment to generated Markdown reports (PR comments / step summaries).

The same GitHub caveat applies:

* Renderers that support embedded HTML will honor the attributes.
* GitHub may remove or ignore `target="_blank"`.

No functional downside in either scenario.

---

## 🔹 PDF Contact Links

Found and fixed a real usability issue:

Previously, contact information was rendered as plain text inside the PDF and was not clickable.

The PDF formatter now uses the PDFKit link API to generate proper URI annotations:

* `mailto:` links for email addresses
* Direct HTTPS links for LinkedIn profiles

### Verification

A generated PDF was inspected by:

1. Decompressing the PDF streams
2. Examining annotation objects

Confirmed that both links are emitted as:

```txt
/Subtype /Link
```

with the expected:

```txt
/URI
```

values.

As a result:

* Email links open the user's default mail client.
* LinkedIn links open the user's default browser.

Whether a new window/tab is created is controlled by the user's PDF viewer and cannot be enforced by the PDF itself.

---

## 🔹 Technical Note

The initial implementation exposed a PDFKit issue and caused:

```txt
unsupported number: NaN
```

Root cause:

* `lineBreak: false` was combined with `link`
* PDFKit calculates link width through the line-wrapping path
* `lineBreak: false` bypasses that path, resulting in an invalid width calculation

Resolution:

* Removed `lineBreak: false` from the linked text segments
* Link annotations now render correctly without runtime errors

---

## 🧪 Quality Assurance

Verified successfully through:

* Lint ✅
* Typecheck ✅
* Build ✅
* Tests ✅ (48/48 passing)

Additionally validated using a real generated PDF and manual inspection of the resulting annotations.
