### PR TITLE
feat(docs): docs --silent — Phase 5.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,55 +16,22 @@
 >
 > **Contact:** [raffaelevasini@gmail.com](mailto:raffaelevasini@gmail.com) · <a href="https://github.com/elleVas" target="_blank" rel="noopener noreferrer">GitHub</a> · <a href="https://www.linkedin.com/in/raffaele-vasini-87937470/" target="_blank" rel="noopener noreferrer">LinkedIn</a>
 
-### What it detects
+**📑 Table of contents**
 
-| Resource           | Waste condition                             | Estimated cost (us-east-1)                              |
-| ------------------ | ------------------------------------------- | ------------------------------------------------------- |
-| **EBS Volumes**    | Unattached (`state: available`)             | gp3: $0.08/GB-mo · gp2: $0.10/GB-mo · io1: $0.125/GB-mo |
-| **Elastic IPs**    | Unassociated (no EC2/NAT binding)           | $3.60/month fixed                                       |
-| **RDS Instances**  | Stopped (still billed for storage)          | gp2/gp3: $0.115/GB-month                                |
-| **Load Balancers** | No registered targets (ALB/NLB)             | ~$16.20/month fixed                                     |
-| **EC2 Instances**  | Stopped — attached EBS volumes keep billing | Sum of attached EBS volumes                             |
-| **EBS Snapshots**  | Source volume deleted (orphan snapshots)    | $0.05/GB-month                                          |
-| **NAT Gateways**   | Zero outbound traffic in the last 48h       | ~$32.40/month fixed                                     |
-| **EBS gp2→gp3**    | In-use gp2 volume upgradeable to gp3 (savings, not waste) | Saving: gp2 − gp3 price × GB (≈ $0.02/GB-mo) |
-| **EBS Volumes (idle)** | Attached (in-use) but zero I/O in the last 48h | gp3: $0.08/GB-mo · gp2: $0.10/GB-mo · io1: $0.125/GB-mo |
-| **EC2 Instances (underutilized)** | Running, max CPU ≤ 5% over 14 days — rightsizing candidate, requires `--live-pricing` | Saving: ~50% of the instance's monthly cost (estimate — verify RAM/network before acting) |
-| **RDS Instances (underutilized)** | Available, max CPU ≤ 5% over 14 days — rightsizing candidate, requires `--live-pricing` | Saving: ~50% of the instance's monthly cost (estimate — verify storage I/O/connections before acting) |
-| **CloudWatch Log Groups** | No retention policy configured (logs grow forever) | $0.03/GB-month |
-| **Orphaned ENIs** | `Status: available` (not attached to any instance) | $0 (hygiene flag, not a direct cost) |
-| **S3 Buckets (no lifecycle)** | No lifecycle configuration — rightsizing candidate | Saving: ~40% of Standard storage cost (estimate — verify access patterns before acting) |
-| **Lambda Functions (underutilized)** | (Near-)zero invocations over 7 days | $0 (hygiene flag — pay-per-use Lambda has no direct cost when unused) |
-| **EFS File Systems (unused)** | No mount targets, or mounted with zero I/O in the last 48h | $0.30/GB-month (Standard storage) |
-| **DynamoDB Tables (overprovisioned)** | PROVISIONED mode, read/write capacity utilization < 10% over 7 days — rightsizing candidate | Saving: ~50% of the provisioned RCU/WCU monthly cost (estimate — verify traffic spikes before acting) |
-| **ElastiCache Clusters (idle)** | Zero client connections in the last 48h, requires `--live-pricing` | Full node-hour cost (node billed regardless of usage) |
-| **Redshift Clusters (idle)** | Zero database connections in the last 48h, requires `--live-pricing` | Full node-hour cost × number of nodes |
-| **OpenSearch Domains (idle)** | Zero search/indexing requests in the last 48h, requires `--live-pricing` | Full instance-hour cost × instance count |
-| **MSK Clusters (idle)** | Provisioned mode, zero broker traffic in the last 48h, requires `--live-pricing` | Full broker-hour cost × number of brokers |
-| **FSx File Systems (idle)** | Zero read/write I/O in the last 48h | $0.093–$0.14/GB-month depending on file system type |
-| **DocumentDB Instances (idle)** | Zero database connections in the last 48h, requires `--live-pricing` | Full instance-hour cost |
-| **Neptune Instances (idle)** | Zero query traffic in the last 48h, requires `--live-pricing` | Full instance-hour cost |
-| **Amazon MQ Brokers (idle)** | Zero network traffic in the last 48h, requires `--live-pricing` | Full broker-hour cost (×2 for ACTIVE_STANDBY_MULTI_AZ) |
-| **WorkSpaces (idle)** | AlwaysOn, no user connection in the last 30 days, requires `--live-pricing` | Full bundle monthly cost |
-| **Site-to-Site VPN Connections (idle)** | Zero tunnel traffic in the last 48h | ~$36.50/month fixed |
-| **Transit Gateway Attachments (idle)** | Zero traffic in the last 48h | ~$36.50/month fixed |
-| **Kinesis Streams (idle, Provisioned mode)** | Zero incoming records in the last 48h (On-Demand mode out of scope — pay-per-use) | ~$10.95/month per shard |
-
-Every finding is also tagged `waste` or `optimization`: `waste` is money being spent now and feeds the headline total and the CI gate; `optimization` (gp2→gp3, EC2/RDS underutilized, S3 no-lifecycle, Lambda underutilized, DynamoDB overprovisioned) is a saving opportunity that keeps the resource, shown separately and never gated. `EC2/RDS Instances (underutilized)`, `S3 Buckets (no lifecycle)` and `DynamoDB Tables (overprovisioned)` are additionally *estimates* — verify before acting.
-
-> **Honest caveat (Lambda):** we only check invocation count over the lookback window, nothing else. We do **not** rightsize memory allocation — that requires Lambda Insights (extra cost, must be enabled per-function), which isn't part of a zero-extra-IAM read-only scan. A function with zero invocations has, by definition, $0 direct cost (pay-per-use); the value of this finding is hygiene (dead code, unnecessary IAM roles/event sources), not a dollar saving. It also won't catch idle **Provisioned Concurrency**, which *is* billed regardless of invocations — out of scope for now.
-
-> **Honest caveat (rightsizing):** the underutilized check is a single-metric heuristic — max CPU below a threshold over the lookback window, nothing else. It does **not** look at RAM, network throughput, IOPS or connection counts, so it can't tell you *which* smaller instance type actually fits. We do this because it requires no extra IAM permissions and works the same on every account; we don't replace [AWS Compute Optimizer](https://aws.amazon.com/compute-optimizer/), which models multiple metrics and recommends a specific target type. Treat our finding as "go check this instance," not as a sizing recommendation — cross-check with Compute Optimizer (or your own metrics) before resizing.
-
-**False-positive guards (waste policies):**
-
-- **Grace period** — resources younger than 7 days (configurable via `--min-age-days`) are never reported. For EC2 the stop time is reconstructed from `StateTransitionReason`; for NAT Gateways and Load Balancers the creation time is used.
-- **Exclusion tag** — any resource tagged `cloudrift:ignore` (configurable via `--ignore-tag`) is skipped.
-- **AMI-bound snapshots** — orphan snapshots referenced by a registered AMI are not reported (they cannot be deleted anyway).
-
-> Prices vary by region. The tool uses region-specific pricing for: `us-east-1`, `us-west-2`, `eu-west-1`, `eu-central-1`, `ap-southeast-1`, `ap-northeast-1`. Every report states the date the price table was last verified (`prices as of`).
-
-> **No npm package yet.** `@cloudrift/cli` is not published on npm — the [release workflow](#releasing) exists but hasn't been triggered with a version tag. For now, build and run from source: see [Quick Start](#quick-start) below. Every command in this README uses `node apps/cli/dist/main.js …` accordingly.
+- [Prerequisites](#prerequisites)
+- [Quick Start](#quick-start)
+- [What it detects](#what-it-detects)
+- [Usage](#usage)
+- [Configuration file](#configuration-file)
+- [Pricing sources](#pricing-sources)
+- [Use in CI/CD](#use-in-cicd)
+- [Required IAM permissions](#required-iam-permissions)
+- [Development](#development)
+- [Releasing](#releasing)
+- [Architecture](#architecture)
+- [Technical documentation](#technical-documentation)
+- [Adding a new resource type](#adding-a-new-resource-type)
+- [License](#license)
 
 ### Prerequisites
 
@@ -140,6 +107,58 @@ node apps/cli/dist/main.js analyze -r us-east-1 eu-west-1
 ```
 
 If everything is configured correctly you'll see tables listing the wasted resources found and an estimated total cost. If the account has no wasted resources you'll see "No wasted resources found".
+
+---
+
+### What it detects
+
+| Resource           | Waste condition                             | Estimated cost (us-east-1)                              |
+| ------------------ | ------------------------------------------- | ------------------------------------------------------- |
+| **EBS Volumes**    | Unattached (`state: available`)             | gp3: $0.08/GB-mo · gp2: $0.10/GB-mo · io1: $0.125/GB-mo |
+| **Elastic IPs**    | Unassociated (no EC2/NAT binding)           | $3.60/month fixed                                       |
+| **RDS Instances**  | Stopped (still billed for storage)          | gp2/gp3: $0.115/GB-month                                |
+| **Load Balancers** | No registered targets (ALB/NLB)             | ~$16.20/month fixed                                     |
+| **EC2 Instances**  | Stopped — attached EBS volumes keep billing | Sum of attached EBS volumes                             |
+| **EBS Snapshots**  | Source volume deleted (orphan snapshots)    | $0.05/GB-month                                          |
+| **NAT Gateways**   | Zero outbound traffic in the last 48h       | ~$32.40/month fixed                                     |
+| **EBS gp2→gp3**    | In-use gp2 volume upgradeable to gp3 (savings, not waste) | Saving: gp2 − gp3 price × GB (≈ $0.02/GB-mo) |
+| **EBS Volumes (idle)** | Attached (in-use) but zero I/O in the last 48h | gp3: $0.08/GB-mo · gp2: $0.10/GB-mo · io1: $0.125/GB-mo |
+| **EC2 Instances (underutilized)** | Running, max CPU ≤ 5% over 14 days — rightsizing candidate, requires `--live-pricing` | Saving: ~50% of the instance's monthly cost (estimate — verify RAM/network before acting) |
+| **RDS Instances (underutilized)** | Available, max CPU ≤ 5% over 14 days — rightsizing candidate, requires `--live-pricing` | Saving: ~50% of the instance's monthly cost (estimate — verify storage I/O/connections before acting) |
+| **CloudWatch Log Groups** | No retention policy configured (logs grow forever) | $0.03/GB-month |
+| **Orphaned ENIs** | `Status: available` (not attached to any instance) | $0 (hygiene flag, not a direct cost) |
+| **S3 Buckets (no lifecycle)** | No lifecycle configuration — rightsizing candidate | Saving: ~40% of Standard storage cost (estimate — verify access patterns before acting) |
+| **Lambda Functions (underutilized)** | (Near-)zero invocations over 7 days | $0 (hygiene flag — pay-per-use Lambda has no direct cost when unused) |
+| **EFS File Systems (unused)** | No mount targets, or mounted with zero I/O in the last 48h | $0.30/GB-month (Standard storage) |
+| **DynamoDB Tables (overprovisioned)** | PROVISIONED mode, read/write capacity utilization < 10% over 7 days — rightsizing candidate | Saving: ~50% of the provisioned RCU/WCU monthly cost (estimate — verify traffic spikes before acting) |
+| **ElastiCache Clusters (idle)** | Zero client connections in the last 48h, requires `--live-pricing` | Full node-hour cost (node billed regardless of usage) |
+| **Redshift Clusters (idle)** | Zero database connections in the last 48h, requires `--live-pricing` | Full node-hour cost × number of nodes |
+| **OpenSearch Domains (idle)** | Zero search/indexing requests in the last 48h, requires `--live-pricing` | Full instance-hour cost × instance count |
+| **MSK Clusters (idle)** | Provisioned mode, zero broker traffic in the last 48h, requires `--live-pricing` | Full broker-hour cost × number of brokers |
+| **FSx File Systems (idle)** | Zero read/write I/O in the last 48h | $0.093–$0.14/GB-month depending on file system type |
+| **DocumentDB Instances (idle)** | Zero database connections in the last 48h, requires `--live-pricing` | Full instance-hour cost |
+| **Neptune Instances (idle)** | Zero query traffic in the last 48h, requires `--live-pricing` | Full instance-hour cost |
+| **Amazon MQ Brokers (idle)** | Zero network traffic in the last 48h, requires `--live-pricing` | Full broker-hour cost (×2 for ACTIVE_STANDBY_MULTI_AZ) |
+| **WorkSpaces (idle)** | AlwaysOn, no user connection in the last 30 days, requires `--live-pricing` | Full bundle monthly cost |
+| **Site-to-Site VPN Connections (idle)** | Zero tunnel traffic in the last 48h | ~$36.50/month fixed |
+| **Transit Gateway Attachments (idle)** | Zero traffic in the last 48h | ~$36.50/month fixed |
+| **Kinesis Streams (idle, Provisioned mode)** | Zero incoming records in the last 48h (On-Demand mode out of scope — pay-per-use) | ~$10.95/month per shard |
+
+Every finding is also tagged `waste` or `optimization`: `waste` is money being spent now and feeds the headline total and the CI gate; `optimization` (gp2→gp3, EC2/RDS underutilized, S3 no-lifecycle, Lambda underutilized, DynamoDB overprovisioned) is a saving opportunity that keeps the resource, shown separately and never gated. `EC2/RDS Instances (underutilized)`, `S3 Buckets (no lifecycle)` and `DynamoDB Tables (overprovisioned)` are additionally *estimates* — verify before acting.
+
+> **Honest caveat (Lambda):** we only check invocation count over the lookback window, nothing else. We do **not** rightsize memory allocation — that requires Lambda Insights (extra cost, must be enabled per-function), which isn't part of a zero-extra-IAM read-only scan. A function with zero invocations has, by definition, $0 direct cost (pay-per-use); the value of this finding is hygiene (dead code, unnecessary IAM roles/event sources), not a dollar saving. It also won't catch idle **Provisioned Concurrency**, which *is* billed regardless of invocations — out of scope for now.
+
+> **Honest caveat (rightsizing):** the underutilized check is a single-metric heuristic — max CPU below a threshold over the lookback window, nothing else. It does **not** look at RAM, network throughput, IOPS or connection counts, so it can't tell you *which* smaller instance type actually fits. We do this because it requires no extra IAM permissions and works the same on every account; we don't replace [AWS Compute Optimizer](https://aws.amazon.com/compute-optimizer/), which models multiple metrics and recommends a specific target type. Treat our finding as "go check this instance," not as a sizing recommendation — cross-check with Compute Optimizer (or your own metrics) before resizing.
+
+**False-positive guards (waste policies):**
+
+- **Grace period** — resources younger than 7 days (configurable via `--min-age-days`) are never reported. For EC2 the stop time is reconstructed from `StateTransitionReason`; for NAT Gateways and Load Balancers the creation time is used.
+- **Exclusion tag** — any resource tagged `cloudrift:ignore` (configurable via `--ignore-tag`) is skipped.
+- **AMI-bound snapshots** — orphan snapshots referenced by a registered AMI are not reported (they cannot be deleted anyway).
+
+> Prices vary by region. The tool uses region-specific pricing for: `us-east-1`, `us-west-2`, `eu-west-1`, `eu-central-1`, `ap-southeast-1`, `ap-northeast-1`. Every report states the date the price table was last verified (`prices as of`).
+
+> **No npm package yet.** `@cloudrift/cli` is not published on npm — the [release workflow](#releasing) exists but hasn't been triggered with a version tag. For now, build and run from source: see [Quick Start](#quick-start) above. Every command in this README uses `node apps/cli/dist/main.js …` accordingly.
 
 ---
 
@@ -473,55 +492,21 @@ Apache License 2.0 — see [LICENSE.md](./LICENSE.md). Free to use, modify, and 
 >
 > **Contatti:** [raffaelevasini@gmail.com](mailto:raffaelevasini@gmail.com) · <a href="https://github.com/elleVas" target="_blank" rel="noopener noreferrer">GitHub</a> · <a href="https://www.linkedin.com/in/raffaele-vasini-87937470/" target="_blank" rel="noopener noreferrer">LinkedIn</a>
 
-### Cosa rileva
+**📑 Indice**
 
-| Risorsa            | Condizione di spreco                                                    | Costo stimato (us-east-1)                                     |
-| ------------------ | ----------------------------------------------------------------------- | ------------------------------------------------------------- |
-| **EBS Volumes**    | Non attaccati a nessuna istanza (`state: available`)                    | gp3: $0,08/GB-mese · gp2: $0,10/GB-mese · io1: $0,125/GB-mese |
-| **Elastic IP**     | Non associati a EC2 o NAT Gateway                                       | $3,60/mese fisso                                              |
-| **RDS Instances**  | Ferme (`stopped`), ancora a pagamento per lo storage                    | gp2: $0,115/GB-mese · gp3: $0,115/GB-mese                     |
-| **Load Balancers** | Nessun target registrato (ALB/NLB)                                      | ~$16,20/mese fisso                                            |
-| **EC2 Instances**  | Ferme (`stopped`), i volumi EBS attaccati continuano a essere fatturati | Somma dei volumi EBS attaccati                                |
-| **EBS Snapshots**  | Volume sorgente cancellato (snapshot orfani)                            | $0,05/GB-mese                                                 |
-| **NAT Gateways**   | Zero traffico in uscita nelle ultime 48h                                | ~$32,40/mese fisso                                            |
-| **EBS gp2→gp3**    | Volume gp2 in uso aggiornabile a gp3 (risparmio, non spreco)            | Risparmio: prezzo gp2 − gp3 × GB (≈ $0,02/GB-mese)           |
-| **EBS Volumes (idle)** | Attaccati (in-use) ma zero I/O nelle ultime 48h                     | gp3: $0,08/GB-mese · gp2: $0,10/GB-mese · io1: $0,125/GB-mese |
-| **EC2 Instances (underutilized)** | Running, CPU massima ≤ 5% in 14 giorni — candidato a rightsizing, richiede `--live-pricing` | Risparmio: ~50% del costo mensile dell'istanza (stima — verificare RAM/rete prima di agire) |
-| **RDS Instances (underutilized)** | Disponibile (`available`), CPU massima ≤ 5% in 14 giorni — candidato a rightsizing, richiede `--live-pricing` | Risparmio: ~50% del costo mensile dell'istanza (stima — verificare storage I/O/connessioni prima di agire) |
-| **CloudWatch Log Groups** | Nessuna retention policy configurata (i log crescono all'infinito) | $0,03/GB-mese |
-| **ENI orfane** | `Status: available` (non attaccate a nessuna istanza) | $0 (segnalazione di igiene, non un costo diretto) |
-| **S3 Buckets (no lifecycle)** | Nessuna lifecycle configuration — candidato a rightsizing | Risparmio: ~40% del costo storage Standard (stima — verificare i pattern di accesso prima di agire) |
-| **Lambda Functions (underutilized)** | (Quasi) zero invocazioni in 7 giorni | $0 (segnalazione di igiene — Lambda pay-per-use non ha costo diretto se inutilizzata) |
-| **EFS File Systems (unused)** | Nessun mount target, oppure montato con zero I/O nelle ultime 48h | $0,30/GB-mese (storage Standard) |
-| **DynamoDB Tables (overprovisioned)** | Modalità PROVISIONED, utilizzo capacità read/write < 10% in 7 giorni — candidato a rightsizing | Risparmio: ~50% del costo mensile RCU/WCU provisioned (stima — verificare picchi di traffico prima di agire) |
-| **ElastiCache Clusters (idle)** | Zero connessioni client nelle ultime 48h, richiede `--live-pricing` | Costo pieno node-hour (il nodo è fatturato indipendentemente dall'uso) |
-| **Redshift Clusters (idle)** | Zero connessioni al database nelle ultime 48h, richiede `--live-pricing` | Costo pieno node-hour × numero di nodi |
-| **OpenSearch Domains (idle)** | Zero richieste di ricerca/indicizzazione nelle ultime 48h, richiede `--live-pricing` | Costo pieno instance-hour × numero di istanze |
-| **MSK Clusters (idle)** | Modalità Provisioned, zero traffico broker nelle ultime 48h, richiede `--live-pricing` | Costo pieno broker-hour × numero di broker |
-| **FSx File Systems (idle)** | Zero I/O di lettura/scrittura nelle ultime 48h | $0,093–$0,14/GB-mese a seconda del tipo di file system |
-| **DocumentDB Instances (idle)** | Zero connessioni al database nelle ultime 48h, richiede `--live-pricing` | Costo pieno instance-hour |
-| **Neptune Instances (idle)** | Zero traffico di query nelle ultime 48h, richiede `--live-pricing` | Costo pieno instance-hour |
-| **Amazon MQ Brokers (idle)** | Zero traffico di rete nelle ultime 48h, richiede `--live-pricing` | Costo pieno broker-hour (×2 per ACTIVE_STANDBY_MULTI_AZ) |
-| **WorkSpaces (idle)** | AlwaysOn, nessuna connessione utente negli ultimi 30 giorni, richiede `--live-pricing` | Costo pieno mensile del bundle |
-| **Connessioni VPN Site-to-Site (idle)** | Zero traffico nei tunnel nelle ultime 48h | ~$36,50/mese fisso |
-| **Transit Gateway Attachments (idle)** | Zero traffico nelle ultime 48h | ~$36,50/mese fisso |
-| **Kinesis Streams (idle, modalità Provisioned)** | Zero record in ingresso nelle ultime 48h (modalità On-Demand fuori scope — pay-per-use) | ~$10,95/mese per shard |
-
-Ogni finding è anche etichettato `waste` o `optimization`: `waste` è denaro speso ora e contribuisce al totale principale e al gate CI; `optimization` (gp2→gp3, EC2/RDS underutilized, S3 no-lifecycle, Lambda underutilized, DynamoDB overprovisioned) è un'opportunità di risparmio che mantiene la risorsa, mostrata a parte e mai usata come gate. `EC2/RDS Instances (underutilized)`, `S3 Buckets (no lifecycle)` e `DynamoDB Tables (overprovisioned)` sono inoltre delle *stime* — da verificare prima di agire.
-
-> **Nota onesta (Lambda):** controlliamo solo il numero di invocazioni nella finestra di osservazione, nient'altro. **Non** facciamo rightsizing della memoria — richiederebbe Lambda Insights (costo extra, da attivare per ogni funzione), fuori scope per uno scan read-only senza permessi IAM aggiuntivi. Una funzione con zero invocazioni ha per definizione $0 di costo diretto (pay-per-use); il valore di questo finding è igiene (codice morto, ruoli IAM/event source inutili), non un risparmio in dollari. Non rileva nemmeno la **Provisioned Concurrency** idle, che invece *è* fatturata indipendentemente dalle invocazioni — fuori scope per ora.
-
-> **Nota onesta (rightsizing):** il check di sottoutilizzo è un'euristica su una singola metrica — CPU massima sotto una soglia nella finestra di osservazione, nient'altro. **Non** guarda RAM, throughput di rete, IOPS o numero di connessioni, quindi non può dirti *quale* instance type più piccolo sia davvero adatto. Lo facciamo così perché non richiede permessi IAM aggiuntivi e funziona uguale su ogni account; non sostituiamo [AWS Compute Optimizer](https://aws.amazon.com/compute-optimizer/), che modella più metriche e raccomanda un target specifico. Tratta il nostro finding come "vai a controllare questa istanza", non come una raccomandazione di sizing — verifica con Compute Optimizer (o con le tue metriche) prima di ridimensionare.
-
-**Protezioni contro i falsi positivi (waste policies):**
-
-- **Periodo di grazia** — le risorse più giovani di 7 giorni (configurabile con `--min-age-days`) non vengono mai segnalate. Per le EC2 la data di stop è ricostruita da `StateTransitionReason`; per NAT Gateway e Load Balancer si usa la data di creazione.
-- **Tag di esclusione** — qualunque risorsa con il tag `cloudrift:ignore` (configurabile con `--ignore-tag`) viene saltata.
-- **Snapshot legati ad AMI** — gli snapshot orfani referenziati da un'AMI registrata non vengono segnalati (non sarebbero comunque cancellabili).
-
-> I prezzi variano per regione. Il tool usa prezzi specifici per: `us-east-1`, `us-west-2`, `eu-west-1`, `eu-central-1`, `ap-southeast-1`, `ap-northeast-1`. Ogni report indica la data di ultima verifica del listino (`prices as of`).
-
-> **Nessun pacchetto npm ancora.** `@cloudrift/cli` non è pubblicato su npm — il [workflow di rilascio](#rilascio) esiste ma non è ancora stato attivato con un tag di versione. Per ora va compilato ed eseguito dai sorgenti: vedi [Guida rapida](#guida-rapida) qui sotto. Ogni comando in questo README usa quindi `node apps/cli/dist/main.js …`.
+- [Prerequisiti](#prerequisiti)
+- [Guida rapida](#guida-rapida)
+- [Cosa rileva](#cosa-rileva)
+- [Utilizzo](#utilizzo)
+- [File di configurazione](#file-di-configurazione)
+- [Fonti dei prezzi](#fonti-dei-prezzi)
+- [Uso in CI/CD](#uso-in-cicd)
+- [Permessi IAM necessari](#permessi-iam-necessari)
+- [Sviluppo](#sviluppo)
+- [Rilascio](#rilascio)
+- [Architettura](#architettura)
+- [Documentazione tecnica](#documentazione-tecnica)
+- [Licenza](#licenza)
 
 ### Prerequisiti
 
@@ -597,6 +582,58 @@ node apps/cli/dist/main.js analyze -r us-east-1 eu-west-1
 ```
 
 Se tutto è configurato correttamente vedrai tabelle con le risorse sprecate trovate e il totale stimato. Se un account non ha risorse sprecate vedrai un messaggio "No wasted resources found".
+
+---
+
+### Cosa rileva
+
+| Risorsa            | Condizione di spreco                                                    | Costo stimato (us-east-1)                                     |
+| ------------------ | ----------------------------------------------------------------------- | ------------------------------------------------------------- |
+| **EBS Volumes**    | Non attaccati a nessuna istanza (`state: available`)                    | gp3: $0,08/GB-mese · gp2: $0,10/GB-mese · io1: $0,125/GB-mese |
+| **Elastic IP**     | Non associati a EC2 o NAT Gateway                                       | $3,60/mese fisso                                              |
+| **RDS Instances**  | Ferme (`stopped`), ancora a pagamento per lo storage                    | gp2: $0,115/GB-mese · gp3: $0,115/GB-mese                     |
+| **Load Balancers** | Nessun target registrato (ALB/NLB)                                      | ~$16,20/mese fisso                                            |
+| **EC2 Instances**  | Ferme (`stopped`), i volumi EBS attaccati continuano a essere fatturati | Somma dei volumi EBS attaccati                                |
+| **EBS Snapshots**  | Volume sorgente cancellato (snapshot orfani)                            | $0,05/GB-mese                                                 |
+| **NAT Gateways**   | Zero traffico in uscita nelle ultime 48h                                | ~$32,40/mese fisso                                            |
+| **EBS gp2→gp3**    | Volume gp2 in uso aggiornabile a gp3 (risparmio, non spreco)            | Risparmio: prezzo gp2 − gp3 × GB (≈ $0,02/GB-mese)           |
+| **EBS Volumes (idle)** | Attaccati (in-use) ma zero I/O nelle ultime 48h                     | gp3: $0,08/GB-mese · gp2: $0,10/GB-mese · io1: $0,125/GB-mese |
+| **EC2 Instances (underutilized)** | Running, CPU massima ≤ 5% in 14 giorni — candidato a rightsizing, richiede `--live-pricing` | Risparmio: ~50% del costo mensile dell'istanza (stima — verificare RAM/rete prima di agire) |
+| **RDS Instances (underutilized)** | Disponibile (`available`), CPU massima ≤ 5% in 14 giorni — candidato a rightsizing, richiede `--live-pricing` | Risparmio: ~50% del costo mensile dell'istanza (stima — verificare storage I/O/connessioni prima di agire) |
+| **CloudWatch Log Groups** | Nessuna retention policy configurata (i log crescono all'infinito) | $0,03/GB-mese |
+| **ENI orfane** | `Status: available` (non attaccate a nessuna istanza) | $0 (segnalazione di igiene, non un costo diretto) |
+| **S3 Buckets (no lifecycle)** | Nessuna lifecycle configuration — candidato a rightsizing | Risparmio: ~40% del costo storage Standard (stima — verificare i pattern di accesso prima di agire) |
+| **Lambda Functions (underutilized)** | (Quasi) zero invocazioni in 7 giorni | $0 (segnalazione di igiene — Lambda pay-per-use non ha costo diretto se inutilizzata) |
+| **EFS File Systems (unused)** | Nessun mount target, oppure montato con zero I/O nelle ultime 48h | $0,30/GB-mese (storage Standard) |
+| **DynamoDB Tables (overprovisioned)** | Modalità PROVISIONED, utilizzo capacità read/write < 10% in 7 giorni — candidato a rightsizing | Risparmio: ~50% del costo mensile RCU/WCU provisioned (stima — verificare picchi di traffico prima di agire) |
+| **ElastiCache Clusters (idle)** | Zero connessioni client nelle ultime 48h, richiede `--live-pricing` | Costo pieno node-hour (il nodo è fatturato indipendentemente dall'uso) |
+| **Redshift Clusters (idle)** | Zero connessioni al database nelle ultime 48h, richiede `--live-pricing` | Costo pieno node-hour × numero di nodi |
+| **OpenSearch Domains (idle)** | Zero richieste di ricerca/indicizzazione nelle ultime 48h, richiede `--live-pricing` | Costo pieno instance-hour × numero di istanze |
+| **MSK Clusters (idle)** | Modalità Provisioned, zero traffico broker nelle ultime 48h, richiede `--live-pricing` | Costo pieno broker-hour × numero di broker |
+| **FSx File Systems (idle)** | Zero I/O di lettura/scrittura nelle ultime 48h | $0,093–$0,14/GB-mese a seconda del tipo di file system |
+| **DocumentDB Instances (idle)** | Zero connessioni al database nelle ultime 48h, richiede `--live-pricing` | Costo pieno instance-hour |
+| **Neptune Instances (idle)** | Zero traffico di query nelle ultime 48h, richiede `--live-pricing` | Costo pieno instance-hour |
+| **Amazon MQ Brokers (idle)** | Zero traffico di rete nelle ultime 48h, richiede `--live-pricing` | Costo pieno broker-hour (×2 per ACTIVE_STANDBY_MULTI_AZ) |
+| **WorkSpaces (idle)** | AlwaysOn, nessuna connessione utente negli ultimi 30 giorni, richiede `--live-pricing` | Costo pieno mensile del bundle |
+| **Connessioni VPN Site-to-Site (idle)** | Zero traffico nei tunnel nelle ultime 48h | ~$36,50/mese fisso |
+| **Transit Gateway Attachments (idle)** | Zero traffico nelle ultime 48h | ~$36,50/mese fisso |
+| **Kinesis Streams (idle, modalità Provisioned)** | Zero record in ingresso nelle ultime 48h (modalità On-Demand fuori scope — pay-per-use) | ~$10,95/mese per shard |
+
+Ogni finding è anche etichettato `waste` o `optimization`: `waste` è denaro speso ora e contribuisce al totale principale e al gate CI; `optimization` (gp2→gp3, EC2/RDS underutilized, S3 no-lifecycle, Lambda underutilized, DynamoDB overprovisioned) è un'opportunità di risparmio che mantiene la risorsa, mostrata a parte e mai usata come gate. `EC2/RDS Instances (underutilized)`, `S3 Buckets (no lifecycle)` e `DynamoDB Tables (overprovisioned)` sono inoltre delle *stime* — da verificare prima di agire.
+
+> **Nota onesta (Lambda):** controlliamo solo il numero di invocazioni nella finestra di osservazione, nient'altro. **Non** facciamo rightsizing della memoria — richiederebbe Lambda Insights (costo extra, da attivare per ogni funzione), fuori scope per uno scan read-only senza permessi IAM aggiuntivi. Una funzione con zero invocazioni ha per definizione $0 di costo diretto (pay-per-use); il valore di questo finding è igiene (codice morto, ruoli IAM/event source inutili), non un risparmio in dollari. Non rileva nemmeno la **Provisioned Concurrency** idle, che invece *è* fatturata indipendentemente dalle invocazioni — fuori scope per ora.
+
+> **Nota onesta (rightsizing):** il check di sottoutilizzo è un'euristica su una singola metrica — CPU massima sotto una soglia nella finestra di osservazione, nient'altro. **Non** guarda RAM, throughput di rete, IOPS o numero di connessioni, quindi non può dirti *quale* instance type più piccolo sia davvero adatto. Lo facciamo così perché non richiede permessi IAM aggiuntivi e funziona uguale su ogni account; non sostituiamo [AWS Compute Optimizer](https://aws.amazon.com/compute-optimizer/), che modella più metriche e raccomanda un target specifico. Tratta il nostro finding come "vai a controllare questa istanza", non come una raccomandazione di sizing — verifica con Compute Optimizer (o con le tue metriche) prima di ridimensionare.
+
+**Protezioni contro i falsi positivi (waste policies):**
+
+- **Periodo di grazia** — le risorse più giovani di 7 giorni (configurabile con `--min-age-days`) non vengono mai segnalate. Per le EC2 la data di stop è ricostruita da `StateTransitionReason`; per NAT Gateway e Load Balancer si usa la data di creazione.
+- **Tag di esclusione** — qualunque risorsa con il tag `cloudrift:ignore` (configurabile con `--ignore-tag`) viene saltata.
+- **Snapshot legati ad AMI** — gli snapshot orfani referenziati da un'AMI registrata non vengono segnalati (non sarebbero comunque cancellabili).
+
+> I prezzi variano per regione. Il tool usa prezzi specifici per: `us-east-1`, `us-west-2`, `eu-west-1`, `eu-central-1`, `ap-southeast-1`, `ap-northeast-1`. Ogni report indica la data di ultima verifica del listino (`prices as of`).
+
+> **Nessun pacchetto npm ancora.** `@cloudrift/cli` non è pubblicato su npm — il [workflow di rilascio](#rilascio) esiste ma non è ancora stato attivato con un tag di versione. Per ora va compilato ed eseguito dai sorgenti: vedi [Guida rapida](#guida-rapida) qui sopra. Ogni comando in questo README usa quindi `node apps/cli/dist/main.js …`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -163,9 +163,12 @@ node apps/cli/dist/main.js analyze [options]
 | `--ignore-tag <tag>`         | Resources carrying this tag are excluded from the report (overrides config)                                   | `cloudrift:ignore` |
 | `--pdf [filename]`           | Also write a PDF report to disk (defaults to `cloudrift-report-YYYY-MM-DD.pdf`)                                | —                  |
 | `--json [filename]`          | Also write a JSON report to disk (defaults to `cloudrift-report-YYYY-MM-DD.json`)                              | —                  |
+| `--silent`                   | Suppress all stdout output (banner, report, confirmations) — use with `--pdf`/`--json` for file-only output    | off                |
 | `-h, --help`                 | Show help                                                                                                      | —                  |
 
-> **stdout vs. file artifacts:** `--format` controls what goes to **stdout** (the report itself). `--json` / `--pdf` write **additional files** to disk and are independent of `--format`. In machine-readable formats (`json`, `markdown`) all human messages are routed to stderr, so stdout carries only the report — ideal for piping.
+> **stdout vs. file artifacts:** `--format` controls what goes to **stdout** (the report itself). `--json` / `--pdf` write **additional files** to disk and are independent of `--format` — by default the chosen `--format` still prints to stdout *in addition to* writing those files (so e.g. `--pdf` alone still shows the table by default). Add `--silent` for file-only output with nothing printed to the terminal. In machine-readable formats (`json`, `markdown`) all human messages are routed to stderr, so stdout carries only the report — ideal for piping. Errors and the cost-gate alert always surface on stderr, even with `--silent`.
+>
+> **Flag order with `--pdf`/`--json`:** their filename is an *optional* value (`--pdf [filename]`), so it's only picked up if it immediately follows the flag — `--pdf --silent ./report.pdf` fails ("too many arguments") because `--silent` blocks `--pdf` from seeing the filename, leaving `./report.pdf` with nothing to attach to. Either keep the filename right after the flag (`--pdf ./report.pdf --silent`), or use `=` to make order irrelevant: `--pdf=./report.pdf --silent --format json`.
 
 **Examples:**
 
@@ -182,6 +185,9 @@ node apps/cli/dist/main.js analyze --min-age-days 0
 # Export a PDF report with an auto-generated filename (reports/AWS_report_YYYY_MM_DD.pdf)
 node apps/cli/dist/main.js analyze --pdf
 
+# Same, but with nothing printed to the terminal — just the file
+node apps/cli/dist/main.js analyze --pdf ./report.pdf --silent
+
 # Machine-readable output (e.g. to feed a dashboard or CI check)
 node apps/cli/dist/main.js analyze --format json | jq '.totalWasteMonthlyUsd'
 
@@ -194,7 +200,7 @@ node apps/cli/dist/main.js analyze --format markdown >> "$GITHUB_STEP_SUMMARY"
 
 **PDF report:**
 
-The `--pdf` flag generates a PDF alongside the normal console output. The report contains:
+The `--pdf` flag generates a PDF alongside the normal console output (add `--silent` to suppress the console output and get only the file). The report contains:
 
 - **Executive summary** — monthly and annual waste totals, resource count, per-type breakdown
 - **Top recommendations** — up to 8 items sorted by monthly savings potential, with estimated annual saving
@@ -614,9 +620,12 @@ node apps/cli/dist/main.js analyze [opzioni]
 | `--ignore-tag <tag>`         | Le risorse con questo tag vengono escluse dal report (ha precedenza sul config)                                     | `cloudrift:ignore` |
 | `--pdf [filename]`           | Scrive anche un report PDF su disco (default `cloudrift-report-YYYY-MM-DD.pdf`)                                      | —                  |
 | `--json [filename]`          | Scrive anche un report JSON su disco (default `cloudrift-report-YYYY-MM-DD.json`)                                   | —                  |
+| `--silent`                   | Sopprime tutto l'output su stdout (banner, report, conferme) — usalo con `--pdf`/`--json` per ottenere solo il file | off                |
 | `-h, --help`                 | Mostra l'help                                                                                                        | —                  |
 
-> **stdout vs. file:** `--format` controlla cosa va su **stdout** (il report). `--json` / `--pdf` scrivono **file aggiuntivi** su disco, indipendenti da `--format`. Nei formati machine-readable (`json`, `markdown`) tutti i messaggi umani vanno su stderr, così su stdout resta solo il report — ideale per il piping.
+> **stdout vs. file:** `--format` controlla cosa va su **stdout** (il report). `--json` / `--pdf` scrivono **file aggiuntivi** su disco, indipendenti da `--format` — di default il `--format` scelto continua comunque a essere stampato su stdout *in aggiunta* alla scrittura di quei file (quindi es. `--pdf` da solo mostra comunque la tabella). Aggiungi `--silent` per ottenere solo il file, senza nulla stampato a terminale. Nei formati machine-readable (`json`, `markdown`) tutti i messaggi umani vanno su stderr, così su stdout resta solo il report — ideale per il piping. Errori e l'alert della soglia di costo vanno sempre su stderr, anche con `--silent`.
+>
+> **Ordine dei flag con `--pdf`/`--json`:** il filename è un valore *opzionale* (`--pdf [filename]`), quindi viene raccolto solo se segue immediatamente il flag — `--pdf --silent ./report.pdf` fallisce ("too many arguments") perché `--silent` impedisce a `--pdf` di vedere il filename, lasciando `./report.pdf` senza nulla a cui agganciarsi. Tieni il filename subito dopo il flag (`--pdf ./report.pdf --silent`), oppure usa `=` per rendere l'ordine irrilevante: `--pdf=./report.pdf --silent --format json`.
 
 **Esempi:**
 
@@ -633,6 +642,9 @@ node apps/cli/dist/main.js analyze --min-age-days 0
 # Esporta un report PDF con nome automatico (reports/AWS_report_YYYY_MM_DD.pdf)
 node apps/cli/dist/main.js analyze --pdf
 
+# Come sopra, ma senza nulla stampato a terminale — solo il file
+node apps/cli/dist/main.js analyze --pdf ./report.pdf --silent
+
 # Output machine-readable (es. per una dashboard o un check CI)
 node apps/cli/dist/main.js analyze --format json | jq '.totalWasteMonthlyUsd'
 
@@ -645,7 +657,7 @@ node apps/cli/dist/main.js analyze --format markdown >> "$GITHUB_STEP_SUMMARY"
 
 **Report PDF:**
 
-Il flag `--pdf` genera un PDF in aggiunta all'output console. Il report contiene:
+Il flag `--pdf` genera un PDF in aggiunta all'output console (aggiungi `--silent` per sopprimere l'output console e ottenere solo il file). Il report contiene:
 
 - **Executive summary** — totale spreco mensile e annuale, numero di risorse, breakdown per tipo
 - **Top raccomandazioni** — fino a 8 voci ordinate per impatto mensile, con risparmio annuale stimato

--- a/apps/cli/src/commands/analyze-waste.command.spec.ts
+++ b/apps/cli/src/commands/analyze-waste.command.spec.ts
@@ -176,6 +176,38 @@ describe('analyzeWasteCommand (CLI end-to-end)', () => {
     }
   });
 
+  it('--silent suppresses all stdout while still writing the requested file artifact', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'cloudrift-cli-'));
+    const file = join(dir, 'out.pdf');
+    try {
+      await run({ format: 'table', pdf: file, silent: true }, makeDeps({
+        summary: summaryOf([wasteVolume('vol-1', 8)], 8),
+      }));
+      expect(stdout).toBe('');
+      expect(stderr).toBe('');
+      const written = await readFile(file);
+      expect(written.subarray(0, 5).toString('latin1')).toBe('%PDF-');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('--silent still surfaces the cost-gate alert on stderr and the exit code', async () => {
+    await run({ format: 'table', silent: true }, makeDeps({
+      config: { costAlertThresholdUsd: 5 },
+      summary: summaryOf([wasteVolume('vol-1', 8)], 8),
+    }));
+    expect(process.exitCode).toBe(2);
+    expect(stdout).toBe('');
+    expect(stderr).toContain('Waste threshold exceeded');
+  });
+
+  it('--silent still surfaces failures (exit 1) on stderr', async () => {
+    await run({ format: 'xml', silent: true }, makeDeps());
+    expect(process.exitCode).toBe(1);
+    expect(stderr).toContain('--format must be one of');
+  });
+
   it('reports a partial scan without crashing, exit code dictated only by the cost threshold', async () => {
     const summary: WastedResourcesSummary = {
       ...summaryOf([], 0),

--- a/apps/cli/src/commands/analyze-waste.command.ts
+++ b/apps/cli/src/commands/analyze-waste.command.ts
@@ -41,6 +41,7 @@ export interface AnalyzeWasteOptions {
   json?: string | boolean;
   minAgeDays?: string;
   ignoreTag?: string;
+  silent?: boolean;
 }
 
 function fail(message: string): void {
@@ -172,11 +173,16 @@ export async function analyzeWasteCommand(
     );
   }
   // In machine-readable mode stdout must contain ONLY the report:
-  // human chrome (banner, confirmations) is routed to stderr.
-  const quietStdout = format !== 'table';
-  const info = quietStdout
-    ? (msg: string) => console.error(msg)
-    : (msg: string) => console.log(msg);
+  // human chrome (banner, confirmations) is routed to stderr. --silent goes
+  // further: no chrome and no report at all, just the file artifacts (if any) —
+  // errors and the cost-gate alert still surface, same as every other mode.
+  const silent = options.silent === true;
+  const quietStdout = format !== 'table' || silent;
+  const info = silent
+    ? () => undefined
+    : quietStdout
+      ? (msg: string) => console.error(msg)
+      : (msg: string) => console.log(msg);
 
   if (!quietStdout) {
     console.log(`\n${renderBanner()}\n`);
@@ -245,18 +251,21 @@ export async function analyzeWasteCommand(
   };
 
   // The chosen report ALWAYS goes to stdout (so it's pipeline-composable:
-  // `--format json | jq`, `--format markdown >> $GITHUB_STEP_SUMMARY`).
-  let rendered: string;
-  if (format === 'json') {
-    rendered = formatWasteReportAsJson(result.value, meta);
-  } else if (format === 'markdown') {
-    rendered = formatWasteReportAsMarkdown(result.value, meta, {
-      costAlertThresholdUsd: config.costAlertThresholdUsd,
-    });
-  } else {
-    rendered = formatWasteReportAsTable(result.value, meta);
+  // `--format json | jq`, `--format markdown >> $GITHUB_STEP_SUMMARY`) —
+  // unless --silent asked for file artifacts only.
+  if (!silent) {
+    let rendered: string;
+    if (format === 'json') {
+      rendered = formatWasteReportAsJson(result.value, meta);
+    } else if (format === 'markdown') {
+      rendered = formatWasteReportAsMarkdown(result.value, meta, {
+        costAlertThresholdUsd: config.costAlertThresholdUsd,
+      });
+    } else {
+      rendered = formatWasteReportAsTable(result.value, meta);
+    }
+    console.log(rendered);
   }
-  console.log(rendered);
 
   await writeArtifacts(result.value, meta, options, info);
   applyCostGate(result.value, config);

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -41,6 +41,10 @@ program
     'stdout output format: table (default), json, or markdown (for CI / PR comments)',
     'table',
   )
+  // [filename] is an optional value: commander only attaches it to --pdf/--json
+  // when it immediately follows the flag. `--pdf --silent ./report.pdf` fails
+  // ("too many arguments") because --silent gets in the way first, leaving
+  // the path orphaned. Use `--pdf=./report.pdf` to make flag order irrelevant.
   .option(
     '--pdf [filename]',
     'Also write a PDF report to disk (optional filename, defaults to reports/AWS_report_YYYY_MM_DD.pdf)',
@@ -48,6 +52,10 @@ program
   .option(
     '--json [filename]',
     'Also write a JSON report to disk (optional filename, defaults to reports/AWS_report_YYYY_MM_DD.json)',
+  )
+  .option(
+    '--silent',
+    'suppress all stdout output (banner, report, confirmations) — use with --pdf/--json for file-only output. Errors and the cost-gate alert still surface.',
   )
   .action((options) => analyzeWasteCommand(options));
 

--- a/docs/adr/0031-chalk-cli-table3-console-output.md
+++ b/docs/adr/0031-chalk-cli-table3-console-output.md
@@ -8,7 +8,7 @@ Terminal output needs colors and aligned tables, plus a clean machine-readable m
 
 ## Decision
 
-`chalk` for colors (automatic color-support detection), `cli-table3` for aligned, readable tables. With `--json` and no output filename, table output is suppressed entirely to keep stdout clean for piping.
+`chalk` for colors (automatic color-support detection), `cli-table3` for aligned, readable tables. `--format json` (not `--json`, which is a file artifact — see [analyze-waste.command.ts](../../apps/cli/src/commands/analyze-waste.command.ts)) suppresses table output entirely to keep stdout clean for piping.
 
 ## Alternatives Considered
 
@@ -16,4 +16,4 @@ Terminal output needs colors and aligned tables, plus a clean machine-readable m
 
 ## Consequences
 
-`--json` to stdout is safely pipeable into other tools. Only the file-output path (`--json --output report.json`) coexists with a printed table view.
+`--format json` to stdout is safely pipeable into other tools. The file-output flags (`--json`/`--pdf`) are independent of `--format` and by default coexist with a printed table view; `--silent` (added later) suppresses that printed view for file-only runs.

--- a/docs/en/how-it-works.md
+++ b/docs/en/how-it-works.md
@@ -79,10 +79,11 @@ program
   .option('--ignore-tag <tag>', 'resources carrying this tag are excluded …', 'cloudrift:ignore')
   .option('--pdf [filename]', 'Export a PDF report …')
   .option('--json [filename]', 'Output the report as JSON …')
+  .option('--silent', 'suppress all stdout output …')
   .action(analyzeWasteCommand);
 ```
 
-`--pdf` and `--json` accept an optional filename. `--json` with no filename prints **only** the JSON to stdout (the table output is suppressed), making the command composable: `cloudrift analyze --json | jq '.totalWasteMonthlyUsd'`.
+`--pdf` and `--json` accept an optional filename and are file artifacts, independent of `--format`: by default the chosen `--format` (table) still prints to stdout *in addition to* writing the file. To get JSON only on stdout (composable: `cloudrift analyze --format json | jq '.totalWasteMonthlyUsd'`), pass `--format json` explicitly. To suppress stdout entirely and only write the file(s), add `--silent`.
 
 ---
 
@@ -261,7 +262,7 @@ export const presenters: PresenterMap = {
 - **JSON** (`waste-report.json-formatter.ts`): serializes `toWasteReportDto(summary, meta)` — the data contract for dashboards, CI or a future frontend. Every finding carries its `category` and `estimated` flag.
 - **Markdown** (`waste-report.markdown-formatter.ts`): a Pull-Request-ready report (totals, breakdown, collapsible `<details>` per kind, top recommendations, cost-threshold callout, a separate "Total optimization" row) for `--format markdown` in CI.
 
-`--format` (`table` | `json` | `markdown`) selects what goes to stdout; `--pdf` / `--json [filename]` write additional files. In machine-readable formats the human chrome is routed to stderr so stdout carries only the report.
+`--format` (`table` | `json` | `markdown`) selects what goes to stdout; `--pdf` / `--json [filename]` write additional files, independent of `--format`. In machine-readable formats the human chrome is routed to stderr so stdout carries only the report. `--silent` suppresses stdout entirely (chrome and report), for file-only runs.
 
 ---
 

--- a/docs/en/technical-choices.md
+++ b/docs/en/technical-choices.md
@@ -148,7 +148,7 @@ if (!parsed.ok) return fail(parsed.error.message); // clean message, exit 1, no 
 
 **Choice:** `chalk` for colors and `cli-table3` for tables.
 
-**Why:** automatic color-support handling; aligned, readable tables. With `--json` and no filename, the table output is suppressed to keep the machine-readable stdout clean.
+**Why:** automatic color-support handling; aligned, readable tables. `--format json` (not `--json`, which is a file artifact, independent of `--format`) suppresses the table to keep machine-readable stdout clean; `--silent` suppresses it for file-only runs regardless of `--format`.
 
 ---
 

--- a/docs/it/funzionamento.md
+++ b/docs/it/funzionamento.md
@@ -79,10 +79,11 @@ program
   .option('--ignore-tag <tag>', 'resources carrying this tag are excluded …', 'cloudrift:ignore')
   .option('--pdf [filename]', 'Export a PDF report …')
   .option('--json [filename]', 'Output the report as JSON …')
+  .option('--silent', 'suppress all stdout output …')
   .action(analyzeWasteCommand);
 ```
 
-`--pdf` e `--json` accettano un filename opzionale. `--json` senza filename stampa **solo** il JSON su stdout (l'output tabellare viene soppresso), così il comando è componibile: `cloudrift analyze --json | jq '.totalWasteMonthlyUsd'`.
+`--pdf` e `--json` accettano un filename opzionale e sono file artifacts, indipendenti da `--format`: di default il `--format` scelto (table) continua comunque a essere stampato su stdout *in aggiunta* alla scrittura del file. Per avere solo JSON su stdout (componibile: `cloudrift analyze --format json | jq '.totalWasteMonthlyUsd'`) passa esplicitamente `--format json`. Per sopprimere del tutto stdout e scrivere solo il/i file, aggiungi `--silent`.
 
 ---
 
@@ -261,7 +262,7 @@ export const presenters: PresenterMap = {
 - **JSON** (`waste-report.json-formatter.ts`): serializza `toWasteReportDto(summary, meta)` — il contratto dati per dashboard, CI o un futuro frontend. Ogni finding porta il proprio `category` e il flag `estimated`.
 - **Markdown** (`waste-report.markdown-formatter.ts`): un report pronto per le Pull Request (totali, breakdown, `<details>` collassabile per kind, raccomandazioni principali, callout sulla soglia di costo, una riga separata "Total optimization") per `--format markdown` in CI.
 
-`--format` (`table` | `json` | `markdown`) sceglie cosa va su stdout; `--pdf` / `--json [filename]` scrivono file aggiuntivi. Nei formati machine-readable il chrome umano va su stderr, così su stdout resta solo il report.
+`--format` (`table` | `json` | `markdown`) sceglie cosa va su stdout; `--pdf` / `--json [filename]` scrivono file aggiuntivi, indipendenti da `--format`. Nei formati machine-readable il chrome umano va su stderr, così su stdout resta solo il report. `--silent` sopprime del tutto stdout (chrome e report), per esecuzioni solo-file.
 
 ---
 

--- a/docs/it/scelte-tecniche.md
+++ b/docs/it/scelte-tecniche.md
@@ -148,7 +148,7 @@ if (!parsed.ok) return fail(parsed.error.message); // messaggio pulito, exit 1, 
 
 **Scelta:** `chalk` per i colori e `cli-table3` per le tabelle.
 
-**Perché:** gestione automatica del supporto colori; tabelle allineate e leggibili. Con `--json` senza filename l'output tabellare viene soppresso per non sporcare lo stdout machine-readable.
+**Perché:** gestione automatica del supporto colori; tabelle allineate e leggibili. `--format json` (non `--json`, che è un file artifact indipendente da `--format`) sopprime la tabella per non sporcare lo stdout machine-readable; `--silent` la sopprime per le esecuzioni solo-file indipendentemente dal `--format`.
 
 ---
 


### PR DESCRIPTION
## Summary
- Add `--silent` flag to the `analyze` command: suppresses all stdout output (banner, scanning message, confirmations, rendered report) for file-only runs with `--pdf`/`--json`. Errors and the cost-gate alert still surface on stderr, exit codes unchanged.
- Fix a pre-existing doc/ADR inaccuracy: several docs claimed `--json` with no filename alone suppressed the table — actually it's `--format json` that does that; `--json`/`--pdf` are file artifacts independent of `--format` and by default coexist with the printed table view.

## Why
`--pdf`/`--json` write file artifacts independently of `--format`, so e.g. `analyze --pdf ./report.pdf` still prints the full table to the terminal by default — surprising when you only want the file. `--silent` gives an explicit opt-out without changing the existing pipeline-composable behavior of `--format json`/`--format markdown`.

## Changes
- `apps/cli/src/main.ts`: register `--silent` on the `analyze` command.
- `apps/cli/src/commands/analyze-waste.command.ts`: `silent` suppresses banner, `info` messages, and the final `console.log(rendered)`; `fail()` and the cost-gate alert are unaffected (still stderr).
- `apps/cli/src/commands/analyze-waste.command.spec.ts`: new tests — silent + `--pdf` produces empty stdout/stderr with the file still written correctly; cost-gate alert and `--format` validation failures still surface on stderr under `--silent`.
- `README.md` (EN/IT): document `--silent`, clarify stdout-vs-file-artifacts behavior, add usage examples.
- `docs/en/how-it-works.md` / `docs/it/funzionamento.md`: same clarification in the architecture walkthrough.
- `docs/adr/0031-chalk-cli-table3-console-output.md`, `docs/en/technical-choices.md`, `docs/it/scelte-tecniche.md`: corrected the stale `--json`-suppresses-table claim, noted `--silent`.

## Test plan
- [x] `pnpm nx run cli:test` — all suites pass, including 3 new `--silent` cases
- [x] `pnpm nx run cli:lint` / `cli:typecheck` / `cli:build` — clean
- [x] Manual verification against LocalStack: `analyze --pdf <file> --silent` produces empty stdout/stderr and a valid PDF on disk