### PR TITLE
feat(security): fix security issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,38 @@ jobs:
       - name: Run tests
         run: pnpm nx run-many --target=test --all --parallel
 
+  audit:
+    name: Dependency audit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: '10.33.0'
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24.x'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Non-blocking for now (continue-on-error): the repo currently has a
+      # handful of moderate/high advisories in nx/@nx/jest's own transitive
+      # deps (not in the shipped @cloudrift/cli package). Surfacing them
+      # without failing the build until they're cleaned up; flip to blocking
+      # once `pnpm audit --audit-level moderate` is clean.
+      - name: Run pnpm audit
+        run: pnpm audit --audit-level moderate
+        continue-on-error: true
+
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,17 +19,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
         with:
           version: '10.33.0'
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '24.x'
           cache: 'pnpm'

--- a/README.md
+++ b/README.md
@@ -460,6 +460,8 @@ pnpm nx run-many -t lint
 pnpm nx run-many -t typecheck
 ```
 
+Diagnostic logging is opt-in via `DEBUG=cloudrift:*` (e.g. `DEBUG=cloudrift:* cloudrift analyze ...`), off by default. It writes to stderr, separate from the report itself — but its output includes AWS resource IDs (volume IDs, instance IDs, etc.) from your account. Don't paste `DEBUG` output into a public GitHub issue or share it outside your organization without checking it first.
+
 </details>
 
 ### Releasing
@@ -966,6 +968,8 @@ pnpm nx run-many -t lint
 # Type check
 pnpm nx run-many -t typecheck
 ```
+
+Il logging diagnostico è opt-in tramite `DEBUG=cloudrift:*` (es. `DEBUG=cloudrift:* cloudrift analyze ...`), disattivato di default. Scrive su stderr, separato dal report — ma il suo output include ID di risorse AWS (volume ID, instance ID, ecc.) del tuo account. Non incollare l'output di `DEBUG` in una issue GitHub pubblica né condividerlo fuori dalla tua organizzazione senza prima controllarlo.
 
 </details>
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -37,3 +37,9 @@ Out of scope:
 - vulnerabilities in AWS services themselves (report those to AWS Security)
 - issues that require an attacker to already have write access to your AWS credentials or local filesystem
 - the IAM permissions you grant to the credentials you run cloudrift with — that's on the user to scope to read-only, as documented in the [README](./README.md#required-iam-permissions)
+
+### If you're wrapping cloudrift in another service
+
+`--json`, `--pdf`, and `--config` accept any filesystem path, resolved with the same privileges as the process running the CLI — by design, so you can write reports and load config wherever you choose, the same trust level as any other CLI flag. Reviewed internally 2026-07-13: this isn't a vulnerability for direct, interactive use (whoever can pass CLI flags already has that filesystem access), so cloudrift does not restrict these paths to the working directory.
+
+If you're building a service that invokes cloudrift on behalf of untrusted callers and forwards user-supplied values into `--json`/`--pdf`/`--config`, validate or sandbox those values yourself before invoking the CLI — cloudrift will not do it for you.

--- a/apps/cli/src/commands/analyze-waste.command.spec.ts
+++ b/apps/cli/src/commands/analyze-waste.command.spec.ts
@@ -105,6 +105,23 @@ describe('analyzeWasteCommand (CLI end-to-end)', () => {
     expect(parsed.findings).toHaveLength(1);
   });
 
