### PR TITLE
feat(docs): policy-as-code via external OPA layer — Phase 5.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
 - [Configuration file](#configuration-file)
 - [Pricing sources](#pricing-sources)
 - [Use in CI/CD](#use-in-cicd)
+- [Policy as Code (OPA)](#policy-as-code-opa)
 - [Required IAM permissions](#required-iam-permissions)
 - [Development](#development)
 - [Releasing](#releasing)
@@ -382,6 +383,22 @@ With a `cloudrift.config.json` committed (`{"costAlertThresholdUsd": 500}`), the
 
 </details>
 
+<details>
+<summary><strong>Policy as Code (OPA)</strong> — richer rules than the budget gate, using Open Policy Agent</summary>
+
+### Policy as Code (OPA)
+
+The `costAlertThresholdUsd` gate above is a single total-vs-budget comparison. For anything more specific — per-tag, per-resource-kind, per-count rules — cloudrift ships example [Open Policy Agent](https://www.openpolicyagent.org/) policies you evaluate against its JSON output, in your own pipeline. cloudrift never runs OPA itself; it only ever produces JSON, exactly as it already does.
+
+```sh
+node apps/cli/dist/main.js analyze --format json > report.json
+conftest test --policy policy report.json
+```
+
+See [docs/en/policy-as-code.md](./docs/en/policy-as-code.md) for a from-zero walkthrough and [policy/README.md](./policy/README.md) for what each example policy checks. Rationale for keeping this external to the CLI: [ADR-0042](./docs/adr/0042-policy-as-code-external-opa-layer.md).
+
+</details>
+
 ### Required IAM permissions
 
 The AWS principal needs the following read-only permissions:
@@ -475,6 +492,7 @@ Full documentation is in the [`docs/`](./docs/) folder — English in [`docs/en/
 | [docs/en/how-it-works.md](./docs/en/how-it-works.md)            | End-to-end execution flow, code walkthrough            |
 | [docs/en/adding-a-resource.md](./docs/en/adding-a-resource.md)  | Step-by-step guide to adding a new resource type       |
 | [docs/en/testing.md](./docs/en/testing.md)                      | Test pyramid, where each level lives, manual AWS verification |
+| [docs/en/policy-as-code.md](./docs/en/policy-as-code.md)        | From-zero OPA walkthrough for the example policies in `policy/` |
 | [docs/en/releasing.md](./docs/en/releasing.md)                  | How `@cloudrift/cli` is built and published to npm     |
 
 ### Adding a new resource type
@@ -511,6 +529,7 @@ Apache License 2.0 — see [LICENSE.md](./LICENSE.md). Free to use, modify, and 
 - [File di configurazione](#file-di-configurazione)
 - [Fonti dei prezzi](#fonti-dei-prezzi)
 - [Uso in CI/CD](#uso-in-cicd)
+- [Policy as Code (OPA)](#policy-as-code-opa-1)
 - [Permessi IAM necessari](#permessi-iam-necessari)
 - [Sviluppo](#sviluppo)
 - [Rilascio](#rilascio)
@@ -882,6 +901,22 @@ Con un `cloudrift.config.json` committato (`{"costAlertThresholdUsd": 500}`), il
 
 </details>
 
+<details>
+<summary><strong>Policy as Code (OPA)</strong> — regole più espressive del gate di budget, con Open Policy Agent</summary>
+
+### Policy as Code (OPA)
+
+Il gate `costAlertThresholdUsd` qui sopra è un singolo confronto totale-vs-budget. Per qualcosa di più specifico — regole per tag, per tipo di risorsa, per conteggio — cloudrift include policy [Open Policy Agent](https://www.openpolicyagent.org/) di esempio che valuti tu contro il suo output JSON, nella tua pipeline. cloudrift non esegue mai OPA da sé; produce solo JSON, esattamente come già fa.
+
+```sh
+node apps/cli/dist/main.js analyze --format json > report.json
+conftest test --policy policy report.json
+```
+
+Vedi [docs/it/policy-as-code.md](./docs/it/policy-as-code.md) per una guida da zero e [policy/README.md](./policy/README.md) per cosa verifica ogni policy di esempio. Motivazione per tenere questo livello esterno alla CLI: [ADR-0042](./docs/adr/0042-policy-as-code-external-opa-layer.md).
+
+</details>
+
 ### Permessi IAM necessari
 
 Il principal AWS deve avere le seguenti permission in sola lettura:
@@ -975,6 +1010,7 @@ Tutta la documentazione è nella cartella [`docs/`](./docs/) — italiano in [`d
 | [docs/it/funzionamento.md](./docs/it/funzionamento.md)               | Flusso di esecuzione end-to-end, spiegazione del codice           |
 | [docs/it/aggiungere-risorsa.md](./docs/it/aggiungere-risorsa.md)     | Guida passo per passo per aggiungere un nuovo tipo di risorsa     |
 | [docs/it/test.md](./docs/it/test.md)                                 | Piramide dei test, dove vive ogni livello, verifica manuale AWS   |
+| [docs/it/policy-as-code.md](./docs/it/policy-as-code.md)             | Guida OPA da zero per le policy di esempio in `policy/`           |
 | [docs/it/rilascio.md](./docs/it/rilascio.md)                         | Come `@cloudrift/cli` viene buildato e pubblicato su npm           |
 
 ## Licenza

--- a/docs/adr/0042-policy-as-code-external-opa-layer.md
+++ b/docs/adr/0042-policy-as-code-external-opa-layer.md
@@ -1,0 +1,28 @@
+# ADR-0042: Policy-as-Code via an external OPA layer, not an embedded Rego engine
+
+- **Status:** Accepted (2026-07-08)
+
+## Context
+
+cloudrift already has one gating mechanism: `applyCostGate` in [`analyze-waste.command.ts`](../../apps/cli/src/commands/analyze-waste.command.ts) sets `process.exitCode = 2` when `config.costAlertThresholdUsd` is set and `totalWasteMonthlyUsd` exceeds it. It is a single scalar comparison against the report total — it cannot express per-finding, per-tag, per-kind, or per-count rules (e.g. "block only if a wasted resource is tagged `production`", "block if there are more than N idle volumes regardless of their cost").
+
+On 2026-06-25 the user approved, in principle, pushing cloudrift's "Policy-as-Code" positioning further with [Open Policy Agent](https://www.openpolicyagent.org/) (OPA), with an explicit constraint: as an external layer, not an OPA/Rego runtime embedded in the npm package. This was deferred until the rest of the v0.5.0 backlog closed; work started 2026-07-08.
+
+## Decision
+
+Ship example policies and documentation, with no changes to `apps/cli` and no new runtime dependency:
+
+- A top-level [`policy/`](../../policy/) directory with three example `.rego` policies (budget total, per-finding tag, per-kind count), each with a matching `*_test.rego` unit test file (OPA's built-in test framework) and a bundled `testdata/sample-report.json` fixture shaped like real `WasteReportDto` JSON, so the examples are runnable with zero AWS setup.
+- Bilingual walkthrough docs, [`docs/en/policy-as-code.md`](../en/policy-as-code.md) / [`docs/it/policy-as-code.md`](../it/policy-as-code.md), written for a reader with no prior OPA/Rego experience.
+- A "Policy as Code (OPA)" section in the main README, next to the existing "Use in CI/CD" section.
+
+cloudrift's own output is unchanged: it still only ever produces JSON via `--format json`. The user (or their CI pipeline) evaluates that JSON against the example (or their own) `.rego` policies using their own [`conftest`](https://www.conftest.dev/)/`opa` install — cloudrift never shells out to or bundles either tool.
+
+## Alternatives Considered
+
+- **Embed an OPA runtime in the CLI** (shelled-out `opa` binary, or a WASM build compiled into `@cloudrift/cli`). Rejected: a heavy, platform-specific dependency, for a result that — for the common case of "compare a total to a budget" — the existing native gate already provides. The only scenario where an embedded engine would add value (expressive, multi-signal policies) is exactly the scenario where the user already has their own OPA/Rego tooling and workflow to plug into, making embedding redundant rather than convenient.
+- **Do nothing beyond the native gate.** Rejected: doesn't serve users who want per-tag/per-kind/per-count rules, or who want to reuse an existing organizational Rego bundle (e.g. the same policies already applied to Terraform plans) against cloudrift's findings too.
+
+## Consequences
+
+New top-level `policy/` directory (three `.rego` policies + tests + fixture + `policy/README.md`), two new doc pages (`docs/en/policy-as-code.md`, `docs/it/policy-as-code.md`), and one new README section (EN + IT). No new npm dependency, no `apps/cli` code change, no change to cloudrift's own CI workflows — evaluation happens entirely in the end user's own environment/pipeline. `opa` and `conftest` were installed locally (via `brew`) only to verify the shipped example policies evaluate correctly before publishing them; neither is a project dependency.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -43,6 +43,7 @@ Each entry follows: Context → Decision → Alternatives Considered → Consequ
 | [0019](0019-server-side-filter-optimization-only.md) | Server-side filtering is an optimization only, never the decision |
 | [0020](0020-multicloud-path-deferred.md) | Multi-cloud: path kept open, not built now |
 | [0021](0021-wastereportdto-frontend-contract.md) | `WasteReportDto` as the future frontend's API contract |
+| [0042](0042-policy-as-code-external-opa-layer.md) | Policy-as-Code via an external OPA layer, not an embedded Rego engine |
 
 ## Stack
 

--- a/docs/en/policy-as-code.md
+++ b/docs/en/policy-as-code.md
@@ -1,0 +1,112 @@
+# Policy as Code (OPA)
+
+> 🇮🇹 [Versione italiana](../it/policy-as-code.md)
+
+This document is a from-zero walkthrough: what [Open Policy Agent](https://www.openpolicyagent.org/) (OPA) is, why cloudrift treats it as an external layer instead of a built-in feature, and how to actually run the example policies shipped in [`policy/`](../../policy/) against a real report. No prior OPA/Rego experience assumed.
+
+## What this is (and isn't)
+
+`cloudrift analyze` already has one built-in gate: set `costAlertThresholdUsd` in `cloudrift.config.json` and the command exits with code 2 when `totalWasteMonthlyUsd` goes over it (`applyCostGate` in [`analyze-waste.command.ts`](../../apps/cli/src/commands/analyze-waste.command.ts)) — enough to fail a CI job on a budget breach. See [Use in CI/CD](../../README.md#use-in-cicd) in the main README.
+
+That gate can only ever compare one number to another. It cannot say "only block if the wasted resource is tagged `production`" or "block if there are more than N idle volumes, regardless of their cost." Rules like that need an actual rule engine, evaluated against the structured findings, not just a total — which is what OPA is for.
+
+**OPA/Rego, in one paragraph:** OPA is a general-purpose policy engine. You write rules in a small language called Rego that read a piece of structured data (JSON, in our case) and decide `deny`/`allow`. It's the same tool a lot of teams already point at a Terraform plan or a Kubernetes manifest before letting it through CI. [`conftest`](https://www.conftest.dev/) is a thin CLI built on top of OPA specifically for "test this file against these Rego policies," which is exactly cloudrift's use case.
+
+**cloudrift's role stops at producing JSON.** It doesn't run OPA, doesn't ship an OPA binary, and doesn't gain a new dependency for this. You (or your CI pipeline) run `conftest`/`opa` yourself, pointed at cloudrift's `--format json` output. Full rationale: [ADR-0042](../adr/0042-policy-as-code-external-opa-layer.md).
+
+## Prerequisites
+
+Install `conftest` — this is the tool used throughout this doc:
+
+```sh
+# macOS
+brew install conftest
+
+# other platforms: see https://www.conftest.dev/install/
+```
+
+> Raw `opa` (`brew install opa`) works too — `conftest` is a convenience wrapper around it, see [Equivalent with raw opa](#equivalent-with-raw-opa) below. You don't need both.
+
+## Try it in 30 seconds — no AWS account needed
+
+The repo ships a small sample report at [`policy/testdata/sample-report.json`](../../policy/testdata/sample-report.json), shaped exactly like real `cloudrift analyze --format json` output, so you can see the policies fire before touching a real account:
+
+```sh
+conftest test --policy policy policy/testdata/sample-report.json
+```
+
+Expected output — all three example policies deny something on purpose, so this fixture always fails:
+
+```
+FAIL - policy/testdata/sample-report.json - main - 3 unattached EBS volumes found, more than the 2 allowed
+FAIL - policy/testdata/sample-report.json - main - ebs-volume (vol-0abc123def456) in production is wasting $40/month: unattached (state: available) for 19 days
+FAIL - policy/testdata/sample-report.json - main - elastic-ip (eipalloc-0123456789abcdef0) in production is wasting $3.6/month: unassociated (no EC2/NAT binding)
+FAIL - policy/testdata/sample-report.json - main - total monthly waste $63.6 exceeds budget $50
+```
+
+`--policy policy` tells conftest where to find `.rego` files (the [`policy/`](../../policy/) directory at the repo root); the last argument is the JSON file to check.
+
+## Run it against a real report
+
+```sh
+node apps/cli/dist/main.js analyze --format json > report.json
+conftest test --policy policy report.json
+```
+
+`conftest` exits `1` if any rule denied something, `0` if the report is clean — exactly the signal a CI step needs.
+
+## What's in `policy/`
+
+| File | Rule |
+| --- | --- |
+| [`waste-budget.rego`](../../policy/waste-budget.rego) | Total monthly waste over a fixed budget — the Rego version of the native `costAlertThresholdUsd` gate |
+| [`production-tag.rego`](../../policy/production-tag.rego) | Any waste finding tagged `Environment: production` — per-finding, not just the total |
+| [`idle-resource-count.rego`](../../policy/idle-resource-count.rego) | More than N unattached EBS volumes, regardless of their individual cost |
+
+Each has a `_test.rego` sibling and a one-line constant documented as "the one line to edit" — see [`policy/README.md`](../../policy/README.md) for the full breakdown. Run the example test suite with:
+
+```sh
+opa test policy/ -v
+```
+
+## Writing your own rule
+
+All three example files share `package main`, and Rego merges same-named `deny contains msg if {...}` blocks across files into a single set — so a fourth file just needs the same package header and its own condition. For example, denying any finding over $100/month regardless of tags:
+
+```rego
+# policy/high-cost-finding.rego
+package main
+
+import rego.v1
+
+deny contains msg if {
+	some finding in input.findings
+	finding.category == "waste"
+	finding.monthlyCostUsd > 100
+	msg := sprintf("%s (%s) is wasting $%v/month", [finding.kind, finding.id, finding.monthlyCostUsd])
+}
+```
+
+`input` is the parsed JSON report — see [`WasteReportDto`](../../libs/cloud-cost/application/src/dto/waste-report.dto.ts) for the full field list (`findings[].kind`, `.category`, `.tags`, `.monthlyCostUsd`, `.region`, top-level `totalWasteMonthlyUsd`, `wasteCount`, etc.).
+
+> **One Rego gotcha worth knowing up front:** cloudrift's JSON serializes a cost that happens to be a whole dollar amount (e.g. exactly `$40`) without a decimal point. Rego's `%.2f` format verb crashes on a value like that (`%!f(int=40)`) — the example policies use `%v` instead, which prints either shape safely. Prefer `%v` over `%.2f` in your own rules unless you've confirmed the field can never be a whole number.
+
+## Wire it into CI
+
+Add a step after the scan, right next to the native budget gate from the [main README](../../README.md#use-in-cicd):
+
+```yaml
+      - run: node cloudrift-cli/apps/cli/dist/main.js analyze -r us-east-1 --format json > report.json
+        working-directory: cloudrift-cli
+
+      - uses: openpolicyagent/conftest-action@v1
+        with:
+          policy: cloudrift-cli/policy
+          files: cloudrift-cli/report.json
+```
+
+(Or install `conftest` directly with the same shell steps as [Prerequisites](#prerequisites) above and run `conftest test --policy policy report.json` if you'd rather not add a marketplace action.)
+
+## Why external, not built into the CLI
+
+Short version: embedding an OPA runtime (a shelled-out `opa` binary or a WASM build) inside the `@cloudrift/cli` npm package would add a heavy, platform-specific dependency to get a result that — for most users — a numeric comparison already provides. The value of a real policy engine only shows up once you want expressive, multi-signal rules, or want to reuse an OPA/Rego bundle you already maintain for Terraform or Kubernetes. Keeping OPA entirely outside the package means cloudrift stays a small, dependency-light CLI, and anyone who wants this layer opts into it explicitly, in their own environment. Full decision record: [ADR-0042](../adr/0042-policy-as-code-external-opa-layer.md).

--- a/docs/it/policy-as-code.md
+++ b/docs/it/policy-as-code.md
@@ -1,0 +1,112 @@
+# Policy as Code (OPA)
+
+> 🇬🇧 [English version](../en/policy-as-code.md)
+
+Questo documento parte da zero: cos'è [Open Policy Agent](https://www.openpolicyagent.org/) (OPA), perché cloudrift lo tratta come un livello esterno invece che una feature integrata, e come eseguire davvero le policy di esempio in [`policy/`](../../policy/) contro un report reale. Non è richiesta nessuna esperienza precedente con OPA/Rego.
+
+## Cosa è (e cosa non è)
+
+`cloudrift analyze` ha già un gate integrato: imposta `costAlertThresholdUsd` in `cloudrift.config.json` e il comando esce con codice 2 quando `totalWasteMonthlyUsd` supera quella soglia (`applyCostGate` in [`analyze-waste.command.ts`](../../apps/cli/src/commands/analyze-waste.command.ts)) — sufficiente per far fallire un job CI al superamento del budget. Vedi [Uso in CI/CD](../../README.md#uso-in-cicd) nel README principale.
+
+Quel gate può solo confrontare un numero con un altro. Non può dire "blocca solo se la risorsa sprecata è taggata `production`" oppure "blocca se ci sono più di N volumi idle, indipendentemente dal loro costo". Regole così richiedono un vero motore di regole, valutato sui findings strutturati, non solo su un totale — ed è a questo che serve OPA.
+
+**OPA/Rego, in un paragrafo:** OPA è un motore di policy general-purpose. Si scrivono regole in un piccolo linguaggio chiamato Rego che leggono un dato strutturato (JSON, nel nostro caso) e decidono `deny`/`allow`. È lo stesso strumento che molti team puntano già contro un piano Terraform o un manifest Kubernetes prima di farlo passare in CI. [`conftest`](https://www.conftest.dev/) è una CLI leggera costruita sopra OPA specificamente per "verifica questo file contro queste policy Rego", che è esattamente il caso d'uso di cloudrift.
+
+**Il ruolo di cloudrift si ferma alla produzione del JSON.** Non esegue OPA, non include un binario OPA, e non guadagna nessuna nuova dipendenza per questo. Sei tu (o la tua pipeline CI) a eseguire `conftest`/`opa`, puntato sull'output `--format json` di cloudrift. Motivazione completa: [ADR-0042](../adr/0042-policy-as-code-external-opa-layer.md).
+
+## Prerequisiti
+
+Installa `conftest` — è lo strumento usato in tutto questo documento:
+
+```sh
+# macOS
+brew install conftest
+
+# altre piattaforme: vedi https://www.conftest.dev/install/
+```
+
+> Anche `opa` puro (`brew install opa`) funziona — `conftest` è un wrapper di comodo sopra di esso, vedi [Equivalente con opa puro](#equivalente-con-opa-puro) qui sotto. Non ti servono entrambi.
+
+## Provalo in 30 secondi — nessun account AWS necessario
+
+Il repo include un piccolo report di esempio in [`policy/testdata/sample-report.json`](../../policy/testdata/sample-report.json), con la stessa identica forma del vero output `cloudrift analyze --format json`, così puoi vedere le policy scattare senza toccare un account reale:
+
+```sh
+conftest test --policy policy policy/testdata/sample-report.json
+```
+
+Output atteso — tutte e tre le policy di esempio negano qualcosa di proposito, quindi questo fixture fallisce sempre:
+
+```
+FAIL - policy/testdata/sample-report.json - main - 3 unattached EBS volumes found, more than the 2 allowed
+FAIL - policy/testdata/sample-report.json - main - ebs-volume (vol-0abc123def456) in production is wasting $40/month: unattached (state: available) for 19 days
+FAIL - policy/testdata/sample-report.json - main - elastic-ip (eipalloc-0123456789abcdef0) in production is wasting $3.6/month: unassociated (no EC2/NAT binding)
+FAIL - policy/testdata/sample-report.json - main - total monthly waste $63.6 exceeds budget $50
+```
+
+`--policy policy` dice a conftest dove trovare i file `.rego` (la cartella [`policy/`](../../policy/) nella root del repo); l'ultimo argomento è il file JSON da verificare.
+
+## Eseguilo contro un report reale
+
+```sh
+node apps/cli/dist/main.js analyze --format json > report.json
+conftest test --policy policy report.json
+```
+
+`conftest` esce con `1` se una regola ha negato qualcosa, `0` se il report è pulito — esattamente il segnale di cui ha bisogno uno step CI.
+
+## Cosa c'è in `policy/`
+
+| File | Regola |
+| --- | --- |
+| [`waste-budget.rego`](../../policy/waste-budget.rego) | Spreco mensile totale oltre un budget fisso — la versione Rego del gate nativo `costAlertThresholdUsd` |
+| [`production-tag.rego`](../../policy/production-tag.rego) | Qualunque finding di spreco taggato `Environment: production` — per singolo finding, non solo sul totale |
+| [`idle-resource-count.rego`](../../policy/idle-resource-count.rego) | Più di N volumi EBS non attaccati, indipendentemente dal costo di ciascuno |
+
+Ognuno ha un file `_test.rego` gemello e una costante commentata come "la riga da modificare" — vedi [`policy/README.md`](../../policy/README.md) per il dettaglio completo. Esegui la suite di test di esempio con:
+
+```sh
+opa test policy/ -v
+```
+
+## Scrivere una tua regola
+
+Tutti e tre i file di esempio condividono `package main`, e Rego unisce i blocchi `deny contains msg if {...}` con lo stesso nome tra file diversi in un unico insieme — quindi un quarto file ti serve solo lo stesso header di package e una sua condizione. Ad esempio, per negare qualunque finding oltre $100/mese indipendentemente dai tag:
+
+```rego
+# policy/high-cost-finding.rego
+package main
+
+import rego.v1
+
+deny contains msg if {
+	some finding in input.findings
+	finding.category == "waste"
+	finding.monthlyCostUsd > 100
+	msg := sprintf("%s (%s) is wasting $%v/month", [finding.kind, finding.id, finding.monthlyCostUsd])
+}
+```
+
+`input` è il report JSON già parsato — vedi [`WasteReportDto`](../../libs/cloud-cost/application/src/dto/waste-report.dto.ts) per l'elenco completo dei campi (`findings[].kind`, `.category`, `.tags`, `.monthlyCostUsd`, `.region`, e a livello superiore `totalWasteMonthlyUsd`, `wasteCount`, ecc.).
+
+> **Una particolarità di Rego da conoscere subito:** il JSON di cloudrift serializza un costo che risulta essere un importo intero in dollari (es. esattamente `$40`) senza punto decimale. Il verbo di formato `%.2f` di Rego va in crash su un valore così (`%!f(int=40)`) — le policy di esempio usano `%v` al suo posto, che stampa entrambe le forme senza errori. Preferisci `%v` a `%.2f` nelle tue regole, a meno che tu non abbia verificato che il campo non possa mai essere un numero intero.
+
+## Integrarlo in CI
+
+Aggiungi uno step dopo la scansione, subito accanto al gate di budget nativo dal [README principale](../../README.md#uso-in-cicd):
+
+```yaml
+      - run: node cloudrift-cli/apps/cli/dist/main.js analyze -r us-east-1 --format json > report.json
+        working-directory: cloudrift-cli
+
+      - uses: openpolicyagent/conftest-action@v1
+        with:
+          policy: cloudrift-cli/policy
+          files: cloudrift-cli/report.json
+```
+
+(In alternativa, installa `conftest` direttamente con gli stessi step shell di [Prerequisiti](#prerequisiti) qui sopra ed esegui `conftest test --policy policy report.json` se preferisci non aggiungere una action da marketplace.)
+
+## Perché esterno, non integrato nella CLI
+
+In breve: incorporare un runtime OPA (un binario `opa` shellato o una build WASM) dentro il pacchetto npm `@cloudrift/cli` aggiungerebbe una dipendenza pesante e platform-specific per ottenere un risultato che, per la maggior parte degli utenti, un confronto numerico offre già. Il valore di un vero motore di policy emerge solo quando vuoi regole espressive, multi-segnale, o vuoi riusare un bundle OPA/Rego che già mantieni per Terraform o Kubernetes. Tenere OPA completamente fuori dal pacchetto mantiene cloudrift una CLI piccola e con poche dipendenze, e chi vuole questo livello lo attiva esplicitamente, nel proprio ambiente. Decisione completa: [ADR-0042](../adr/0042-policy-as-code-external-opa-layer.md).

--- a/policy/README.md
+++ b/policy/README.md
@@ -1,0 +1,53 @@
+# Example Open Policy Agent policies
+
+Three small [Rego](https://www.openpolicyagent.org/docs/latest/policy-language/) policies that evaluate cloudrift's JSON report (`analyze --format json`) and deny when a rule is broken. cloudrift itself never runs these — you evaluate them yourself with [`conftest`](https://www.conftest.dev/) or [`opa`](https://www.openpolicyagent.org/), in your own shell or CI pipeline. See [docs/en/policy-as-code.md](../docs/en/policy-as-code.md) (or [docs/it/policy-as-code.md](../docs/it/policy-as-code.md)) for a full walkthrough starting from zero OPA experience, and [ADR-0042](../docs/adr/0042-policy-as-code-external-opa-layer.md) for why this is a separate layer instead of something built into the CLI.
+
+All three files share `package main` so a single `conftest test`/`opa eval` picks up every rule at once — Rego merges `deny contains msg if {...}` blocks with the same name across files into one set.
+
+| File | Checks | The one line to edit |
+| --- | --- | --- |
+| [`waste-budget.rego`](./waste-budget.rego) | `totalWasteMonthlyUsd` against a fixed budget — the same rule cloudrift's own `costAlertThresholdUsd` gate already enforces natively, written in Rego as a starting point | `budget_usd` |
+| [`production-tag.rego`](./production-tag.rego) | Any individual **waste** finding tagged `Environment: production` — something the native gate can't express, since it only ever looks at the total | the tag key/value on line 11 |
+| [`idle-resource-count.rego`](./idle-resource-count.rego) | The *number* of `ebs-volume` findings, not their cost — flags "too many idle volumes" even if each one is cheap | `max_idle_ebs_volumes` |
+
+Each `*.rego` file has a matching `*_test.rego` using OPA's built-in test framework. Run them with:
+
+```sh
+opa test policy/ -v
+```
+
+## Try it against the bundled fixture
+
+[`testdata/sample-report.json`](./testdata/sample-report.json) is a small, hand-written report (3 EBS volumes + 1 Elastic IP, one of them tagged `production`) shaped exactly like real `cloudrift analyze --format json` output, so you can try every rule immediately with no AWS account:
+
+```sh
+conftest test --policy policy policy/testdata/sample-report.json
+```
+
+All three rules are written to trigger against this fixture on purpose, so you'll see:
+
+```
+FAIL - policy/testdata/sample-report.json - main - 3 unattached EBS volumes found, more than the 2 allowed
+FAIL - policy/testdata/sample-report.json - main - ebs-volume (vol-0abc123def456) in production is wasting $40/month: unattached (state: available) for 19 days
+FAIL - policy/testdata/sample-report.json - main - elastic-ip (eipalloc-0123456789abcdef0) in production is wasting $3.6/month: unassociated (no EC2/NAT binding)
+FAIL - policy/testdata/sample-report.json - main - total monthly waste $63.6 exceeds budget $50
+```
+
+`conftest` exits non-zero whenever `deny` is non-empty — that's what fails a CI job.
+
+## Run it against a real report
+
+```sh
+node apps/cli/dist/main.js analyze --format json > report.json
+conftest test --policy policy report.json
+```
+
+## Equivalent with raw `opa`
+
+`conftest` is a thin, purpose-built wrapper around `opa eval` for exactly this "structured file + Rego policy → pass/fail" shape. The same check with the underlying tool:
+
+```sh
+opa eval --data policy --input report.json 'data.main.deny' --format pretty
+```
+
+A non-empty array means at least one rule fired.

--- a/policy/idle-resource-count.rego
+++ b/policy/idle-resource-count.rego
@@ -1,0 +1,20 @@
+package main
+
+import rego.v1
+
+# The one line to edit: how many unattached EBS volumes you're willing to
+# tolerate before it's worth a person looking at what keeps creating them.
+max_idle_ebs_volumes := 2
+
+deny contains msg if {
+	count(idle_ebs_volume_ids) > max_idle_ebs_volumes
+	msg := sprintf(
+		"%d unattached EBS volumes found, more than the %d allowed",
+		[count(idle_ebs_volume_ids), max_idle_ebs_volumes],
+	)
+}
+
+idle_ebs_volume_ids contains finding.id if {
+	some finding in input.findings
+	finding.kind == "ebs-volume"
+}

--- a/policy/idle-resource-count_test.rego
+++ b/policy/idle-resource-count_test.rego
@@ -1,0 +1,26 @@
+package main
+
+import rego.v1
+
+test_denies_too_many if {
+	count(deny) > 0 with input as {"findings": [
+		{"id": "a", "kind": "ebs-volume"},
+		{"id": "b", "kind": "ebs-volume"},
+		{"id": "c", "kind": "ebs-volume"},
+	]}
+}
+
+test_allows_within_limit if {
+	count(deny) == 0 with input as {"findings": [
+		{"id": "a", "kind": "ebs-volume"},
+		{"id": "b", "kind": "ebs-volume"},
+	]}
+}
+
+test_ignores_other_kinds if {
+	count(deny) == 0 with input as {"findings": [
+		{"id": "a", "kind": "elastic-ip"},
+		{"id": "b", "kind": "elastic-ip"},
+		{"id": "c", "kind": "elastic-ip"},
+	]}
+}

--- a/policy/production-tag.rego
+++ b/policy/production-tag.rego
@@ -1,0 +1,19 @@
+package main
+
+import rego.v1
+
+# Denies any *waste* finding (never *optimization* — that's a savings
+# opportunity, not money being wasted right now) tagged Environment:
+# production. This is the kind of rule the native budget gate can't express:
+# it only ever looks at the grand total, never at individual findings or
+# their tags.
+deny contains msg if {
+	some finding in input.findings
+	finding.category == "waste"
+	finding.tags.Environment == "production"
+	msg := sprintf(
+		# `%v`, not `%.2f` — see the comment in waste-budget.rego.
+		"%s (%s) in production is wasting $%v/month: %s",
+		[finding.kind, finding.id, finding.monthlyCostUsd, finding.wasteReason],
+	)
+}

--- a/policy/production-tag_test.rego
+++ b/policy/production-tag_test.rego
@@ -1,0 +1,43 @@
+package main
+
+import rego.v1
+
+test_denies_production_waste if {
+	count(deny) > 0 with input as {"findings": [{
+		"id": "vol-1", "kind": "ebs-volume", "category": "waste",
+		"monthlyCostUsd": 40, "wasteReason": "unattached for 12 days",
+		"tags": {"Environment": "production"},
+	}]}
+}
+
+test_allows_staging_waste if {
+	count(deny) == 0 with input as {"findings": [{
+		"id": "vol-2", "kind": "ebs-volume", "category": "waste",
+		"monthlyCostUsd": 40, "wasteReason": "unattached for 12 days",
+		"tags": {"Environment": "staging"},
+	}]}
+}
+
+test_allows_production_optimization if {
+	count(deny) == 0 with input as {"findings": [{
+		"id": "vol-3", "kind": "ebs-gp2-upgrade", "category": "optimization",
+		"monthlyCostUsd": 5, "wasteReason": "gp2 upgradeable to gp3",
+		"tags": {"Environment": "production"},
+	}]}
+}
+
+test_denies_whole_dollar_amount_without_format_glitch if {
+	deny == {"ebs-volume (vol-5) in production is wasting $40/month: unattached for 12 days"} with input as {"findings": [{
+		"id": "vol-5", "kind": "ebs-volume", "category": "waste",
+		"monthlyCostUsd": 40, "wasteReason": "unattached for 12 days",
+		"tags": {"Environment": "production"},
+	}]}
+}
+
+test_allows_untagged_waste if {
+	count(deny) == 0 with input as {"findings": [{
+		"id": "vol-4", "kind": "ebs-volume", "category": "waste",
+		"monthlyCostUsd": 40, "wasteReason": "unattached for 12 days",
+		"tags": {},
+	}]}
+}

--- a/policy/testdata/sample-report.json
+++ b/policy/testdata/sample-report.json
@@ -1,0 +1,92 @@
+{
+  "meta": {
+    "accountId": "123456789012",
+    "regions": ["us-east-1"],
+    "generatedAt": "2026-07-08T09:00:00.000Z",
+    "pricesAsOf": "2026-07-08 (static table)"
+  },
+  "disclaimer": "cloudrift is a read-only analysis tool: it reports estimated waste and recommendations only — it never deletes, modifies, or stops any AWS resource. All findings should be validated by your infrastructure team before taking action. The maintainers assume no liability for actions taken based on this report.",
+  "contact": {
+    "email": "raffaelevasini@gmail.com",
+    "github": "https://github.com/elleVas",
+    "linkedin": "https://www.linkedin.com/in/raffaele-vasini-87937470/"
+  },
+  "totalWasteMonthlyUsd": 63.6,
+  "totalWasteAnnualUsd": 763.2,
+  "totalOptimizationMonthlyUsd": 0,
+  "wasteCount": 4,
+  "optimizationCount": 0,
+  "breakdown": [
+    {
+      "kind": "ebs-volume",
+      "label": "EBS Volumes",
+      "category": "waste",
+      "estimated": false,
+      "count": 3,
+      "monthlyCostUsd": 60
+    },
+    {
+      "kind": "elastic-ip",
+      "label": "Elastic IPs",
+      "category": "waste",
+      "estimated": false,
+      "count": 1,
+      "monthlyCostUsd": 3.6
+    }
+  ],
+  "findings": [
+    {
+      "id": "vol-0abc123def456",
+      "kind": "ebs-volume",
+      "category": "waste",
+      "estimated": false,
+      "region": "us-east-1",
+      "accountId": "123456789012",
+      "detectedAt": "2026-07-08T09:00:00.000Z",
+      "wasteReason": "unattached (state: available) for 19 days",
+      "description": "500 GB gp3 volume, unattached",
+      "monthlyCostUsd": 40,
+      "tags": { "Environment": "production", "Team": "platform" }
+    },
+    {
+      "id": "vol-0def456abc789",
+      "kind": "ebs-volume",
+      "category": "waste",
+      "estimated": false,
+      "region": "us-east-1",
+      "accountId": "123456789012",
+      "detectedAt": "2026-07-08T09:00:00.000Z",
+      "wasteReason": "unattached (state: available) for 11 days",
+      "description": "150 GB gp3 volume, unattached",
+      "monthlyCostUsd": 12,
+      "tags": { "Environment": "staging" }
+    },
+    {
+      "id": "vol-0aaa111bbb222",
+      "kind": "ebs-volume",
+      "category": "waste",
+      "estimated": false,
+      "region": "us-east-1",
+      "accountId": "123456789012",
+      "detectedAt": "2026-07-08T09:00:00.000Z",
+      "wasteReason": "unattached (state: available) for 8 days",
+      "description": "100 GB gp2 volume, unattached",
+      "monthlyCostUsd": 8,
+      "tags": {}
+    },
+    {
+      "id": "eipalloc-0123456789abcdef0",
+      "kind": "elastic-ip",
+      "category": "waste",
+      "estimated": false,
+      "region": "us-east-1",
+      "accountId": "123456789012",
+      "detectedAt": "2026-07-08T09:00:00.000Z",
+      "wasteReason": "unassociated (no EC2/NAT binding)",
+      "description": "Elastic IP not associated with any resource",
+      "monthlyCostUsd": 3.6,
+      "tags": { "Environment": "production" }
+    }
+  ],
+  "scanErrors": []
+}

--- a/policy/waste-budget.rego
+++ b/policy/waste-budget.rego
@@ -1,0 +1,21 @@
+package main
+
+import rego.v1
+
+# The one line to edit: your monthly waste budget in USD.
+budget_usd := 50
+
+# This mirrors the gate cloudrift already enforces natively via
+# `costAlertThresholdUsd` (apps/cli/src/commands/analyze-waste.command.ts,
+# `applyCostGate`) — same rule, written in Rego, as the starting point before
+# writing something more specific than "total waste vs. one number".
+deny contains msg if {
+	input.totalWasteMonthlyUsd > budget_usd
+	msg := sprintf(
+		# `%v`, not `%.2f`: cloudrift's JSON serializes a whole-dollar cost
+		# (e.g. exactly $50) without a decimal point, and Rego's `%f` verb
+		# panics on a bare integer — `%v` prints either shape safely.
+		"total monthly waste $%v exceeds budget $%v",
+		[input.totalWasteMonthlyUsd, budget_usd],
+	)
+}

--- a/policy/waste-budget_test.rego
+++ b/policy/waste-budget_test.rego
@@ -1,0 +1,19 @@
+package main
+
+import rego.v1
+
+test_denies_over_budget if {
+	count(deny) > 0 with input as {"totalWasteMonthlyUsd": 100}
+}
+
+test_allows_under_budget if {
+	count(deny) == 0 with input as {"totalWasteMonthlyUsd": 10}
+}
+
+test_allows_exactly_at_budget if {
+	count(deny) == 0 with input as {"totalWasteMonthlyUsd": 50}
+}
+
+test_denies_whole_dollar_amount_without_format_glitch if {
+	deny == {"total monthly waste $100 exceeds budget $50"} with input as {"totalWasteMonthlyUsd": 100}
+}


### PR DESCRIPTION
## Summary
- Ship example Open Policy Agent (OPA) policies for cloudrift's JSON report, as a purely external layer — no changes to the CLI itself.
- Add bilingual, from-zero OPA walkthrough docs and a matching README section pointing at them.

## Why
On 2026-06-25 the direction was approved in principle: extend cloudrift's "Policy-as-Code" positioning beyond the existing total-only `costAlertThresholdUsd` gate (`applyCostGate` in `analyze-waste.command.ts`), but as an **external** layer — the user runs `opa`/`conftest` themselves against cloudrift's JSON, rather than cloudrift embedding an OPA runtime in the npm package. Avoids a heavy, platform-specific dependency for a result most users don't need, while still letting anyone who wants expressive per-tag/per-kind/per-count rules opt in on their own. Full rationale in ADR-0042.

## Changes
- `policy/` (new): three example `.rego` policies, all `package main` so a single `conftest test`/`opa eval` picks up every rule at once:
  - `waste-budget.rego` — Rego version of the native budget gate (total vs. a fixed threshold)
  - `production-tag.rego` — denies any **waste** finding tagged `Environment: production` (per-finding, something the native gate can't express)
  - `idle-resource-count.rego` — denies more than N idle EBS volumes, regardless of their individual cost
  - Each has a matching `*_test.rego` (12 OPA unit tests total, via `opa test`) and a `testdata/sample-report.json` fixture shaped exactly like real `WasteReportDto` JSON, so the examples run with zero AWS setup. `policy/README.md` documents each file and the exact commands.
- `docs/en/policy-as-code.md` / `docs/it/policy-as-code.md` (new): a walkthrough written for zero prior OPA/Rego experience — install `conftest`, try the bundled fixture, run against a real `analyze --format json` report, write a custom rule, wire it into CI. Includes a callout on a non-obvious Rego formatting gotcha found while writing the examples: `%.2f` crashes (`%!f(int=40)`) on a cost that happens to be a whole dollar amount, which cloudrift's JSON can produce — fixed by using `%v` instead.
- `README.md` (EN+IT): new "Policy as Code (OPA)" `<details>` section after "Use in CI/CD"/"Uso in CI/CD", plus TOC and technical-docs-index entries.
- `docs/adr/0042-policy-as-code-external-opa-layer.md` (new) + index row added to `docs/adr/README.md` under Architecture.

## Test plan
- [x] `opa test policy/ -v` — 12/12 pass
- [x] `conftest test --policy policy policy/testdata/sample-report.json` — all 4 example rules fire as documented in the docs, with clean `$N`/`$N.NN` formatting (no `%!f(int=...)` glitch)
- [x] Every relative link in the new docs/README sections manually checked to resolve
- [x] Confirmed no `apps/cli` code changes, no new npm dependency, no CI workflow changes — `nx build`/`lint`/`test`/`typecheck` untouched by this PR