+  it('warns (with the --account-id fix) when STS account resolution fails and no override was given', async () => {
+    await run({ format: 'table' }, makeDeps());
+    expect(stdout).toContain('Could not resolve the AWS account ID via STS');
+    expect(stdout).toContain('--account-id');
+  });
+
+  it('does not warn about account resolution when --account-id is passed explicitly', async () => {
+    await run({ format: 'table', accountId: '123456789012' }, makeDeps());
+    expect(stdout).not.toContain('Could not resolve the AWS account ID');
+  });
+
+  it('routes the account-resolution warning to stderr in json format, keeping stdout pure JSON', async () => {
+    await run({ format: 'json' }, makeDeps());
+    expect(stderr).toContain('Could not resolve the AWS account ID via STS');
+    expect(() => JSON.parse(stdout.trim())).not.toThrow();
+  });
+
   it('markdown format: stdout is the markdown report', async () => {
     await run({ format: 'markdown' }, makeDeps({
       summary: summaryOf([wasteVolume('vol-1', 8)], 8),

--- a/apps/cli/src/commands/analyze-waste.command.ts
+++ b/apps/cli/src/commands/analyze-waste.command.ts
@@ -121,6 +121,13 @@ export async function analyzeWasteCommand(
 
   const accountId =
     options.accountId ?? (await deps.resolveAccountId()) ?? 'unknown';
+  // accountId is only ever 'unknown' when both --account-id was omitted and
+  // STS GetCallerIdentity failed (e.g. credentials lack that permission) —
+  // surfaced here so the omission in the report isn't silent, with the
+  // override the user needs right in the message.
+  if (accountId === 'unknown') {
+    info(chalk.dim('  Could not resolve the AWS account ID via STS — pass --account-id to set it explicitly.'));
+  }
 
   if (!quietStdout) {
     const accountLabel =

--- a/docker-compose.localstack.yml
+++ b/docker-compose.localstack.yml
@@ -13,7 +13,7 @@ services:
       - '4566:4566'
     environment:
       - PERSISTENCE=0
-      - LOCALSTACK_AUTH_TOKEN=${LOCALSTACK_AUTH_TOKEN}
+      - LOCALSTACK_AUTH_TOKEN=${LOCALSTACK_AUTH_TOKEN:-}
     healthcheck:
       test: ['CMD', 'curl', '-f', 'http://localhost:4566/_localstack/health']
       interval: 5s

--- a/docs/adr/0047-minimal-namespaced-debug-logger.md
+++ b/docs/adr/0047-minimal-namespaced-debug-logger.md
@@ -23,3 +23,5 @@ Two call sites at the time of this decision:
 ## Consequences
 
 New `libs/shared/kernel/src/logging/logger.ts` + 7 tests (namespace matching, wildcard, multiple patterns, stderr routing, no-op when disabled). No behavior change when `DEBUG` is unset (the default): `enabled` is computed once at `createLogger()` call time and every `debug()` call short-circuits before formatting or writing anything. The existing user-facing "info" flow (`AnalysisContext.info`, chalk output) is untouched — this is a separate, opt-in diagnostic channel, not a replacement for it.
+
+**Security note (added 2026-07-13, internal security review):** since scanner debug output includes AWS resource IDs (see the `cloudrift:scanner` call site above, and per-scanner malformed-response logs), `DEBUG=cloudrift:*` output shouldn't be pasted into a public GitHub issue or shared outside the user's organization without review — documented in the README's Development section. Not a code change: opt-in, off by default, stderr-only as designed; this is a usage caveat, not a defect.


### PR DESCRIPTION
## Summary

Closes out an internal security review (`docs/todo/security-analysis-2026-07-10.md`, gitignored working doc — 12 findings, SEC-01 through SEC-12). Every finding was re-verified against current code before acting, since the review predates several merged PRs; two were already resolved along the way (`engines: node >=18`, `pdfkit`/`zod`/`@clack/prompts` declared — ADR-0061) and needed no further change.

- **SEC-04 (high) — GitHub Actions pinned to SHA in `release.yml`.** `actions/checkout`, `pnpm/action-setup`, `actions/setup-node` were on floating `@v6` tags in the one workflow with `contents: write` + `id-token: write` (npm provenance publish). Pinned to the exact commit each `v6` tag resolves to today (verified via `git ls-remote`, not guessed), with the tag kept in a trailing comment for maintainability. `ci.yml` intentionally stays on `@v6` — it only has `contents: read`, floating tags there are an accepted tradeoff for less pinning-maintenance overhead.

- **SEC-10 (medium) — `pnpm audit` added to CI.** New `audit` job, non-blocking (`continue-on-error: true`): the repo currently has 4 real advisories (1 low, 1 moderate, 2 high) in `nx`/`@nx/jest`'s own transitive deps — none reachable from the shipped `@cloudrift/cli` package, but not yet clean. Comment in the workflow flags flipping it to blocking once `pnpm audit --audit-level moderate` passes clean.

- **SEC-08 (informational) — silent STS fallback now surfaced.** `resolveAwsAccountId()` failing (e.g. credentials without `sts:GetCallerIdentity`) previously degraded to `'unknown'` with zero indication anything went wrong — a user could ship a report with the wrong/missing account label and never notice. Now emits an explicit message pointing at `--account-id` as the override, routed correctly per output mode (stdout in table format, stderr in `--format json` so machine-readable stdout stays pure — both covered by new tests).

- **SEC-07 (low) — `DEBUG=cloudrift:*` info-disclosure documented.** Debug output includes AWS resource IDs from the scanned account; added a caveat to the README's Development section (EN+IT) and a consequence note on ADR-0047, warning against pasting `DEBUG` output into a public issue unreviewed.

- **SEC-03 (low) — `LOCALSTACK_AUTH_TOKEN` default.** `docker-compose.localstack.yml` now defaults to an explicit empty string, suppressing Docker Compose's unset-variable warning on local runs. The review's second suggested mitigation (skip the e2e CI step entirely when the token is missing, for fork PRs) was **deliberately not applied** — LocalStack Community 4.14.0 already starts and runs correctly with no token (that's the whole reason it's pinned to that version), so skipping would silently drop e2e coverage on fork PRs to "fix" something that isn't actually broken.

- **SEC-01/02 (low) — path handling on `--pdf`/`--json`/`--config`: documented, not restricted.** These flags accept any filesystem path by design, inheriting the invoking process's own privileges — `SECURITY.md` already explicitly listed "attacker with local filesystem access" as out of scope. Restricting to the CWD would break legitimate use (`--json ~/Desktop/report.json`, `--config ~/.config/cloudrift.json`) to guard against a scenario the project's own threat model already excludes. Added a `SECURITY.md` section instead, aimed at anyone wrapping cloudrift in a service that forwards untrusted input into these flags: validate/sandbox that input yourself before invoking the CLI, cloudrift won't.

- **SEC-05, SEC-06, SEC-09, SEC-11** — no action: already fine (SEC-05, SEC-11), already fixed by an earlier PR (SEC-09), or an accepted low residual risk already reasoned through in the original review (SEC-06, MITM ruled out by TLS).
- **SEC-12 (SBOM)** — deliberately deferred to the release backlog, not part of this PR. Pre-enterprise maturity item, not a direct security risk; ties to the (also not-yet-scheduled) Homebrew + npm + GitHub Action release work.

## Verification

- `pnpm nx run-many -t typecheck lint test build --all` — clean across all 5 projects, 68 CLI tests (3 new, covering the SEC-08 message and its stdout/stderr routing per format).
- `pnpm audit --audit-level moderate` run locally to confirm the exact current advisory count before wiring the CI step non-blocking.
- `git ls-remote` against `actions/checkout`, `pnpm/action-setup`, `actions/setup-node` to resolve real commit SHAs for the pins (not fabricated).

## Test plan

- [x] `pnpm nx run-many -t typecheck lint test build --all`
- [x] New tests: STS-failure warning shown/hidden correctly, routed to the right stream per `--format`
- [x] Manual read-through of `release.yml`/`ci.yml`/`docker-compose.localstack.yml` diffs for YAML correctness (no `yaml`/`js-yaml` parser available in this environment to lint automatically)
