### PR TITLE
feat(cloud-cost): added new vertical scanner

### DIFF
--- a/apps/cli/src/commands/scanner-registry.ts
+++ b/apps/cli/src/commands/scanner-registry.ts
@@ -29,6 +29,9 @@ import {
   VpnConnectionIdlePolicy,
   TransitGatewayIdleAttachmentPolicy,
   KinesisProvisionedIdleStreamPolicy,
+  SqsDlqAbandonedWastePolicy,
+  LambdaLogGroupOrphanedPolicy,
+  AuroraServerlessOverprovisionedPolicy,
   RESOURCE_KINDS,
 } from 'cloud-cost-domain';
 import type {
@@ -67,6 +70,9 @@ import {
   AwsVpnConnectionIdleScanner,
   AwsTransitGatewayIdleScanner,
   AwsKinesisIdleScanner,
+  AwsSqsDlqAbandonedScanner,
+  AwsLambdaLogGroupOrphanedScanner,
+  AwsAuroraServerlessIdleScanner,
 } from 'cloud-cost-infrastructure-aws-adapter';
 import type { AwsPricingApiAdapter } from 'cloud-cost-infrastructure-aws-adapter';
 import type { CloudriftConfig } from '../config/cloudrift.config';
@@ -228,6 +234,36 @@ export const ALWAYS_ON_SCANNERS: ScannerRegistration<ScannerBuildContext>[] = [
         ctx.accountId,
         new KinesisProvisionedIdleStreamPolicy(ctx.policyOptions),
         ctx.cloudwatchWindowHours,
+      ),
+  },
+  // Phase 6.1 (ADR-0065): serverless orphans vertical.
+  {
+    kind: 'sqs-dlq-abandoned',
+    create: (ctx) => new AwsSqsDlqAbandonedScanner(ctx.accountId, new SqsDlqAbandonedWastePolicy(ctx.policyOptions)),
+  },
+  {
+    kind: 'lambda-loggroup-orphaned',
+    create: (ctx) =>
+      new AwsLambdaLogGroupOrphanedScanner(
+        ctx.pricing,
+        ctx.accountId,
+        new LambdaLogGroupOrphanedPolicy(ctx.policyOptions),
+      ),
+  },
+  // Phase 6.2 (ADR-0065): Aurora Serverless v2 vertical. Static flat ACU-hour
+  // price, so always-on (ADR-0037); uses the longer utilization window (peak,
+  // not zero-activity), like the CPU-underutilized scanners.
+  {
+    kind: 'aurora-serverless-overprovisioned',
+    create: (ctx) =>
+      new AwsAuroraServerlessIdleScanner(
+        ctx.pricing,
+        ctx.accountId,
+        new AuroraServerlessOverprovisionedPolicy(
+          ctx.policyOptions,
+          ctx.config.thresholds?.auroraMinAcuUtilizationPercent ?? 50,
+        ),
+        ctx.utilizationWindowHours,
       ),
   },
 ];

--- a/apps/cli/src/config/cloudrift.config.ts
+++ b/apps/cli/src/config/cloudrift.config.ts
@@ -55,6 +55,8 @@ export interface CloudriftConfig {
     efsIoBytesMin?: number;
     /** Maximum RCU/WCU utilization (%) below which a DynamoDB table is "overprovisioned". Default 10. */
     dynamoCapacityUtilizationPercent?: number;
+    /** Maximum peak-to-Min-ACU ratio (%) below which an Aurora Serverless v2 Min ACU floor is "overprovisioned". Default 50. */
+    auroraMinAcuUtilizationPercent?: number;
   };
 }
 
@@ -118,6 +120,7 @@ const configSchema = z.object({
       lambdaInvocationsMin: nonNegativeAmount.optional(),
       efsIoBytesMin: nonNegativeAmount.optional(),
       dynamoCapacityUtilizationPercent: percent.optional(),
+      auroraMinAcuUtilizationPercent: percent.optional(),
     })
     .optional(),
 }) satisfies z.ZodType<CloudriftConfig, unknown>;

--- a/apps/cli/src/formatters/resource-presenters.ts
+++ b/apps/cli/src/formatters/resource-presenters.ts
@@ -340,6 +340,49 @@ export const presenters: PresenterMap = {
     recommend: (s) =>
       `Delete or scale down idle Kinesis stream ${s.id} in ${s.region.code} — ${s.wasteReason}`,
   },
+  'sqs-dlq-abandoned': {
+    title: 'SQS Dead Letter Queues — Abandoned (hygiene, no direct cost)',
+    head: ['Queue Name', 'Region', 'Messages', 'Oldest Message', 'Source Queue'],
+    colWidths: [150, 70, 65, 80, 150, 80],
+    row: (q) => [
+      q.queueName,
+      q.region.code,
+      `${q.approximateNumberOfMessages}`,
+      `${Math.floor(q.oldestMessageAgeSeconds / 86400)}d`,
+      q.sourceQueueArn ?? 'unknown',
+    ],
+    recommend: (q) =>
+      `Review DLQ ${q.queueName} in ${q.region.code} — ${q.wasteReason}`,
+  },
+  'lambda-loggroup-orphaned': {
+    title: 'CloudWatch Log Groups — Orphaned Lambda (function no longer exists)',
+    head: ['Log Group', 'Function (deleted)', 'Region', 'Stored', 'Last Event'],
+    colWidths: [150, 130, 65, 70, 84, 80],
+    row: (g) => [
+      g.id,
+      g.functionName,
+      g.region.code,
+      `${(g.storedBytes / 1024 ** 3).toFixed(1)} GB`,
+      day(g.lastEventTimestamp),
+    ],
+    recommend: (g) =>
+      `Delete orphaned log group ${g.id} in ${g.region.code} — ${g.wasteReason}`,
+  },
+  'aurora-serverless-overprovisioned': {
+    title: 'Aurora Serverless v2 — Overprovisioned Min ACU (rightsizing candidate, verify before acting)',
+    head: ['Cluster', 'Region', 'Engine', 'Min ACU', 'Peak ACU', 'Suggested Min'],
+    colWidths: [130, 72, 100, 66, 68, 84, 80],
+    row: (c) => [
+      c.id,
+      c.region.code,
+      c.engine,
+      `${c.minAcu}`,
+      `${c.peakAcu.toFixed(2)}`,
+      `${c.suggestedMinAcu}`,
+    ],
+    recommend: (c) =>
+      `Lower Aurora Serverless v2 cluster ${c.id} (${c.engine}) in ${c.region.code} Min ACU ${c.minAcu}→${c.suggestedMinAcu} — peak ${c.peakAcu.toFixed(2)} ACU over ${c.windowHours}h (verify real workload peaks first)`,
+  },
 };
 
 /**
@@ -369,7 +412,7 @@ type AnyResourceEntity = ResourceKindMap[ResourceKind];
  * kind IS the finding's own, so there is nothing to decouple. Compiler
  * enforced: `noImplicitReturns` (tsconfig.base.json) fails the build if a
  * kind is left unhandled, and `noFallthroughCasesInSwitch` blocks accidental
- * fallthrough between the 29 cases.
+ * fallthrough between the cases (one per `ResourceKind`, see `RESOURCE_KINDS`).
  *
  * Tried a generic `presenterFor<K extends ResourceKind>(kind: K): ResourcePresenter<ResourceKindMap[K]>`
  * first: it does not work, because every real call site derives `kind` from
@@ -408,6 +451,9 @@ export function rowFor(finding: AnyResourceEntity): string[] {
     case 'vpn-connection-idle': return presenters['vpn-connection-idle'].row(finding);
     case 'transit-gateway-idle-attachment': return presenters['transit-gateway-idle-attachment'].row(finding);
     case 'kinesis-provisioned-idle-stream': return presenters['kinesis-provisioned-idle-stream'].row(finding);
+    case 'sqs-dlq-abandoned': return presenters['sqs-dlq-abandoned'].row(finding);
+    case 'lambda-loggroup-orphaned': return presenters['lambda-loggroup-orphaned'].row(finding);
+    case 'aurora-serverless-overprovisioned': return presenters['aurora-serverless-overprovisioned'].row(finding);
   }
 }
 
@@ -443,5 +489,8 @@ export function recommendFor(finding: AnyResourceEntity): string {
     case 'vpn-connection-idle': return presenters['vpn-connection-idle'].recommend(finding);
     case 'transit-gateway-idle-attachment': return presenters['transit-gateway-idle-attachment'].recommend(finding);
     case 'kinesis-provisioned-idle-stream': return presenters['kinesis-provisioned-idle-stream'].recommend(finding);
+    case 'sqs-dlq-abandoned': return presenters['sqs-dlq-abandoned'].recommend(finding);
+    case 'lambda-loggroup-orphaned': return presenters['lambda-loggroup-orphaned'].recommend(finding);
+    case 'aurora-serverless-overprovisioned': return presenters['aurora-serverless-overprovisioned'].recommend(finding);
   }
 }

--- a/docs/adr/0065-vertical-premium-scanners-phase-6-strategy.md
+++ b/docs/adr/0065-vertical-premium-scanners-phase-6-strategy.md
@@ -1,0 +1,38 @@
+# ADR-0065: Vertical premium scanners — Phase 6 strategy
+
+- **Status:** Accepted (2026-07-14)
+
+## Context
+
+cloudrift covers 29 resource kinds with a generalist approach: EBS, EC2, RDS, networking, and a broad set of "idle/underutilized" scanners added through v0.4.0/v0.5.0. That breadth is complete enough that the next unit of differentiation isn't a 30th generalist scanner — it's depth in niches competitors and native AWS tools (Cost Explorer, Compute Optimizer) don't look at: Kubernetes (EKS), AI/ML (SageMaker), serverless database (Aurora Serverless v2), ephemeral environments (Dev/PR), and event-driven hygiene (SQS DLQs, orphaned Lambda log groups).
+
+The existing `WasteScannerPort` + `WastePolicy` + declarative scanner registry ([ADR-0043](0043-declarative-scanner-registry.md)) already makes adding a scanner a mechanical, testable operation — no changes needed to the use case, DTO, or report layer. This is what makes 8 new scanners across 5 verticals tractable as a single phase rather than 8 separate initiatives.
+
+## Decision
+
+Phase 6 adds 8 new `ResourceKind`s across 5 verticals, built incrementally (each phase independently demoable via `analyze --scanners <kind>`):
+
+1. **Serverless orphans** — `sqs-dlq-abandoned` (stagnant SQS DLQs, $0 hygiene finding, same rationale as [ADR-0004](0004-orphaned-eni-included.md)'s $0 ENI scanner) and `lambda-loggroup-orphaned` (CloudWatch log groups under `/aws/lambda/` whose function no longer exists — distinct from the existing `log-group` scanner, which flags missing retention on log groups that still belong to a live function).
+2. **Aurora Serverless v2** — `aurora-serverless-overprovisioned` (Min ACU set well above real peak usage).
+3. **SageMaker suite** — `sagemaker-notebook-idle`, `sagemaker-endpoint-idle` (both gated behind `--live-pricing`, per-instance pricing), `sagemaker-training-orphaned` (models never attached to an endpoint).
+4. **Dev/PR ghost environments** — `environment-ghost`, grouping resources by tag or naming-pattern heuristic and flagging groups that are entirely inactive.
+5. **EKS cost visibility** — `eks-node-overprovisioned` and `eks-orphan-pvc`, both AWS-API-only (see [ADR-0066](0066-eks-scanners-aws-api-only-kubeconfig-deferred.md)).
+
+All 5 verticals ship in this phase; none is deferred. Execution order follows complexity, not just value: independent/low-complexity scanners first (SQS, Lambda, Aurora, the two SageMaker idle scanners), `sagemaker-training-orphaned` after the SageMaker idle pair (it cross-references their endpoint list), `environment-ghost` as the most experimental/tag-dependent scanner, and the EKS pair last as the highest-complexity, most novel-API surface.
+
+New AWS SDK clients required: `@aws-sdk/client-eks`, `@aws-sdk/client-sagemaker`, `@aws-sdk/client-sqs`, `@aws-sdk/client-resource-groups-tagging-api`. All read-only IAM actions, consistent with the existing threat model (`SECURITY.md`).
+
+A SaaS-readiness hint is documented separately in [ADR-0067](0067-saas-readiness-architectural-hints.md) — it is a forward-looking note, not part of this phase's implementation.
+
+## Alternatives Considered
+
+- **Pick a subset of the 5 verticals for this phase, defer the rest.** Rejected: each vertical is small in isolation (1-3 scanners) and they don't share a natural "do 3 now, 2 later" split — splitting would mean two ADRs and two review passes for work that's already fully scoped in one plan (`docs/todo/piano-scanner-verticali.md`).
+- **A generic "resource-groups-tagging-api" based scanner covering all 5 niches via tags alone**, instead of dedicated per-service scanners. Rejected: EKS and SageMaker waste signals come from CloudWatch/Container Insights metrics and service-specific describe calls, not from tags — a single generic scanner couldn't express the different waste conditions (idle CPU, zero invocations, orphaned PVC state) without becoming an if/else pile that defeats the point of the `WastePolicy` abstraction.
+
+## Consequences
+
+- `ResourceKind` grows from 29 to 37 values; the scanner registry ([ADR-0043](0043-declarative-scanner-registry.md)) gains 8 entries (2 in the live-pricing-gated array: `sagemaker-notebook-idle`, `sagemaker-endpoint-idle`, `eks-node-overprovisioned`; the rest always-on).
+- 4 new AWS SDK dependencies, 4 new IAM read permissions groups (`eks:*`, `sagemaker:*`, `sqs:*`, `tag:GetResources`) documented in the README's IAM policy block.
+- `cloudrift.config.example.json` gains new threshold/config keys: `auroraMinAcuUtilizationPercent`, `eksNodeUtilizationPercent`, `environmentDetection.{tagKeys,namingPatterns,inactivityDays}`.
+- No changes to `AnalyzeCloudWasteUseCase`, DTO shape, or the report/presenter dispatch mechanism ([ADR-0059](0059-presenter-dispatch-exhaustive-switch.md)) beyond adding new cases to the exhaustive switch.
+- `environment-ghost` carries the highest false-positive risk of the 8 (teams without consistent tagging); documented with a caveat and a naming-pattern fallback rather than blocked on tagging discipline.

--- a/docs/adr/0066-eks-scanners-aws-api-only-kubeconfig-deferred.md
+++ b/docs/adr/0066-eks-scanners-aws-api-only-kubeconfig-deferred.md
@@ -1,0 +1,33 @@
+# ADR-0066: EKS scanners — AWS API only, kubeconfig deferred
+
+- **Status:** Accepted (2026-07-14)
+
+## Context
+
+The two EKS scanners in [ADR-0065](0065-vertical-premium-scanners-phase-6-strategy.md) (`eks-node-overprovisioned`, `eks-orphan-pvc`) need to answer "is this node group/volume actually used by the workloads scheduled on it?" — a question that, at full fidelity, requires reading Pod-level `resources.requests`/`resources.limits` from the Kubernetes API itself. cloudrift's entire scanning model, however, is a read-only AWS API client with IAM credentials ([SECURITY.md](../../SECURITY.md)); it has never required network access to anything other than AWS endpoints, no cluster-internal connectivity, no kubeconfig, no in-cluster agent.
+
+Reading Pod-level data would mean either (a) requiring a kubeconfig with cluster RBAC read access, breaking the "just an IAM role, nothing else" trust story that's central to cloudrift's positioning (see the marketing/trust-factor backlog point about permissions), or (b) deploying an in-cluster read-only agent, which is a fundamentally different product surface (an in-cluster component, not a CLI you point at an AWS account).
+
+## Decision
+
+Both EKS scanners are **AWS-API-only** for this phase:
+
+- `eks-node-overprovisioned` uses `eks:ListClusters` → `eks:ListNodegroups` → `eks:DescribeNodegroup`, plus CloudWatch **Container Insights** metrics (namespace `ContainerInsights`: `node_cpu_request`, `node_cpu_limit`, `node_cpu_utilization`, and the memory equivalents) if the cluster has Container Insights enabled. If it isn't enabled, the scanner degrades gracefully: it emits a warning (surfaced the same way as other soft scan errors, [ADR-0018](0018-scan-errors-per-scanner-region.md)) and produces no finding for that cluster, rather than guessing.
+- `eks-orphan-pvc` uses `ec2:DescribeVolumes` filtered on the CSI driver's own tag convention (`kubernetes.io/created-for/pvc/name`), correlating orphan status via two AWS-visible signals only: volume `state = available` (PVC/PV deleted but EBS volume left behind), or a tagged cluster name that no longer resolves via `eks:ListClusters` (cluster torn down, volume orphaned).
+
+Neither scanner sees individual Pod requests/limits, only Node-group-level aggregates (Container Insights) or EBS/tag-level state. This is an explicit accuracy ceiling, documented as a caveat in each scanner's presenter output, not something to work around within this phase.
+
+A future `KubernetesDataPort` (kubeconfig-based, in-cluster or via the EKS API's Kubernetes-aware endpoints) is left as an explicit extension point — an optional collaborator, undefined for now — for a later phase, once there's a decision on whether cloudrift takes on cluster-internal read access as a supported capability.
+
+## Alternatives Considered
+
+- **Require kubeconfig from the start, read Pod-level requests/limits directly.** Rejected: breaks the AWS-API-only / IAM-only trust model that's core to cloudrift's current positioning, and turns "point cloudrift at an AWS account" into "point cloudrift at an AWS account and hand it cluster RBAC" — a materially bigger ask for a Phase 6 experiment whose value isn't yet proven.
+- **Skip EKS entirely until kubeconfig support is designed.** Rejected: Container Insights + tag-based volume correlation already answers "is this node group grossly overprovisioned" and "is this volume orphaned" at a coarse but real level — useful signal today, not blocked on a bigger, unscoped kubeconfig decision.
+- **Silently estimate Pod-level usage from Node-level metrics (divide by pod count, etc.).** Rejected: would fabricate a false precision the data doesn't support; the chosen approach instead surfaces the real Container-Insights-level aggregate and documents the limitation explicitly.
+
+## Consequences
+
+- `eks-node-overprovisioned` finding accuracy is bounded by Container Insights being enabled on the target cluster — a real-world gap (Container Insights is opt-in and has its own cost), documented as the scanner's primary risk in the plan's risk matrix and repeated in its presenter caveat.
+- No new runtime dependency (no Kubernetes client library, no kubeconfig parsing) added to `apps/cli` or the aws-adapter package in this phase.
+- IAM policy additions are `eks:ListClusters`, `eks:ListNodegroups`, `eks:DescribeNodegroup`, `eks:DescribeCluster` — all read-only, consistent with the rest of the IAM policy block in the README.
+- Phase 7 (not scoped, not started) is the natural place to revisit a `KubernetesDataPort` if Pod-level accuracy becomes a requested feature.

--- a/docs/adr/0067-saas-readiness-architectural-hints.md
+++ b/docs/adr/0067-saas-readiness-architectural-hints.md
@@ -1,0 +1,26 @@
+# ADR-0067: SaaS readiness — architectural hints for recurring scans
+
+- **Status:** Accepted (2026-07-14)
+
+## Context
+
+Phase 6's vertical scanners are aimed at higher-budget segments (Kubernetes/ML/data platform teams) who are also the most likely audience for a recurring, hosted version of cloudrift (scheduled scans, historical trend, a dashboard) rather than a one-off CLI run. No such SaaS product is being built now, and none is scoped in this phase's task list ([`docs/todo/piano-scanner-verticali.md`](../todo/piano-scanner-verticali.md)) — but it's worth recording, while the vertical scanners are fresh, which existing architectural choices already leave that door open and which don't, so a future decision to build it isn't blocked by avoidable rework.
+
+## Decision
+
+This ADR documents observations only. No code changes accompany it.
+
+- `WasteReportDto` ([ADR-0021](0021-wastereportdto-frontend-contract.md)) is already a plain JSON-serializable contract — persistable as-is to DynamoDB/S3 keyed by `{accountId, timestamp}` for scan history, without a schema migration.
+- `FindWastedResourcesUseCasePort` is decoupled from the CLI adapter — an orchestrator (e.g. a Lambda triggered by EventBridge on a schedule) could call the same use case a future HTTP/Lambda adapter would use, mirroring how the CLI adapter calls it today.
+- `analyze-waste.composition.ts`'s registry-based scanner wiring ([ADR-0043](0043-declarative-scanner-registry.md)) is an isolated factory, already free of CLI-specific concerns (`process.argv`, stdout formatting) — reusable from a non-CLI entry point without extraction work.
+- `ResourceKind` plus the existing `--live-pricing` gate is a natural, already-drawn line for a future pricing tier (e.g. free tier = always-on scanners, paid tier = live-pricing-gated scanners including the new SageMaker/EKS ones) — not a mechanism to build now, just a boundary that already exists and happens to line up.
+- A recurring-scan flow, if built, would look like: EventBridge Rule (schedule) → Lambda (runs the existing use case) → S3 (report + history) → SNS/email (notification) → a later dashboard reading history via API Gateway → Lambda. This is a sketch for future reference, not a design that's been reviewed or committed to.
+
+## Alternatives Considered
+
+Not applicable — this ADR records observations about existing architecture, it does not choose between implementation alternatives for a system that doesn't exist yet.
+
+## Consequences
+
+- No code, dependency, or test changes result from this ADR.
+- If a SaaS/recurring-scan direction is picked up later, this ADR is the starting reference point — but it is not a commitment, timeline, or design; a real implementation would need its own ADR(s) once actually scoped (consistent with [ADR-0007](0007-no-release-until-requested.md)'s "nothing ships until explicitly requested" posture applied more broadly to unscoped future work).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -19,6 +19,7 @@ Each entry follows: Context → Decision → Alternatives Considered → Consequ
 | [0007](0007-no-release-until-requested.md) | No version bump/tag/publish until explicitly requested | Accepted |
 | [0008](0008-commit-and-pr-owned-by-user.md) | Commit and PR always owned by the user | Accepted |
 | [0038](0038-eleven-fixed-cost-scanners-phase-5-5.md) | 11 new fixed-cost scanners in v0.5.0 Phase 5.5 | Accepted |
+| [0065](0065-vertical-premium-scanners-phase-6-strategy.md) | Vertical premium scanners — Phase 6 strategy | Accepted |
 
 ## Pricing
 
@@ -82,6 +83,7 @@ Each entry follows: Context → Decision → Alternatives Considered → Consequ
 | [0058](0058-aws-client-request-timeout.md) | AWS SDK clients get a per-request HTTP timeout, not a global scan timeout | Accepted, `requestHandler` sharing refined by [ADR-0064](0064-per-client-requesthandler-not-shared.md) |
 | [0061](0061-pdfkit-lazy-import-and-dynamic-external-detection.md) | `pdfkit` loaded via lazy dynamic import; publish-manifest generator scans for dynamic imports too | Accepted |
 | [0064](0064-per-client-requesthandler-not-shared.md) | Every AWS SDK client gets its own `NodeHttpHandler`, not a shared singleton | Accepted |
+| [0066](0066-eks-scanners-aws-api-only-kubeconfig-deferred.md) | EKS scanners — AWS API only, kubeconfig deferred | Accepted |
 
 ## Reporting
 
@@ -99,3 +101,9 @@ Each entry follows: Context → Decision → Alternatives Considered → Consequ
 | [0039](0039-cloudwatch-localstack-incompatibility.md) | `GetMetricStatistics` fails on LocalStack 4.0 — CloudWatch scanners marked soft | Superseded by [ADR-0040](0040-localstack-bumped-4-14-0-cloudwatch-fixed.md) |
 | [0040](0040-localstack-bumped-4-14-0-cloudwatch-fixed.md) | LocalStack bumped to 4.14.0 — CloudWatch incompatibility resolved | Accepted |
 | [0055](0055-pdf-formatter-smoke-test.md) | PDF formatter gets a full-coverage smoke test, not a layout snapshot | Accepted |
+
+## Future / non-implemented
+
+| ADR | Title | Status |
+|---|---|---|
+| [0067](0067-saas-readiness-architectural-hints.md) | SaaS readiness — architectural hints for recurring scans (no implementation) | Accepted |

--- a/libs/cloud-cost/domain/src/entities/aurora-serverless-overprovisioned.entity.ts
+++ b/libs/cloud-cost/domain/src/entities/aurora-serverless-overprovisioned.entity.ts
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: Apache-2.0
+import { Entity } from 'shared-kernel';
+import { AwsRegion } from '../value-objects/aws-region.value-object';
+import { CostEstimate } from '../value-objects/cost-estimate.value-object';
+import type { WastedResource } from '../wasted-resource';
+
+/**
+ * Aurora Serverless v2 cluster whose configured **Min ACU** floor is far
+ * above the real peak capacity observed over the window. Serverless v2 never
+ * scales below Min ACU, so that floor is billed 730h/month regardless of load
+ * — lowering it is a definite, always-on saving.
+ *
+ * Advisory (`estimated`): the saving assumes the floor keeps being billed at
+ * the current Min ACU and that `suggestedMinAcu` still covers real peaks;
+ * `monthlyCostUsd` here is the *saving* from lowering Min ACU, not the cost
+ * of the cluster (same convention as {@link RdsUnderutilizedInstance}).
+ */
+export interface AuroraServerlessOverprovisionedProps {
+  clusterIdentifier: string;
+  region: AwsRegion;
+  accountId: string;
+  engine: string;
+  minAcu: number;
+  maxAcu: number;
+  /** Maximum ServerlessDatabaseCapacity (ACU) observed over the window; 0 if `hasDatapoint` is false. */
+  peakAcu: number;
+  /**
+   * Whether CloudWatch actually returned a datapoint for the window. `false`
+   * means "no evidence", not "confirmed zero load" — the policy must not
+   * treat it as an idle floor (unlike the zero-activity scanners, where a
+   * missing datapoint legitimately means "no traffic").
+   */
+  hasDatapoint: boolean;
+  /** Recommended Min ACU: peak + 20% margin, rounded up to AWS's 0.5 granularity. */
+  suggestedMinAcu: number;
+  windowHours: number;
+  clusterCreateTime: Date;
+  detectedAt: Date;
+  tags: Record<string, string>;
+  monthlyCostUsd: number;
+}
+
+export class AuroraServerlessOverprovisioned extends Entity<string> implements WastedResource {
+  private readonly props: Readonly<AuroraServerlessOverprovisionedProps>;
+
+  constructor(props: AuroraServerlessOverprovisionedProps) {
+    super(props.clusterIdentifier);
+    this.props = this.deepFreeze({ ...props });
+  }
+
+  get region(): AwsRegion { return this.props.region; }
+  get accountId(): string { return this.props.accountId; }
+  get engine(): string { return this.props.engine; }
+  get minAcu(): number { return this.props.minAcu; }
+  get maxAcu(): number { return this.props.maxAcu; }
+  get peakAcu(): number { return this.props.peakAcu; }
+  get hasDatapoint(): boolean { return this.props.hasDatapoint; }
+  get suggestedMinAcu(): number { return this.props.suggestedMinAcu; }
+  get windowHours(): number { return this.props.windowHours; }
+  get clusterCreateTime(): Date { return this.props.clusterCreateTime; }
+  get detectedAt(): Date { return this.props.detectedAt; }
+  get tags(): Record<string, string> { return this.props.tags; }
+
+  get kind(): 'aurora-serverless-overprovisioned' { return 'aurora-serverless-overprovisioned'; }
+
+  get wasteReason(): string {
+    return `peak ${this.props.peakAcu.toFixed(2)} ACU vs Min ACU ${this.props.minAcu} over ${this.props.windowHours}h — lower Min ACU to ${this.props.suggestedMinAcu}`;
+  }
+
+  get costEstimate(): CostEstimate {
+    return CostEstimate.of(
+      this.props.monthlyCostUsd,
+      `Aurora Serverless v2 ${this.props.engine} Min ACU ${this.props.minAcu}→${this.props.suggestedMinAcu} — estimated saving`,
+    );
+  }
+}

--- a/libs/cloud-cost/domain/src/entities/lambda-loggroup-orphaned.entity.ts
+++ b/libs/cloud-cost/domain/src/entities/lambda-loggroup-orphaned.entity.ts
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+import { Entity } from 'shared-kernel';
+import { AwsRegion } from '../value-objects/aws-region.value-object';
+import { CostEstimate } from '../value-objects/cost-estimate.value-object';
+import type { WastedResource } from '../wasted-resource';
+
+export interface LambdaLogGroupOrphanedProps {
+  logGroupName: string;
+  functionName: string;
+  functionExists: boolean;
+  storedBytes: number;
+  lastEventTimestamp: Date;
+  region: AwsRegion;
+  accountId: string;
+  tags: Record<string, string>;
+  monthlyCostUsd: number;
+}
+
+/**
+ * CloudWatch Log Group under `/aws/lambda/` whose Lambda function no longer
+ * exists — distinct from the `log-group` scanner, which flags missing
+ * retention on log groups that still belong to a live function. This one
+ * flags a log group left behind after the function itself was deleted.
+ */
+export class LambdaLogGroupOrphaned extends Entity<string> implements WastedResource {
+  private readonly props: Readonly<LambdaLogGroupOrphanedProps>;
+
+  constructor(props: LambdaLogGroupOrphanedProps) {
+    super(props.logGroupName);
+    this.props = this.deepFreeze({ ...props });
+  }
+
+  get logGroupName(): string { return this.props.logGroupName; }
+  get functionName(): string { return this.props.functionName; }
+  get functionExists(): boolean { return this.props.functionExists; }
+  get storedBytes(): number { return this.props.storedBytes; }
+  get lastEventTimestamp(): Date { return this.props.lastEventTimestamp; }
+  get region(): AwsRegion { return this.props.region; }
+  get accountId(): string { return this.props.accountId; }
+  get tags(): Record<string, string> { return this.props.tags; }
+
+  get detectedAt(): Date { return new Date(); }
+  get kind(): 'lambda-loggroup-orphaned' { return 'lambda-loggroup-orphaned'; }
+  get wasteReason(): string {
+    return `function ${this.props.functionName} no longer exists`;
+  }
+
+  get costEstimate(): CostEstimate {
+    const storedGb = (this.props.storedBytes / 1024 ** 3).toFixed(2);
+    return CostEstimate.of(this.props.monthlyCostUsd, `${storedGb} GB CW logs (orphaned Lambda log group)`);
+  }
+}

--- a/libs/cloud-cost/domain/src/entities/sqs-dlq-abandoned.entity.ts
+++ b/libs/cloud-cost/domain/src/entities/sqs-dlq-abandoned.entity.ts
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+import { Entity } from 'shared-kernel';
+import { AwsRegion } from '../value-objects/aws-region.value-object';
+import { CostEstimate } from '../value-objects/cost-estimate.value-object';
+import type { WastedResource } from '../wasted-resource';
+
+export interface SqsDlqAbandonedProps {
+  queueUrl: string;
+  queueName: string;
+  approximateNumberOfMessages: number;
+  oldestMessageAgeSeconds: number;
+  /** Set by the scanner: RedriveAllowPolicy present, ARN referenced by another queue's RedrivePolicy, or name matches a DLQ naming convention. */
+  identifiedAsDlq: boolean;
+  sourceQueueArn?: string;
+  region: AwsRegion;
+  accountId: string;
+  tags: Record<string, string>;
+}
+
+/**
+ * SQS queue identified as a Dead Letter Queue (via RedrivePolicy/RedriveAllowPolicy
+ * or naming convention) holding messages older than the policy's grace period.
+ * SQS has no storage cost: the finding is a hygiene flag (errors nobody is
+ * looking at), not a direct saving — same reasoning as OrphanedEni.
+ */
+export class SqsDlqAbandoned extends Entity<string> implements WastedResource {
+  private readonly props: Readonly<SqsDlqAbandonedProps>;
+
+  constructor(props: SqsDlqAbandonedProps) {
+    super(props.queueUrl);
+    this.props = this.deepFreeze({ ...props });
+  }
+
+  get queueUrl(): string { return this.props.queueUrl; }
+  get queueName(): string { return this.props.queueName; }
+  get approximateNumberOfMessages(): number { return this.props.approximateNumberOfMessages; }
+  get oldestMessageAgeSeconds(): number { return this.props.oldestMessageAgeSeconds; }
+  get identifiedAsDlq(): boolean { return this.props.identifiedAsDlq; }
+  get sourceQueueArn(): string | undefined { return this.props.sourceQueueArn; }
+  get region(): AwsRegion { return this.props.region; }
+  get accountId(): string { return this.props.accountId; }
+  get tags(): Record<string, string> { return this.props.tags; }
+
+  get detectedAt(): Date { return new Date(Date.now() - this.props.oldestMessageAgeSeconds * 1000); }
+  get kind(): 'sqs-dlq-abandoned' { return 'sqs-dlq-abandoned'; }
+  get wasteReason(): string {
+    const days = Math.floor(this.props.oldestMessageAgeSeconds / 86400);
+    return `oldest message ${days}d old, ${this.props.approximateNumberOfMessages} message(s) unconsumed`;
+  }
+
+  get costEstimate(): CostEstimate {
+    return CostEstimate.of(0, 'Abandoned SQS DLQ (hygiene flag, no storage cost)');
+  }
+}

--- a/libs/cloud-cost/domain/src/group-by-kind.ts
+++ b/libs/cloud-cost/domain/src/group-by-kind.ts
@@ -29,6 +29,9 @@ import type { Workspace } from './entities/workspace.entity';
 import type { VpnConnection } from './entities/vpn-connection.entity';
 import type { TransitGatewayAttachment } from './entities/transit-gateway-attachment.entity';
 import type { KinesisStream } from './entities/kinesis-stream.entity';
+import type { SqsDlqAbandoned } from './entities/sqs-dlq-abandoned.entity';
+import type { LambdaLogGroupOrphaned } from './entities/lambda-loggroup-orphaned.entity';
+import type { AuroraServerlessOverprovisioned } from './entities/aurora-serverless-overprovisioned.entity';
 
 /**
  * Map kind → concrete entity. Allows consumers (formatters, frontend)
@@ -64,6 +67,9 @@ export interface ResourceKindMap {
   'vpn-connection-idle': VpnConnection;
   'transit-gateway-idle-attachment': TransitGatewayAttachment;
   'kinesis-provisioned-idle-stream': KinesisStream;
+  'sqs-dlq-abandoned': SqsDlqAbandoned;
+  'lambda-loggroup-orphaned': LambdaLogGroupOrphaned;
+  'aurora-serverless-overprovisioned': AuroraServerlessOverprovisioned;
 }
 
 export type FindingsByKind = {

--- a/libs/cloud-cost/domain/src/index.ts
+++ b/libs/cloud-cost/domain/src/index.ts
@@ -75,6 +75,12 @@ export { TransitGatewayAttachment } from './entities/transit-gateway-attachment.
 export type { TransitGatewayAttachmentProps } from './entities/transit-gateway-attachment.entity';
 export { KinesisStream } from './entities/kinesis-stream.entity';
 export type { KinesisStreamProps } from './entities/kinesis-stream.entity';
+export { SqsDlqAbandoned } from './entities/sqs-dlq-abandoned.entity';
+export type { SqsDlqAbandonedProps } from './entities/sqs-dlq-abandoned.entity';
+export { LambdaLogGroupOrphaned } from './entities/lambda-loggroup-orphaned.entity';
+export type { LambdaLogGroupOrphanedProps } from './entities/lambda-loggroup-orphaned.entity';
+export { AuroraServerlessOverprovisioned } from './entities/aurora-serverless-overprovisioned.entity';
+export type { AuroraServerlessOverprovisionedProps } from './entities/aurora-serverless-overprovisioned.entity';
 
 // Value Objects
 export { AwsRegion, InvalidAwsRegionError } from './value-objects/aws-region.value-object';
@@ -119,6 +125,9 @@ export {
   VpnConnectionIdlePolicy,
   TransitGatewayIdleAttachmentPolicy,
   KinesisProvisionedIdleStreamPolicy,
+  SqsDlqAbandonedWastePolicy,
+  LambdaLogGroupOrphanedPolicy,
+  AuroraServerlessOverprovisionedPolicy,
 } from './policies/resource-waste-policies';
 
 // Outbound Ports

--- a/libs/cloud-cost/domain/src/policies/resource-waste-policies.ts
+++ b/libs/cloud-cost/domain/src/policies/resource-waste-policies.ts
@@ -29,6 +29,9 @@ import type { Workspace } from '../entities/workspace.entity';
 import type { VpnConnection } from '../entities/vpn-connection.entity';
 import type { TransitGatewayAttachment } from '../entities/transit-gateway-attachment.entity';
 import type { KinesisStream } from '../entities/kinesis-stream.entity';
+import type { SqsDlqAbandoned } from '../entities/sqs-dlq-abandoned.entity';
+import type { LambdaLogGroupOrphaned } from '../entities/lambda-loggroup-orphaned.entity';
+import type { AuroraServerlessOverprovisioned } from '../entities/aurora-serverless-overprovisioned.entity';
 
 export class EbsVolumeWastePolicy extends WastePolicy<EbsVolume> {
   protected judge(volume: EbsVolume, now: Date): WasteVerdict {
@@ -352,6 +355,60 @@ export class KinesisProvisionedIdleStreamPolicy extends WastePolicy<KinesisStrea
       return notWaste(`created less than ${this.minAgeDays}d ago`);
     }
     return waste(`zero incoming records in last ${stream.metricWindowHours}h`);
+  }
+}
+
+export class SqsDlqAbandonedWastePolicy extends WastePolicy<SqsDlqAbandoned> {
+  /** minMessageAgeDays: age of the oldest unconsumed message, not resource age — `minAgeDays`'s grace period does not apply here. */
+  constructor(options: WastePolicyOptions = {}, private readonly minMessageAgeDays = 14) {
+    super(options);
+  }
+
+  protected judge(queue: SqsDlqAbandoned): WasteVerdict {
+    if (!queue.identifiedAsDlq) return notWaste('not identified as a DLQ');
+    if (queue.approximateNumberOfMessages === 0) return notWaste('no messages');
+    const ageDays = queue.oldestMessageAgeSeconds / 86400;
+    if (ageDays < this.minMessageAgeDays) {
+      return notWaste(`oldest message ${ageDays.toFixed(1)}d old, within ${this.minMessageAgeDays}d grace period`);
+    }
+    return waste(`oldest message ${ageDays.toFixed(1)}d old, ${queue.approximateNumberOfMessages} unconsumed`);
+  }
+}
+
+export class LambdaLogGroupOrphanedPolicy extends WastePolicy<LambdaLogGroupOrphaned> {
+  protected judge(group: LambdaLogGroupOrphaned, now: Date): WasteVerdict {
+    if (group.functionExists) return notWaste('function still exists');
+    if (this.isWithinGracePeriod(group.lastEventTimestamp, now)) {
+      return notWaste(`last log event less than ${this.minAgeDays}d ago`);
+    }
+    return waste(`function ${group.functionName} no longer exists`);
+  }
+}
+
+export class AuroraServerlessOverprovisionedPolicy extends WastePolicy<AuroraServerlessOverprovisioned> {
+  /** minAcuUtilizationPercent: peak-to-Min-ACU ratio (%) below which the floor is "overprovisioned". Default 50. */
+  constructor(options: WastePolicyOptions = {}, private readonly minAcuUtilizationPercent = 50) {
+    super(options);
+  }
+
+  protected judge(cluster: AuroraServerlessOverprovisioned, now: Date): WasteVerdict {
+    // A missing datapoint is "no evidence", not "confirmed zero load" — unlike
+    // the zero-activity scanners, flagging on it would recommend slashing
+    // Min ACU off a metric CloudWatch never actually reported.
+    if (!cluster.hasDatapoint) return notWaste('no ServerlessDatabaseCapacity datapoint in window');
+    if (cluster.peakAcu >= cluster.minAcu * (this.minAcuUtilizationPercent / 100)) {
+      return notWaste('peak ACU above threshold');
+    }
+    // After rounding the suggestion up to AWS's 0.5 ACU granularity there may
+    // be nothing left to lower (e.g. Min ACU already at the 0.5 floor).
+    if (cluster.suggestedMinAcu >= cluster.minAcu) {
+      return notWaste('no Min ACU reduction available');
+    }
+    // A just-created cluster might not have reached its real peak load yet.
+    if (this.isWithinGracePeriod(cluster.clusterCreateTime, now)) {
+      return notWaste(`created less than ${this.minAgeDays}d ago`);
+    }
+    return waste(`peak ${cluster.peakAcu.toFixed(2)} ACU / Min ACU ${cluster.minAcu} over ${cluster.windowHours}h`);
   }
 }
 

--- a/libs/cloud-cost/domain/src/wasted-resource.ts
+++ b/libs/cloud-cost/domain/src/wasted-resource.ts
@@ -32,6 +32,9 @@ export const RESOURCE_KINDS = [
   'vpn-connection-idle',
   'transit-gateway-idle-attachment',
   'kinesis-provisioned-idle-stream',
+  'sqs-dlq-abandoned',
+  'lambda-loggroup-orphaned',
+  'aurora-serverless-overprovisioned',
 ] as const;
 
 export type ResourceKind = (typeof RESOURCE_KINDS)[number];
@@ -101,6 +104,22 @@ export const RESOURCE_KIND_META: Record<ResourceKind, ResourceKindMeta> = {
     label: 'Kinesis Streams (idle, Provisioned mode)',
     category: 'waste',
     estimated: false,
+  },
+  // Phase 6.1 (ADR-0065): serverless orphans vertical. $0 hygiene flag, same
+  // rationale as 'eni-orphaned' — no direct AWS cost, but signals ignored errors.
+  'sqs-dlq-abandoned': { label: 'SQS Dead Letter Queues (abandoned)', category: 'waste', estimated: false },
+  'lambda-loggroup-orphaned': {
+    label: 'CloudWatch Log Groups (orphaned Lambda)',
+    category: 'waste',
+    estimated: false,
+  },
+  // Phase 6.2: Aurora Serverless v2 vertical. The Min ACU floor is always
+  // billed (730h/mo); lowering it is a definite saving, but the recommended
+  // floor is a heuristic (peak + 20% margin), hence estimated.
+  'aurora-serverless-overprovisioned': {
+    label: 'Aurora Serverless v2 (overprovisioned Min ACU)',
+    category: 'optimization',
+    estimated: true,
   },
 };
 

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/index.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/index.ts
@@ -38,6 +38,9 @@ export type { WorkSpacesBundlePricingSource } from './scanners/aws-workspaces-id
 export { AwsVpnConnectionIdleScanner } from './scanners/aws-vpn-connection-idle.scanner';
 export { AwsTransitGatewayIdleScanner } from './scanners/aws-transit-gateway-idle.scanner';
 export { AwsKinesisIdleScanner } from './scanners/aws-kinesis-idle.scanner';
+export { AwsSqsDlqAbandonedScanner } from './scanners/aws-sqs-dlq-abandoned.scanner';
+export { AwsLambdaLogGroupOrphanedScanner } from './scanners/aws-lambda-loggroup-orphaned.scanner';
+export { AwsAuroraServerlessIdleScanner, suggestMinAcu } from './scanners/aws-aurora-serverless-idle.scanner';
 export { AwsAdapterError } from './errors/aws-adapter.error';
 export {
   StaticPriceTableAdapter,

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/pricing/prices.json
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/pricing/prices.json
@@ -29,7 +29,8 @@
     "fsx-openzfs":   0.093,
     "vpn-connection": 36.500,
     "transit-gateway-attachment": 36.500,
-    "kinesis-shard": 10.950
+    "kinesis-shard": 10.950,
+    "aurora-acu": 87.600
   },
   "us-east-1": {
     "ebs-gp2":       0.100,

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-aurora-serverless-idle.scanner.spec.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-aurora-serverless-idle.scanner.spec.ts
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: Apache-2.0
+import { RDSClient } from '@aws-sdk/client-rds';
+import { CloudWatchClient, GetMetricStatisticsCommand } from '@aws-sdk/client-cloudwatch';
+import { AwsAuroraServerlessIdleScanner, suggestMinAcu } from './aws-aurora-serverless-idle.scanner';
+import { AwsRegion } from 'cloud-cost-domain';
+import { AwsAdapterError } from '../errors/aws-adapter.error';
+import { mockPricing } from '../testing/mock-pricing';
+
+jest.mock('@aws-sdk/client-rds');
+jest.mock('@aws-sdk/client-cloudwatch');
+
+const mockRdsSend = jest.fn();
+const mockRdsDestroy = jest.fn();
+const mockCwSend = jest.fn();
+const mockCwDestroy = jest.fn();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (RDSClient as jest.Mock).mockImplementation(() => ({ send: mockRdsSend, destroy: mockRdsDestroy }));
+  (CloudWatchClient as jest.Mock).mockImplementation(() => ({ send: mockCwSend, destroy: mockCwDestroy }));
+});
+
+const region = AwsRegion.create('us-east-1');
+const scanner = new AwsAuroraServerlessIdleScanner(mockPricing);
+const OLD_DATE = new Date('2024-03-01');
+
+function mockServerlessV2Cluster(
+  id: string,
+  { minAcu = 8, maxAcu = 16, createTime = OLD_DATE }: { minAcu?: number; maxAcu?: number; createTime?: Date } = {},
+) {
+  mockRdsSend.mockResolvedValueOnce({
+    DBClusters: [
+      {
+        DBClusterIdentifier: id,
+        Engine: 'aurora-postgresql',
+        ServerlessV2ScalingConfiguration: { MinCapacity: minAcu, MaxCapacity: maxAcu },
+        ClusterCreateTime: createTime,
+        TagList: [],
+      },
+    ],
+  });
+}
+
+function mockPeak(acu: number) {
+  mockCwSend.mockResolvedValueOnce({ Datapoints: [{ Maximum: acu }] });
+}
+
+describe('suggestMinAcu', () => {
+  it('adds a 20% margin and rounds up to 0.5-ACU granularity', () => {
+    expect(suggestMinAcu(2)).toBe(2.5); // 2 * 1.2 = 2.4 → 2.5
+    expect(suggestMinAcu(5)).toBe(6); // 5 * 1.2 = 6.0 → 6
+  });
+
+  it('never drops below the 0.5 ACU floor', () => {
+    expect(suggestMinAcu(0)).toBe(0.5);
+    expect(suggestMinAcu(0.1)).toBe(0.5);
+  });
+});
+
+describe('AwsAuroraServerlessIdleScanner', () => {
+  it('exposes its resource kind', () => {
+    expect(scanner.kind).toBe('aurora-serverless-overprovisioned');
+  });
+
+  it('reports a cluster whose peak ACU is far below the Min ACU floor', async () => {
+    mockServerlessV2Cluster('billing-db', { minAcu: 8 });
+    mockPeak(2); // 2 < 8 * 0.5 → overprovisioned
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.map((c) => c.id)).toEqual(['billing-db']);
+    // suggested = suggestMinAcu(2) = 2.5; saving = (8 - 2.5) * 87.6
+    expect(result.value[0].costEstimate.monthlyCostUsd).toBeCloseTo(5.5 * 87.6, 2);
+  });
+
+  it('does not report a cluster whose peak ACU is above the threshold', async () => {
+    mockServerlessV2Cluster('busy-db', { minAcu: 8 });
+    mockPeak(6); // 6 >= 8 * 0.5 → not overprovisioned
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toHaveLength(0);
+  });
+
+  it('does not report a just-created cluster within the grace period', async () => {
+    mockServerlessV2Cluster('fresh-db', { minAcu: 8, createTime: new Date() });
+    mockPeak(2);
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toHaveLength(0);
+  });
+
+  it('does not report when there is no Min ACU reduction left after rounding', async () => {
+    mockServerlessV2Cluster('tiny-db', { minAcu: 0.5, maxAcu: 4 });
+    mockPeak(0.1); // suggested rounds back up to 0.5 = current Min ACU → nothing to lower
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toHaveLength(0);
+  });
+
+  it('does not report a cluster with no ServerlessDatabaseCapacity datapoint at all (no evidence, not confirmed idle)', async () => {
+    mockServerlessV2Cluster('untagged-metric-db', { minAcu: 8 });
+    mockCwSend.mockResolvedValueOnce({ Datapoints: [] }); // CloudWatch has nothing for this window
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toHaveLength(0);
+  });
+
+  it('ignores clusters that are not Serverless v2 (no Min ACU floor)', async () => {
+    mockRdsSend.mockResolvedValueOnce({
+      DBClusters: [{ DBClusterIdentifier: 'provisioned-db', Engine: 'aurora-mysql' }],
+    });
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toHaveLength(0);
+    expect(mockCwSend).not.toHaveBeenCalled();
+  });
+
+  it('queries ServerlessDatabaseCapacity (Maximum) from the AWS/RDS namespace', async () => {
+    mockServerlessV2Cluster('billing-db');
+    mockPeak(2);
+
+    await scanner.scan(region);
+
+    const args = (GetMetricStatisticsCommand as unknown as jest.Mock).mock.calls[0][0];
+    expect(args.Namespace).toBe('AWS/RDS');
+    expect(args.MetricName).toBe('ServerlessDatabaseCapacity');
+    expect(args.Dimensions).toEqual([{ Name: 'DBClusterIdentifier', Value: 'billing-db' }]);
+    expect(args.Statistics).toEqual(['Maximum']);
+  });
+
+  it('returns Result.fail wrapping AwsAdapterError and destroys both clients on error', async () => {
+    mockRdsSend.mockRejectedValueOnce(new Error('boom'));
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect((result.error as AwsAdapterError).service).toBe('Aurora');
+    expect(mockRdsDestroy).toHaveBeenCalledTimes(1);
+    expect(mockCwDestroy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-aurora-serverless-idle.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-aurora-serverless-idle.scanner.ts
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: Apache-2.0
+import { RDSClient, DescribeDBClustersCommand, type DBCluster } from '@aws-sdk/client-rds';
+import type { CloudWatchClient } from '@aws-sdk/client-cloudwatch';
+import { createLogger } from 'shared-kernel';
+import type { AwsRegion, PricingPort, WastePolicy } from 'cloud-cost-domain';
+import { AuroraServerlessOverprovisioned, AuroraServerlessOverprovisionedPolicy } from 'cloud-cost-domain';
+import { createAwsClientConfig } from '../utils/client-config';
+import { paginate } from '../utils/paginate';
+import { getMetricDatapoint, type MetricWindow } from '../utils/cloudwatch-metrics';
+import { CloudWatchIdleScanner } from './cloudwatch-idle.scanner';
+
+interface AcuMetric {
+  peakAcu: number;
+  /** false when CloudWatch returned no datapoint at all — see the entity doc. */
+  hasDatapoint: boolean;
+}
+
+// Rightsizing signal — a longer window than the "zero-activity" scanners, so
+// a rare weekly peak isn't mistaken for an idle floor (same reasoning as the
+// CPU-underutilized scanners).
+const DEFAULT_LOOKBACK_HOURS = 168;
+const METRIC_CONCURRENCY = 5;
+const logger = createLogger('cloudrift:scanner');
+
+type ServerlessV2Cluster = DBCluster & {
+  DBClusterIdentifier: string;
+  ServerlessV2ScalingConfiguration: { MinCapacity: number; MaxCapacity?: number };
+};
+
+/**
+ * Recommended Min ACU: the observed peak plus a 20% margin, rounded up to the
+ * 0.5-ACU granularity AWS accepts, never below the 0.5 ACU floor.
+ */
+export function suggestMinAcu(peakAcu: number): number {
+  const withMargin = peakAcu * 1.2;
+  const roundedToHalf = Math.ceil(withMargin * 2) / 2;
+  return Math.max(0.5, roundedToHalf);
+}
+
+/**
+ * Detects Aurora Serverless v2 clusters whose configured Min ACU floor is far
+ * above the real peak capacity (ServerlessDatabaseCapacity) observed over the
+ * window. The floor is billed 730h/month at a single flat ACU-hour rate (no
+ * per-type cardinality), so pricing is always-on (ADR-0037).
+ */
+export class AwsAuroraServerlessIdleScanner extends CloudWatchIdleScanner<
+  RDSClient,
+  ServerlessV2Cluster,
+  AcuMetric,
+  AuroraServerlessOverprovisioned
+> {
+  readonly kind = 'aurora-serverless-overprovisioned' as const;
+  protected readonly serviceLabel = 'Aurora';
+
+  constructor(
+    private readonly pricing: PricingPort,
+    private readonly accountId = 'unknown',
+    policy: WastePolicy<AuroraServerlessOverprovisioned> = new AuroraServerlessOverprovisionedPolicy(),
+    windowHours = DEFAULT_LOOKBACK_HOURS,
+  ) {
+    super(policy, windowHours, METRIC_CONCURRENCY);
+  }
+
+  protected createPrimaryClient(region: AwsRegion): RDSClient {
+    return new RDSClient({ ...createAwsClientConfig(), region: region.code });
+  }
+
+  protected destroyPrimaryClient(client: RDSClient): void {
+    client.destroy();
+  }
+
+  protected async listResources(client: RDSClient): Promise<ServerlessV2Cluster[]> {
+    const clusters = await paginate<DBCluster>(async (cursor) => {
+      const r = await client.send(new DescribeDBClustersCommand({ Marker: cursor }));
+      return { items: r.DBClusters ?? [], cursor: r.Marker };
+    });
+
+    // Only Serverless v2 clusters have a Min ACU floor (v1 uses the legacy
+    // ScalingConfigurationInfo; provisioned Aurora has neither).
+    const serverlessV2 = clusters.filter(
+      (c): c is ServerlessV2Cluster =>
+        !!c.DBClusterIdentifier && typeof c.ServerlessV2ScalingConfiguration?.MinCapacity === 'number',
+    );
+    if (serverlessV2.length !== clusters.length) {
+      logger.debug(
+        `${this.kind}: skipped ${clusters.length - serverlessV2.length} non-Serverless-v2 (or unnamed) clusters`,
+      );
+    }
+    return serverlessV2;
+  }
+
+  protected async fetchMetric(
+    cw: CloudWatchClient,
+    _region: AwsRegion,
+    c: ServerlessV2Cluster,
+    window: MetricWindow,
+  ): Promise<AcuMetric> {
+    const dp = await getMetricDatapoint(
+      cw,
+      'AWS/RDS',
+      'ServerlessDatabaseCapacity',
+      [{ Name: 'DBClusterIdentifier', Value: c.DBClusterIdentifier }],
+      window,
+      ['Maximum'],
+    );
+    return { peakAcu: dp.Maximum ?? 0, hasDatapoint: dp.Maximum !== undefined };
+  }
+
+  protected toEntity(
+    c: ServerlessV2Cluster,
+    { peakAcu, hasDatapoint }: AcuMetric,
+    _prices: Map<string, number>,
+    region: AwsRegion,
+    now: Date,
+  ): AuroraServerlessOverprovisioned {
+    const minAcu = c.ServerlessV2ScalingConfiguration.MinCapacity;
+    const maxAcu = c.ServerlessV2ScalingConfiguration.MaxCapacity ?? minAcu;
+    const suggestedMinAcu = suggestMinAcu(peakAcu);
+    const acuMonthlyPrice = this.pricing.getPrice(region, 'aurora-acu');
+    // Not gated on hasDatapoint: an entity is still built so the (notWaste)
+    // policy verdict can be reasoned about; the policy itself refuses to
+    // flag a missing datapoint as waste, so a bogus saving never surfaces.
+    const monthlySavingsUsd = Math.max(0, minAcu - suggestedMinAcu) * acuMonthlyPrice;
+    return new AuroraServerlessOverprovisioned({
+      clusterIdentifier: c.DBClusterIdentifier,
+      region,
+      accountId: this.accountId,
+      engine: c.Engine ?? 'aurora',
+      minAcu,
+      maxAcu,
+      peakAcu,
+      hasDatapoint,
+      suggestedMinAcu,
+      windowHours: this.windowHours,
+      clusterCreateTime: c.ClusterCreateTime ?? new Date(0),
+      detectedAt: now,
+      tags: Object.fromEntries((c.TagList ?? []).map((t) => [t.Key ?? '', t.Value ?? ''])),
+      monthlyCostUsd: +monthlySavingsUsd.toFixed(4),
+    });
+  }
+}

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-lambda-loggroup-orphaned.scanner.spec.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-lambda-loggroup-orphaned.scanner.spec.ts
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: Apache-2.0
+import { CloudWatchLogsClient, DescribeLogStreamsCommand } from '@aws-sdk/client-cloudwatch-logs';
+import { LambdaClient } from '@aws-sdk/client-lambda';
+import { AwsLambdaLogGroupOrphanedScanner } from './aws-lambda-loggroup-orphaned.scanner';
+import { AwsRegion } from 'cloud-cost-domain';
+import { AwsAdapterError } from '../errors/aws-adapter.error';
+import { mockPricing } from '../testing/mock-pricing';
+
+jest.mock('@aws-sdk/client-cloudwatch-logs');
+jest.mock('@aws-sdk/client-lambda');
+
+const mockLogsSend = jest.fn();
+const mockLogsDestroy = jest.fn();
+const mockLambdaSend = jest.fn();
+const mockLambdaDestroy = jest.fn();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (CloudWatchLogsClient as jest.Mock).mockImplementation(() => ({ send: mockLogsSend, destroy: mockLogsDestroy }));
+  (LambdaClient as jest.Mock).mockImplementation(() => ({ send: mockLambdaSend, destroy: mockLambdaDestroy }));
+});
+
+const region = AwsRegion.create('us-east-1');
+const scanner = new AwsLambdaLogGroupOrphanedScanner(mockPricing);
+const OLD_DATE = new Date('2024-03-01').getTime();
+
+describe('AwsLambdaLogGroupOrphanedScanner', () => {
+  it('exposes its resource kind', () => {
+    expect(scanner.kind).toBe('lambda-loggroup-orphaned');
+  });
+
+  it('reports a log group whose function no longer exists', async () => {
+    mockLogsSend
+      .mockResolvedValueOnce({
+        logGroups: [{ logGroupName: '/aws/lambda/deleted-fn', storedBytes: 1024 ** 3 }],
+      })
+      .mockResolvedValueOnce({ logStreams: [{ lastEventTimestamp: OLD_DATE }] });
+    mockLambdaSend.mockResolvedValueOnce({ Functions: [] });
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.map((g) => g.id)).toEqual(['/aws/lambda/deleted-fn']);
+    expect(result.value[0].costEstimate.monthlyCostUsd).toBeCloseTo(0.03, 2);
+  });
+
+  it('does not report a log group whose function still exists', async () => {
+    mockLogsSend.mockResolvedValueOnce({
+      logGroups: [{ logGroupName: '/aws/lambda/live-fn', storedBytes: 1024 ** 3 }],
+    });
+    mockLambdaSend.mockResolvedValueOnce({ Functions: [{ FunctionName: 'live-fn' }] });
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toHaveLength(0);
+    // No DescribeLogStreams call for a candidate whose function is still active.
+    expect(mockLogsSend).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not report an orphaned log group within the last-event grace period', async () => {
+    mockLogsSend
+      .mockResolvedValueOnce({
+        logGroups: [{ logGroupName: '/aws/lambda/just-deleted', storedBytes: 1024 ** 3 }],
+      })
+      .mockResolvedValueOnce({ logStreams: [{ lastEventTimestamp: Date.now() }] });
+    mockLambdaSend.mockResolvedValueOnce({ Functions: [] });
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toHaveLength(0);
+  });
+
+  it('treats a log group with no streams as never logged (definitely orphaned)', async () => {
+    mockLogsSend
+      .mockResolvedValueOnce({
+        logGroups: [{ logGroupName: '/aws/lambda/empty-fn', storedBytes: 0 }],
+      })
+      .mockResolvedValueOnce({ logStreams: [] });
+    mockLambdaSend.mockResolvedValueOnce({ Functions: [] });
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toHaveLength(1);
+  });
+
+  it('queries DescribeLogStreams ordered by LastEventTime, most recent first', async () => {
+    mockLogsSend
+      .mockResolvedValueOnce({
+        logGroups: [{ logGroupName: '/aws/lambda/deleted-fn', storedBytes: 1024 ** 3 }],
+      })
+      .mockResolvedValueOnce({ logStreams: [{ lastEventTimestamp: OLD_DATE }] });
+    mockLambdaSend.mockResolvedValueOnce({ Functions: [] });
+
+    await scanner.scan(region);
+
+    const args = (DescribeLogStreamsCommand as unknown as jest.Mock).mock.calls[0][0];
+    expect(args.logGroupName).toBe('/aws/lambda/deleted-fn');
+    expect(args.orderBy).toBe('LastEventTime');
+    expect(args.descending).toBe(true);
+    expect(args.limit).toBe(1);
+  });
+
+  it('returns Result.fail wrapping AwsAdapterError and destroys both clients on error', async () => {
+    mockLogsSend.mockRejectedValueOnce(new Error('boom'));
+    mockLambdaSend.mockResolvedValueOnce({ Functions: [] });
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect((result.error as AwsAdapterError).service).toBe('CloudWatchLogs');
+    expect(mockLogsDestroy).toHaveBeenCalledTimes(1);
+    expect(mockLambdaDestroy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-lambda-loggroup-orphaned.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-lambda-loggroup-orphaned.scanner.ts
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: Apache-2.0
+import {
+  CloudWatchLogsClient,
+  DescribeLogGroupsCommand,
+  DescribeLogStreamsCommand,
+  type LogGroup as AwsLogGroup,
+} from '@aws-sdk/client-cloudwatch-logs';
+import { LambdaClient, ListFunctionsCommand, type FunctionConfiguration } from '@aws-sdk/client-lambda';
+import { Result, createLogger } from 'shared-kernel';
+import type { AwsRegion, PricingPort, WasteScannerPort, WastedResource } from 'cloud-cost-domain';
+import { LambdaLogGroupOrphaned, LambdaLogGroupOrphanedPolicy } from 'cloud-cost-domain';
+import { AwsAdapterError } from '../errors/aws-adapter.error';
+import { paginate } from '../utils/paginate';
+import { mapWithConcurrency } from '../utils/map-with-concurrency';
+import { createAwsClientConfig } from '../utils/client-config';
+
+const LOG_GROUP_PREFIX = '/aws/lambda/';
+// Only orphan candidates pay for a DescribeLogStreams call — the (usually
+// much larger) set of log groups whose function still exists never does.
+const STREAM_LOOKUP_CONCURRENCY = 5;
+const logger = createLogger('cloudrift:scanner');
+
+type LogGroupWithName = AwsLogGroup & { logGroupName: string };
+
+/**
+ * Detects `/aws/lambda/*` CloudWatch Log Groups whose function no longer
+ * exists — distinct from the `log-group` scanner, which flags missing
+ * retention on log groups that still belong to a live function.
+ */
+export class AwsLambdaLogGroupOrphanedScanner implements WasteScannerPort {
+  readonly kind = 'lambda-loggroup-orphaned' as const;
+
+  constructor(
+    private readonly pricing: PricingPort,
+    private readonly accountId = 'unknown',
+    private readonly policy = new LambdaLogGroupOrphanedPolicy(),
+  ) {}
+
+  async scan(region: AwsRegion): Promise<Result<WastedResource[]>> {
+    const logsClient = new CloudWatchLogsClient({ ...createAwsClientConfig(), region: region.code });
+    const lambdaClient = new LambdaClient({ ...createAwsClientConfig(), region: region.code });
+    try {
+      const [rawLogGroups, functions] = await Promise.all([
+        paginate<AwsLogGroup>(async (cursor) => {
+          const r = await logsClient.send(
+            new DescribeLogGroupsCommand({ logGroupNamePrefix: LOG_GROUP_PREFIX, nextToken: cursor }),
+          );
+          return { items: r.logGroups ?? [], cursor: r.nextToken };
+        }),
+        paginate<FunctionConfiguration>(async (cursor) => {
+          const r = await lambdaClient.send(new ListFunctionsCommand({ Marker: cursor }));
+          return { items: r.Functions ?? [], cursor: r.NextMarker };
+        }),
+      ]);
+
+      const validGroups = rawLogGroups.filter((lg): lg is LogGroupWithName => !!lg.logGroupName);
+      if (validGroups.length !== rawLogGroups.length) {
+        logger.debug(`${this.kind}: skipped ${rawLogGroups.length - validGroups.length} entries missing logGroupName`);
+      }
+      const activeFunctionNames = new Set(functions.map((fn) => fn.FunctionName).filter((n): n is string => !!n));
+      const orphanCandidates = validGroups.filter(
+        (lg) => !activeFunctionNames.has(lg.logGroupName.slice(LOG_GROUP_PREFIX.length)),
+      );
+
+      const pricePerGb = this.pricing.getPrice(region, 'cw-logs');
+      const now = new Date();
+      const entities = await mapWithConcurrency(orphanCandidates, STREAM_LOOKUP_CONCURRENCY, async (lg) => {
+        const lastEventTimestamp = await this.lastEventTimestamp(logsClient, lg.logGroupName);
+        const storedBytes = lg.storedBytes ?? 0;
+        return new LambdaLogGroupOrphaned({
+          logGroupName: lg.logGroupName,
+          functionName: lg.logGroupName.slice(LOG_GROUP_PREFIX.length),
+          functionExists: false,
+          storedBytes,
+          lastEventTimestamp,
+          region,
+          accountId: this.accountId,
+          tags: {},
+          monthlyCostUsd: +((storedBytes / 1024 ** 3) * pricePerGb).toFixed(4),
+        });
+      });
+
+      return Result.ok(entities.filter((group) => this.policy.evaluate(group, now).isWaste));
+    } catch (err) {
+      return Result.fail(new AwsAdapterError('CloudWatchLogs', err as Error));
+    } finally {
+      logsClient.destroy();
+      lambdaClient.destroy();
+    }
+  }
+
+  private async lastEventTimestamp(client: CloudWatchLogsClient, logGroupName: string): Promise<Date> {
+    const r = await client.send(
+      new DescribeLogStreamsCommand({ logGroupName, orderBy: 'LastEventTime', descending: true, limit: 1 }),
+    );
+    const timestamp = r.logStreams?.[0]?.lastEventTimestamp;
+    return timestamp ? new Date(timestamp) : new Date(0);
+  }
+}

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-sqs-dlq-abandoned.scanner.spec.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-sqs-dlq-abandoned.scanner.spec.ts
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: Apache-2.0
+import { SQSClient } from '@aws-sdk/client-sqs';
+import { CloudWatchClient, GetMetricStatisticsCommand } from '@aws-sdk/client-cloudwatch';
+import { AwsSqsDlqAbandonedScanner, DLQ_NAME_PATTERN } from './aws-sqs-dlq-abandoned.scanner';
+import { AwsRegion } from 'cloud-cost-domain';
+import { AwsAdapterError } from '../errors/aws-adapter.error';
+
+jest.mock('@aws-sdk/client-sqs');
+jest.mock('@aws-sdk/client-cloudwatch');
+
+const mockSqsSend = jest.fn();
+const mockSqsDestroy = jest.fn();
+const mockCwSend = jest.fn();
+const mockCwDestroy = jest.fn();
+
+interface QueueFixture {
+  url: string;
+  attributes?: Record<string, string>;
+  sourceQueueUrls?: string[];
+  tags?: Record<string, string>;
+}
+
+/**
+ * Queues down the SQS responses for a single-queue scenario, in the exact
+ * order `listResources` issues them: ListQueues, then — per queue, kicked
+ * off together via `Promise.all` — GetQueueAttributes, ListDeadLetterSourceQueues.
+ * ListQueueTags is queued too, but only when the fixture actually reaches it
+ * (the scanner defers that call until after the DLQ-identification check) —
+ * queuing it unconditionally would leave an unconsumed response sitting in
+ * `mockSqsSend`'s queue, silently shifting every later test's alignment.
+ * Automocked SDK Command instances don't retain `.input` (only the mock
+ * constructor's captured call args do), so dispatching by command type
+ * inside `send` isn't an option here — sequential mocking, like every other
+ * scanner spec in this suite, is.
+ */
+function mockQueue(url: string, fixture: Omit<QueueFixture, 'url'> = {}): void {
+  const queueName = url.slice(url.lastIndexOf('/') + 1);
+  const isDlqCandidate =
+    !!fixture.attributes?.RedriveAllowPolicy ||
+    (fixture.sourceQueueUrls?.length ?? 0) > 0 ||
+    DLQ_NAME_PATTERN.test(queueName);
+
+  mockSqsSend
+    .mockResolvedValueOnce({ QueueUrls: [url] })
+    .mockResolvedValueOnce({ Attributes: fixture.attributes ?? {} })
+    .mockResolvedValueOnce({ queueUrls: fixture.sourceQueueUrls ?? [] });
+  if (isDlqCandidate) {
+    mockSqsSend.mockResolvedValueOnce({ Tags: fixture.tags ?? {} });
+  }
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (SQSClient as jest.Mock).mockImplementation(() => ({ send: mockSqsSend, destroy: mockSqsDestroy }));
+  (CloudWatchClient as jest.Mock).mockImplementation(() => ({ send: mockCwSend, destroy: mockCwDestroy }));
+});
+
+const region = AwsRegion.create('us-east-1');
+const scanner = new AwsSqsDlqAbandonedScanner();
+const FOURTEEN_DAYS_SECONDS = 15 * 86400;
+
+describe('AwsSqsDlqAbandonedScanner', () => {
+  it('exposes its resource kind', () => {
+    expect(scanner.kind).toBe('sqs-dlq-abandoned');
+  });
+
+  it('reports a DLQ identified via RedriveAllowPolicy with a stale oldest message', async () => {
+    mockQueue('https://sqs.us-east-1.amazonaws.com/000000000000/orders-dlq-target', {
+      attributes: { RedriveAllowPolicy: '{"redrivePermission":"allowAll"}', ApproximateNumberOfMessages: '3' },
+    });
+    mockCwSend.mockResolvedValueOnce({ Datapoints: [{ Maximum: FOURTEEN_DAYS_SECONDS }] });
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.map((q) => q.id)).toEqual(['https://sqs.us-east-1.amazonaws.com/000000000000/orders-dlq-target']);
+    expect(result.value[0].costEstimate.monthlyCostUsd).toBe(0);
+  });
+
+  it('reports a DLQ identified via an active RedrivePolicy association and derives sourceQueueArn', async () => {
+    const scannerWithAccount = new AwsSqsDlqAbandonedScanner('000000000000');
+    mockQueue('https://sqs.us-east-1.amazonaws.com/000000000000/my-dead-letters', {
+      attributes: { ApproximateNumberOfMessages: '5' },
+      sourceQueueUrls: ['https://sqs.us-east-1.amazonaws.com/000000000000/orders-worker'],
+    });
+    mockCwSend.mockResolvedValueOnce({ Datapoints: [{ Maximum: FOURTEEN_DAYS_SECONDS }] });
+
+    const result = await scannerWithAccount.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value).toHaveLength(1);
+    expect(result.value[0].sourceQueueArn).toBe('arn:aws:sqs:us-east-1:000000000000:orders-worker');
+  });
+
+  it('omits sourceQueueArn (rather than a malformed pseudo-ARN) when the account ID could not be resolved', async () => {
+    mockQueue('https://sqs.us-east-1.amazonaws.com/000000000000/my-dead-letters', {
+      attributes: { ApproximateNumberOfMessages: '5' },
+      sourceQueueUrls: ['https://sqs.us-east-1.amazonaws.com/000000000000/orders-worker'],
+    });
+    mockCwSend.mockResolvedValueOnce({ Datapoints: [{ Maximum: FOURTEEN_DAYS_SECONDS }] });
+
+    const result = await scanner.scan(region); // default scanner: accountId = 'unknown'
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value).toHaveLength(1);
+    expect(result.value[0].sourceQueueArn).toBeUndefined();
+  });
+
+  it('reports a DLQ identified only via naming convention (source already decommissioned)', async () => {
+    mockQueue('https://sqs.us-east-1.amazonaws.com/000000000000/payments-dlq', {
+      attributes: { ApproximateNumberOfMessages: '1' },
+    });
+    mockCwSend.mockResolvedValueOnce({ Datapoints: [{ Maximum: FOURTEEN_DAYS_SECONDS }] });
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toHaveLength(1);
+  });
+
+  it('does not report a queue with none of the three DLQ signals', async () => {
+    mockQueue('https://sqs.us-east-1.amazonaws.com/000000000000/orders-worker', {
+      attributes: { ApproximateNumberOfMessages: '5' },
+    });
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toHaveLength(0);
+    expect(mockCwSend).not.toHaveBeenCalled();
+  });
+
+  it('does not report an identified DLQ with zero messages', async () => {
+    mockQueue('https://sqs.us-east-1.amazonaws.com/000000000000/idle-dlq', {
+      attributes: { RedriveAllowPolicy: '{}', ApproximateNumberOfMessages: '0' },
+    });
+    mockCwSend.mockResolvedValueOnce({ Datapoints: [{ Maximum: FOURTEEN_DAYS_SECONDS }] });
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toHaveLength(0);
+  });
+
+  it('does not report a DLQ whose oldest message is within the grace period', async () => {
+    mockQueue('https://sqs.us-east-1.amazonaws.com/000000000000/fresh-dlq', {
+      attributes: { RedriveAllowPolicy: '{}', ApproximateNumberOfMessages: '2' },
+    });
+    mockCwSend.mockResolvedValueOnce({ Datapoints: [{ Maximum: 3 * 86400 }] });
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toHaveLength(0);
+  });
+
+  it('queries ApproximateAgeOfOldestMessage from the AWS/SQS namespace', async () => {
+    mockQueue('https://sqs.us-east-1.amazonaws.com/000000000000/orders-dlq', {
+      attributes: { ApproximateNumberOfMessages: '1' },
+    });
+    mockCwSend.mockResolvedValueOnce({ Datapoints: [{ Maximum: FOURTEEN_DAYS_SECONDS }] });
+
+    await scanner.scan(region);
+
+    const args = (GetMetricStatisticsCommand as unknown as jest.Mock).mock.calls[0][0];
+    expect(args.Namespace).toBe('AWS/SQS');
+    expect(args.MetricName).toBe('ApproximateAgeOfOldestMessage');
+    expect(args.Dimensions).toEqual([{ Name: 'QueueName', Value: 'orders-dlq' }]);
+  });
+
+  it('skips CloudWatch entirely when no queue matches a DLQ signal', async () => {
+    mockQueue('https://sqs.us-east-1.amazonaws.com/000000000000/plain-queue', { attributes: {} });
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    expect(mockCwSend).not.toHaveBeenCalled();
+  });
+
+  it('returns Result.fail wrapping AwsAdapterError and destroys both clients on error', async () => {
+    mockSqsSend.mockRejectedValueOnce(new Error('boom'));
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect((result.error as AwsAdapterError).service).toBe('SQS');
+    expect(mockSqsDestroy).toHaveBeenCalledTimes(1);
+    expect(mockCwDestroy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-sqs-dlq-abandoned.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-sqs-dlq-abandoned.scanner.ts
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: Apache-2.0
+import {
+  SQSClient,
+  ListQueuesCommand,
+  GetQueueAttributesCommand,
+  ListDeadLetterSourceQueuesCommand,
+  ListQueueTagsCommand,
+} from '@aws-sdk/client-sqs';
+import type { CloudWatchClient } from '@aws-sdk/client-cloudwatch';
+import type { AwsRegion } from 'cloud-cost-domain';
+import { SqsDlqAbandoned, SqsDlqAbandonedWastePolicy, type WastePolicy } from 'cloud-cost-domain';
+import { paginate } from '../utils/paginate';
+import { mapWithConcurrency } from '../utils/map-with-concurrency';
+import { createAwsClientConfig } from '../utils/client-config';
+import { maxMetric, type MetricWindow } from '../utils/cloudwatch-metrics';
+import { CloudWatchIdleScanner } from './cloudwatch-idle.scanner';
+
+// `ApproximateAgeOfOldestMessage` is a point-in-time gauge SQS publishes to
+// CloudWatch every 5 minutes, not a rate that needs a long lookback to
+// average out — unlike the idle scanners' windows (48h+, "was there any
+// activity"), this window only needs to be wide enough to catch the most
+// recent datapoint. The 14-day waste threshold itself lives in
+// SqsDlqAbandonedWastePolicy, applied to whatever age this window returns.
+const DEFAULT_LOOKBACK_HOURS = 24;
+const ATTRIBUTE_CONCURRENCY = 5;
+
+// Naming-convention fallback for the DLQ-identification signals GetQueueAttributes/
+// ListDeadLetterSourceQueues can't cover on their own (see toDlqCandidate below).
+// Exported so the scanner spec can predict whether a given fixture will reach
+// the (conditional) ListQueueTags call, without duplicating the pattern.
+export const DLQ_NAME_PATTERN = /(-dlq|-dead-letter|_dlq|_dead_letter)(-queue)?$/i;
+
+interface DlqCandidate {
+  queueUrl: string;
+  queueName: string;
+  approximateNumberOfMessages: number;
+  sourceQueueArn?: string;
+  tags: Record<string, string>;
+}
+
+function queueNameFromUrl(queueUrl: string): string {
+  return queueUrl.slice(queueUrl.lastIndexOf('/') + 1);
+}
+
+/**
+ * Detects SQS queues acting as Dead Letter Queues (identified via
+ * RedriveAllowPolicy, an active RedrivePolicy association from another
+ * queue, or a DLQ naming convention) holding messages nobody has consumed
+ * in a while. $0 direct cost — SQS has no storage cost — the finding is a
+ * hygiene flag (errors nobody is looking at), same reasoning as
+ * `eni-orphaned`.
+ */
+export class AwsSqsDlqAbandonedScanner extends CloudWatchIdleScanner<SQSClient, DlqCandidate, number, SqsDlqAbandoned> {
+  readonly kind = 'sqs-dlq-abandoned' as const;
+  protected readonly serviceLabel = 'SQS';
+
+  constructor(
+    private readonly accountId = 'unknown',
+    policy: WastePolicy<SqsDlqAbandoned> = new SqsDlqAbandonedWastePolicy(),
+    windowHours = DEFAULT_LOOKBACK_HOURS,
+  ) {
+    super(policy, windowHours);
+  }
+
+  protected createPrimaryClient(region: AwsRegion): SQSClient {
+    return new SQSClient({ ...createAwsClientConfig(), region: region.code });
+  }
+
+  protected destroyPrimaryClient(client: SQSClient): void {
+    client.destroy();
+  }
+
+  protected async listResources(client: SQSClient, region: AwsRegion): Promise<DlqCandidate[]> {
+    const queueUrls = await paginate<string>(async (cursor) => {
+      const r = await client.send(new ListQueuesCommand({ NextToken: cursor }));
+      return { items: r.QueueUrls ?? [], cursor: r.NextToken };
+    });
+
+    const candidates = await mapWithConcurrency(queueUrls, ATTRIBUTE_CONCURRENCY, (queueUrl) =>
+      this.toDlqCandidate(client, queueUrl, region),
+    );
+    return candidates.filter((c): c is DlqCandidate => c !== null);
+  }
+
+  private async toDlqCandidate(client: SQSClient, queueUrl: string, region: AwsRegion): Promise<DlqCandidate | null> {
+    const queueName = queueNameFromUrl(queueUrl);
+    const [attrs, sourceQueueUrls] = await Promise.all([
+      client.send(new GetQueueAttributesCommand({ QueueUrl: queueUrl, AttributeNames: ['All'] })),
+      paginate<string>(async (cursor) => {
+        const r = await client.send(
+          new ListDeadLetterSourceQueuesCommand({ QueueUrl: queueUrl, NextToken: cursor }),
+        );
+        return { items: r.queueUrls ?? [], cursor: r.NextToken };
+      }),
+    ]);
+
+    // Three independent DLQ-identification signals (ADR-0065/plan Task 2):
+    // (a) this queue advertises itself as a valid redrive target,
+    // (b) another queue's RedrivePolicy currently points at it (AWS already
+    //     did the cross-reference for us), or (c) naming convention — the
+    //     fallback for a DLQ whose source queue was already decommissioned,
+    //     which is exactly the "abandoned" case this scanner exists to catch.
+    const hasRedriveAllowPolicy = !!attrs.Attributes?.RedriveAllowPolicy;
+    const hasActiveSource = sourceQueueUrls.length > 0;
+    const matchesNamingConvention = DLQ_NAME_PATTERN.test(queueName);
+    if (!hasRedriveAllowPolicy && !hasActiveSource && !matchesNamingConvention) return null;
+
+    // Tags are only needed for a candidate that's actually a DLQ — deferred
+    // until after the check above so a non-DLQ queue never pays for this call.
+    const tagsResult = await client.send(new ListQueueTagsCommand({ QueueUrl: queueUrl }));
+
+    // Only synthesize a real ARN when the account ID is actually known — with
+    // the 'unknown' fallback (STS resolution failed) this would otherwise
+    // present a malformed pseudo-ARN as if it were a real one.
+    return {
+      queueUrl,
+      queueName,
+      approximateNumberOfMessages: Number(attrs.Attributes?.ApproximateNumberOfMessages ?? '0'),
+      sourceQueueArn:
+        hasActiveSource && this.accountId !== 'unknown'
+          ? `arn:aws:sqs:${region.code}:${this.accountId}:${queueNameFromUrl(sourceQueueUrls[0])}`
+          : undefined,
+      tags: tagsResult.Tags ?? {},
+    };
+  }
+
+  protected fetchMetric(cw: CloudWatchClient, _region: AwsRegion, candidate: DlqCandidate, window: MetricWindow) {
+    return maxMetric(
+      cw,
+      'AWS/SQS',
+      'ApproximateAgeOfOldestMessage',
+      [{ Name: 'QueueName', Value: candidate.queueName }],
+      window,
+    );
+  }
+
+  protected toEntity(
+    candidate: DlqCandidate,
+    oldestMessageAgeSeconds: number,
+    _prices: Map<string, number>,
+    region: AwsRegion,
+    _now: Date,
+  ): SqsDlqAbandoned {
+    return new SqsDlqAbandoned({
+      queueUrl: candidate.queueUrl,
+      queueName: candidate.queueName,
+      approximateNumberOfMessages: candidate.approximateNumberOfMessages,
+      oldestMessageAgeSeconds,
+      identifiedAsDlq: true,
+      sourceQueueArn: candidate.sourceQueueArn,
+      region,
+      accountId: this.accountId,
+      tags: candidate.tags,
+    });
+  }
+}

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/scanner-contract.spec.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/scanner-contract.spec.ts
@@ -44,6 +44,9 @@ import {
   VpnConnectionIdlePolicy,
   TransitGatewayIdleAttachmentPolicy,
   KinesisProvisionedIdleStreamPolicy,
+  SqsDlqAbandonedWastePolicy,
+  LambdaLogGroupOrphanedPolicy,
+  AuroraServerlessOverprovisionedPolicy,
 } from 'cloud-cost-domain';
 import type { ResourceKind, WasteScannerPort } from 'cloud-cost-domain';
 import { AwsEbsVolumeScanner } from './aws-ebs-volume.scanner';
@@ -75,6 +78,9 @@ import { AwsWorkspacesIdleScanner } from './aws-workspaces-idle.scanner';
 import { AwsVpnConnectionIdleScanner } from './aws-vpn-connection-idle.scanner';
 import { AwsTransitGatewayIdleScanner } from './aws-transit-gateway-idle.scanner';
 import { AwsKinesisIdleScanner } from './aws-kinesis-idle.scanner';
+import { AwsSqsDlqAbandonedScanner } from './aws-sqs-dlq-abandoned.scanner';
+import { AwsLambdaLogGroupOrphanedScanner } from './aws-lambda-loggroup-orphaned.scanner';
+import { AwsAuroraServerlessIdleScanner } from './aws-aurora-serverless-idle.scanner';
 import { StaticPriceTableAdapter } from '../pricing/static-price-table.adapter';
 
 interface ContractFixture {
@@ -181,6 +187,11 @@ const scannerFactories: Record<ResourceKind, () => WasteScannerPort> = {
     new AwsTransitGatewayIdleScanner(pricing, ACCOUNT, new TransitGatewayIdleAttachmentPolicy(po)),
   'kinesis-provisioned-idle-stream': () =>
     new AwsKinesisIdleScanner(pricing, ACCOUNT, new KinesisProvisionedIdleStreamPolicy(po)),
+  'sqs-dlq-abandoned': () => new AwsSqsDlqAbandonedScanner(ACCOUNT, new SqsDlqAbandonedWastePolicy(po)),
+  'lambda-loggroup-orphaned': () =>
+    new AwsLambdaLogGroupOrphanedScanner(pricing, ACCOUNT, new LambdaLogGroupOrphanedPolicy(po)),
+  'aurora-serverless-overprovisioned': () =>
+    new AwsAuroraServerlessIdleScanner(pricing, ACCOUNT, new AuroraServerlessOverprovisionedPolicy(po, 50)),
   'ec2-underutilized': () => new AwsEc2UnderutilizedScanner(livePrices, ACCOUNT, new Ec2UnderutilizedPolicy(po, 5)),
   'rds-underutilized': () => new AwsRdsUnderutilizedScanner(livePrices, ACCOUNT, new RdsUnderutilizedPolicy(po, 5)),
   'elasticache-idle': () => new AwsElastiCacheIdleScanner(livePrices, ACCOUNT, new ElastiCacheIdlePolicy(po)),

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/testing/contract-fixtures/aurora-serverless-overprovisioned.json
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/testing/contract-fixtures/aurora-serverless-overprovisioned.json
@@ -1,0 +1,50 @@
+{
+  "kind": "aurora-serverless-overprovisioned",
+  "source": "hand-transcribed from the RDS/CloudWatch API reference, 2026-07-14 (rds not in the LocalStack Community license)",
+  "region": "us-east-1",
+  "accountId": "000000000000",
+  "pages": {
+    "DescribeDBClustersCommand": [
+      {
+        "DBClusters": [
+          {
+            "DBClusterIdentifier": "analytics-serverless",
+            "DBClusterArn": "arn:aws:rds:us-east-1:000000000000:cluster:analytics-serverless",
+            "Engine": "aurora-postgresql",
+            "EngineVersion": "15.4",
+            "EngineMode": "provisioned",
+            "Status": "available",
+            "ClusterCreateTime": "2025-01-01T00:00:00.000Z",
+            "ServerlessV2ScalingConfiguration": { "MinCapacity": 16, "MaxCapacity": 64 },
+            "TagList": [{ "Key": "team", "Value": "data" }]
+          },
+          {
+            "DBClusterIdentifier": "legacy-provisioned",
+            "DBClusterArn": "arn:aws:rds:us-east-1:000000000000:cluster:legacy-provisioned",
+            "Engine": "aurora-mysql",
+            "EngineMode": "provisioned",
+            "Status": "available",
+            "ClusterCreateTime": "2025-01-01T00:00:00.000Z",
+            "TagList": []
+          }
+        ],
+        "$metadata": { "httpStatusCode": 200, "requestId": "5c4b3a2d-3333-4a2b-9c3d-000000000001", "attempts": 1, "totalRetryDelay": 0 }
+      }
+    ],
+    "GetMetricStatisticsCommand": [
+      {
+        "Label": "ServerlessDatabaseCapacity",
+        "Datapoints": [{ "Timestamp": "2026-07-13T12:00:00.000Z", "Maximum": 4.0, "Unit": "Count" }],
+        "$metadata": { "httpStatusCode": 200, "requestId": "5c4b3a2d-3333-4a2b-9c3d-000000000002", "attempts": 1, "totalRetryDelay": 0 }
+      }
+    ]
+  },
+  "expected": {
+    "findings": [
+      {
+        "id": "analytics-serverless",
+        "monthlyCostUsd": 963.6
+      }
+    ]
+  }
+}

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/testing/contract-fixtures/lambda-loggroup-orphaned.json
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/testing/contract-fixtures/lambda-loggroup-orphaned.json
@@ -1,0 +1,59 @@
+{
+  "kind": "lambda-loggroup-orphaned",
+  "source": "hand-transcribed from the CloudWatch Logs/Lambda API reference, 2026-07-14",
+  "region": "us-east-1",
+  "accountId": "000000000000",
+  "pages": {
+    "DescribeLogGroupsCommand": [
+      {
+        "logGroups": [
+          {
+            "logGroupName": "/aws/lambda/checkout-worker-v1",
+            "creationTime": 1735689600000,
+            "storedBytes": 52428800,
+            "arn": "arn:aws:logs:us-east-1:000000000000:log-group:/aws/lambda/checkout-worker-v1:*",
+            "logGroupClass": "STANDARD"
+          }
+        ],
+        "$metadata": { "httpStatusCode": 200, "requestId": "3a2b1c0d-2222-4a2b-9c3d-000000000001", "attempts": 1, "totalRetryDelay": 0 }
+      }
+    ],
+    "ListFunctionsCommand": [
+      {
+        "Functions": [
+          {
+            "FunctionName": "orders-api",
+            "FunctionArn": "arn:aws:lambda:us-east-1:000000000000:function:orders-api",
+            "Runtime": "nodejs20.x",
+            "MemorySize": 256,
+            "LastModified": "2026-06-01T00:00:00.000+0000"
+          }
+        ],
+        "$metadata": { "httpStatusCode": 200, "requestId": "3a2b1c0d-2222-4a2b-9c3d-000000000002", "attempts": 1, "totalRetryDelay": 0 }
+      }
+    ],
+    "DescribeLogStreamsCommand": [
+      {
+        "logStreams": [
+          {
+            "logStreamName": "2026/06/15/[$LATEST]abcdef0123456789",
+            "creationTime": 1749945600000,
+            "firstEventTimestamp": 1749945600000,
+            "lastEventTimestamp": 1749945600000,
+            "lastIngestionTime": 1749945660000,
+            "storedBytes": 52428800
+          }
+        ],
+        "$metadata": { "httpStatusCode": 200, "requestId": "3a2b1c0d-2222-4a2b-9c3d-000000000003", "attempts": 1, "totalRetryDelay": 0 }
+      }
+    ]
+  },
+  "expected": {
+    "findings": [
+      {
+        "id": "/aws/lambda/checkout-worker-v1",
+        "monthlyCostUsd": 0.0015
+      }
+    ]
+  }
+}

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/testing/contract-fixtures/sqs-dlq-abandoned.json
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/testing/contract-fixtures/sqs-dlq-abandoned.json
@@ -1,0 +1,57 @@
+{
+  "kind": "sqs-dlq-abandoned",
+  "source": "hand-transcribed from the SQS/CloudWatch API reference, 2026-07-14 (LocalStack Community does not publish SQS metrics to CloudWatch)",
+  "region": "us-east-1",
+  "accountId": "000000000000",
+  "pages": {
+    "ListQueuesCommand": [
+      {
+        "QueueUrls": [
+          "https://sqs.us-east-1.amazonaws.com/000000000000/orders-processing-dlq"
+        ],
+        "$metadata": { "httpStatusCode": 200, "requestId": "8f2a1c3d-1111-4a2b-9c3d-000000000001", "attempts": 1, "totalRetryDelay": 0 }
+      }
+    ],
+    "GetQueueAttributesCommand": [
+      {
+        "Attributes": {
+          "QueueArn": "arn:aws:sqs:us-east-1:000000000000:orders-processing-dlq",
+          "ApproximateNumberOfMessages": "7",
+          "RedriveAllowPolicy": "{\"redrivePermission\":\"allowAll\"}",
+          "CreatedTimestamp": "1751328000",
+          "LastModifiedTimestamp": "1751328000"
+        },
+        "$metadata": { "httpStatusCode": 200, "requestId": "8f2a1c3d-1111-4a2b-9c3d-000000000002", "attempts": 1, "totalRetryDelay": 0 }
+      }
+    ],
+    "ListDeadLetterSourceQueuesCommand": [
+      {
+        "queueUrls": [],
+        "$metadata": { "httpStatusCode": 200, "requestId": "8f2a1c3d-1111-4a2b-9c3d-000000000003", "attempts": 1, "totalRetryDelay": 0 }
+      }
+    ],
+    "ListQueueTagsCommand": [
+      {
+        "Tags": {},
+        "$metadata": { "httpStatusCode": 200, "requestId": "8f2a1c3d-1111-4a2b-9c3d-000000000004", "attempts": 1, "totalRetryDelay": 0 }
+      }
+    ],
+    "GetMetricStatisticsCommand": [
+      {
+        "Datapoints": [
+          { "Maximum": 1814400, "Unit": "Seconds", "Timestamp": "2026-07-14T00:00:00Z" }
+        ],
+        "Label": "ApproximateAgeOfOldestMessage",
+        "$metadata": { "httpStatusCode": 200, "requestId": "8f2a1c3d-1111-4a2b-9c3d-000000000005", "attempts": 1, "totalRetryDelay": 0 }
+      }
+    ]
+  },
+  "expected": {
+    "findings": [
+      {
+        "id": "https://sqs.us-east-1.amazonaws.com/000000000000/orders-processing-dlq",
+        "monthlyCostUsd": 0
+      }
+    ]
+  }
+}

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/testing/mock-pricing.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/testing/mock-pricing.ts
@@ -19,6 +19,7 @@ const PRICES_BY_KEY: Record<string, number> = {
   'vpn-connection': 36.5,
   'transit-gateway-attachment': 36.5,
   'kinesis-shard': 10.95,
+  'aurora-acu': 87.6,
 };
 
 export const mockPricing: PricingPort = {

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/utils/cloudwatch-metrics.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/utils/cloudwatch-metrics.ts
@@ -82,6 +82,18 @@ export async function sumMetrics(
   return sums.reduce((total, sum) => total + sum, 0);
 }
 
+/** Maximum of a single metric over `window`, `0` if there's no datapoint. */
+export async function maxMetric(
+  cw: CloudWatchClient,
+  namespace: string,
+  metricName: string,
+  dimensions: Dimension[],
+  window: MetricWindow,
+): Promise<number> {
+  const dp = await getMetricDatapoint(cw, namespace, metricName, dimensions, window, ['Maximum']);
+  return dp.Maximum ?? 0;
+}
+
 /** Average of a single metric over `window`, `0` if there's no datapoint. */
 export async function avgMetric(
   cw: CloudWatchClient,

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@aws-sdk/client-rds": "^3.741.0",
     "@aws-sdk/client-redshift": "^3.1075.0",
     "@aws-sdk/client-s3": "^3.1073.0",
+    "@aws-sdk/client-sqs": "~3.1075.0",
     "@aws-sdk/client-sts": "^3.1068.0",
     "@aws-sdk/client-workspaces": "^3.1075.0",
     "@smithy/node-http-handler": "^4.7.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,9 @@ importers:
       '@aws-sdk/client-s3':
         specifier: ^3.1073.0
         version: 3.1073.0
+      '@aws-sdk/client-sqs':
+        specifier: ~3.1075.0
+        version: 3.1075.0
       '@aws-sdk/client-sts':
         specifier: ^3.1068.0
         version: 3.1068.0
@@ -73,7 +76,7 @@ importers:
         version: 3.1075.0
       '@smithy/node-http-handler':
         specifier: ^4.7.7
-        version: 4.7.7
+        version: 4.9.5
       chalk:
         specifier: ^4.1.2
         version: 4.1.2
@@ -331,6 +334,10 @@ packages:
     resolution: {integrity: sha512-/Dvhrff0I4D2YUWSdm8uLKa1bfXdw9BMRDUME6ZeoTrrdQKQDeo2scLDjdpC5X2YdvTc/ZnUCR2HAvD7qXvS1w==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/client-sqs@3.1075.0':
+    resolution: {integrity: sha512-ZHowzLHFTIz482Z98Y8GtszLN7Q1YvC74xxExwr2rbKJeNWTXHVoMVwlq/jv5Kyf0elVAGmoID12Gf6aSdWy0Q==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/client-sts@3.1068.0':
     resolution: {integrity: sha512-WCUEpfdsSSO7zsXi7GUwHR+A5HZDQNsGktFJxOm73ZU+WLlBKRDzKdWZdYOpNkgBpXxy5KCeVMvXuaq2s1zn7w==}
     engines: {node: '>=20.0.0'}
@@ -339,184 +346,40 @@ packages:
     resolution: {integrity: sha512-sSVDmatHtyX0Ro/eYKfMpNT+wSQC++rgeww60tSw1yGvlBN+SFYdGNKyooIri/sS31+f8qjA7xQYyd6du6zefA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/core@3.974.19':
-    resolution: {integrity: sha512-SMNfLCU/41xxfFaC5Slwy8V/f1FRhakvyeeMeDeIxqNF0DzhDlXsXnJDELJYke1EtnJbfzfilW7tvulGfxMY6A==}
+  '@aws-sdk/core@3.975.1':
+    resolution: {integrity: sha512-8qh/6EYb7hl/ZwVfQufhbMEZs1gQIc7GbdrIf4eprQJ7cv042+74nE6l3YDfyWNzb9iPXb8fRyYSHkNIk5eE6Q==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/core@3.974.20':
-    resolution: {integrity: sha512-7sDi2B2N3mc3nf1nz6FyEx/FCrJ1N1QnBmraHHQNabFaeAh2IaOOLml48/rHOD1bICHgTRkbBgNTvUzEr5Z35g==}
+  '@aws-sdk/credential-provider-env@3.972.57':
+    resolution: {integrity: sha512-1RfJaF7SW1TOnvNGU7kaYjwUf5H3sfm+synGH1bHhRlqcnxCt3szebH3dmKEyY4tuGcbQ6ffzUT89cRitBV8OQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/core@3.974.21':
-    resolution: {integrity: sha512-P5JAHvn4dTi96UsAGS67LVOqqpUNNRhnfFXqzCYtdBIGZtqBue4CXvRr9YenOO7PALj/Pn8uuyw53FBCiCYw8w==}
+  '@aws-sdk/credential-provider-http@3.972.59':
+    resolution: {integrity: sha512-sRCkpTiFnCdQvuaRVjQ6SVoHu6i7RUpurVo1c4F81HWhPvUJ7Wdp5MNtSdX1O29CNXc8em3O5m52hCjVtAD9SA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/core@3.974.22':
-    resolution: {integrity: sha512-YofH63shc6YRdXjz80BJkpJW+Bkn0Cuu2dn4Rv7s9G2Idt58tgtzQEWxrR2xVljlVfIBeUjPuULnSVYLke3sUQ==}
+  '@aws-sdk/credential-provider-ini@3.973.1':
+    resolution: {integrity: sha512-6d8H6ZAh3ZPKZ6fe1nG2OWeZEZPtt9ravoD1dezPdPtsSkJRoxGAnFSHwKT3E/Te6fHE30zRzjV6TD12rvF6yQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/core@3.974.23':
-    resolution: {integrity: sha512-MiWR/uWjxjFXGzrE0Ghc5lWxUxzHsUWFhV+OX7M4cR9SrmrnZs6TXavnCWnzzdwJeFri34xQo81rvGNzK3c4BQ==}
+  '@aws-sdk/credential-provider-login@3.972.63':
+    resolution: {integrity: sha512-GREWRrMj0XnNKMaVa/Mauoaui26qBEHu71WWqXbwZOu/jFQOnPZjTf7u0KtGKC8VGa6VUs9kDWGgocrKNLS9vw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-env@3.972.45':
-    resolution: {integrity: sha512-ZPsnLyrpDRmojKrBbJykASyLLVFkjyD+fWATeSuYgaqablijGOzxPxEKyrwUvNg+bgSQ7PkW2FTu65Xco19Gag==}
+  '@aws-sdk/credential-provider-node@3.972.67':
+    resolution: {integrity: sha512-oYlzWst56rlhhjbYnexwv5hVLYe1cW4liLObhDfxDLI4RAQzleMVHQgQgx7XsC4HKj4e3kjT8v9DId+Pi/dndw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-env@3.972.46':
-    resolution: {integrity: sha512-+GPXVS2srMOlH74S+SmC1gVuP2TvUZ0siuC0onKO93q+udP+M72dmY8wJfVQ5CX9z/9X5A1HHwz5yRIGBtskvQ==}
+  '@aws-sdk/credential-provider-process@3.972.57':
+    resolution: {integrity: sha512-TiVQhuU0pbhIZAUZacbPHMyzrIdiH+lnx+PMY/Pu/b93dJrq3wdZwzUJ0TPpvNxaqbHsxJvQZW3/h/beLiKq7Q==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-env@3.972.47':
-    resolution: {integrity: sha512-3YoPwJczcc+MtX2xxXaYaOOWO6xKUJr1ZIIDIFuninr51BYONVVcF/CP8K2xfVRC/PztJjqKWxNGFH7BWQAw1Q==}
+  '@aws-sdk/credential-provider-sso@3.973.1':
+    resolution: {integrity: sha512-3foTZUJ4821Ij60X7K3NJroygiZLnbBmarN+T//O2cjkISan90zElN3NBmgSlDrTQ7Gs6z/yO8V7h60QNcDZHQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-env@3.972.48':
-    resolution: {integrity: sha512-h6FEC95fbexUd6zxm4PdgS82bTcI2PRtUb2ZwMipb/Xr8bPwtf0G8rBo2jp7NA24Mbx2JA8/WingiYpA9RCCyw==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-env@3.972.49':
-    resolution: {integrity: sha512-liB3yQNHCM9k/gu/w36XHMKPluT7HTlnGUhRbBGSISDQkcr/Sy1zsZabiuvQj8WG5yW573u9RehrBvvnIQ9OEQ==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-http@3.972.47':
-    resolution: {integrity: sha512-1XdgHDIPbARHuzZXM7ouzIbSUZFU9dTi9k+ryMhiZU4QCam4dvwOyUEFjEHNxAZehCYUIOmsSUZ2un6BIgUkWg==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-http@3.972.48':
-    resolution: {integrity: sha512-fA5loSdlocacRxyUXtpoHSMuk5rsIKRDzQYVMnMxjcmFeZshaJlJ8lymy/hYKji6sne/UmNGj5pxuEs6kq/Qcg==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-http@3.972.49':
-    resolution: {integrity: sha512-2UtGUPy+x3lqyceHrtC1uEuVxBZbDalPF6KAFqBwYgm4edWdBrZKNnCqzDs7KynWUvEC6mrR+ojRk+ZgQz9C2w==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-http@3.972.50':
-    resolution: {integrity: sha512-lJO3OLpjvz5m/RSBQmsG/CEUGsvCy5ruxKwPQaOCqxqCMuyYT2BZwQUTDZVVwqQ9LrZKuK24JSa6r31hL/tvkg==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-http@3.972.51':
-    resolution: {integrity: sha512-XET0H2oofciJ5lMRWNIvRjAP7Q3wv2XT+JtJJEdhPWUMwe3TvQ9qcxonpu7vXmNngncvFpi4E2It+Tamas/naA==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-ini@3.972.51':
-    resolution: {integrity: sha512-f8sRTVyM+9BbzQKPlUP9dVVpgNEu65jFckNAAGzRfCrlaSi5AWUbCKEHIMcIYokv8pWblSKEqHkqKYZtwINnhw==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-ini@3.972.53':
-    resolution: {integrity: sha512-ZfdhIOR41q8TcWEnUac+gCOb+O2LBWdHLmjedXpXz4IEFW2ppNuFcm6p0sMTavpM+zD5TYfpH5Gp7guRyqSgsQ==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-ini@3.972.54':
-    resolution: {integrity: sha512-Hx4gO4YRjFwitf3MVl3cDwYe1aryJthC4txVl9b+JAURovA50M2ywf9r8j1E/Q6SCTPT4qQpjOAbKYIC9CG+Vw==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-ini@3.972.55':
-    resolution: {integrity: sha512-TBoF4buBGYhXjdZAryayY2TrkQj2B2KfE/msG4V53XCt+w0EhEwM2JRjx8p2grJ2C6gtH5++SAwEvGMRdi0yyw==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-ini@3.972.56':
-    resolution: {integrity: sha512-IAmc61hbgQiHht9U3x0tnRwz0lzdwOwD/i9voRgdJrKamF+JtmrBOsW9GwB7mfFonNWOWL4qARWYrF8veEMe3w==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-login@3.972.50':
-    resolution: {integrity: sha512-NHHsKoMhw6UylSU0XDnDc87+IQW8tRBTIe6vnOX12GSIlBDtoce6bSzONleIglCyu8d3H9bmTSfk+sIN5yh3WA==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-login@3.972.52':
-    resolution: {integrity: sha512-9hu2oR0qH7Fst5Tzdx+UWxm+w5zCXtErTLtOOW5hwwQc170CLwOeniRxyFY6s9mHfGEfC5zFukNBdKBwJR8mhQ==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-login@3.972.53':
-    resolution: {integrity: sha512-+71sluhkgPqdhbbD3UDwUpj24GCkng9HQx6z7qoBFb8dwkF4ktpOcVKDeHpgg8PvBgLYwAnUYLTEGRC/PniCiQ==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-login@3.972.54':
-    resolution: {integrity: sha512-hBWI3wZTdTGiuMfmPts6AWbAjFfRniOQnqx68tc2cQvRKWawFbN9wkLOVPWM1FAOyowZU73mC6Fi+rHSHNyLFw==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-login@3.972.55':
-    resolution: {integrity: sha512-hBBkANo3cDn+h2qxxzER4a+J8JCO9o9Z/YYmU7iky6AcaarX5RRdRcHNC6SLdwY0vAXQygn6soUbDqPn3GghaA==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-node@3.972.53':
-    resolution: {integrity: sha512-z/JJ8Qvf2GiTn4bw+x8k7wQjxmPpNsiwZ7ls/h1cZHikrSpS0+65lB+lafnXZlxv1lqH4k6rQwh+2UsycC662g==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-node@3.972.55':
-    resolution: {integrity: sha512-zMGLa/dhESVqmCD7mmIFFKSwSFrJGScvCXcjvBZEVOOMauFS5JRQvLTMukFpMEFWiV6dTAlsen2ATDBulLPtbg==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-node@3.972.56':
-    resolution: {integrity: sha512-iI+4o0dvQQ4NHel4FMDiFy5q2gaU/ryLK3niOsoPccAt9WLFRkV4XTYPWRr9XvmBUqEzXG73S4p/8gm0Lu/W3A==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-node@3.972.57':
-    resolution: {integrity: sha512-u6dClpzNdWf1HGWz4wwhdXi1wiOofCLniM9S4BQQGlLAN9TW7VB+ld5V533GdKrYMaFeBGFqKnj0JCYvynLqwQ==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-node@3.972.58':
-    resolution: {integrity: sha512-OyCLVmSI7pZO8hxwNVX6pXhTVlJqRBTp+ijdEfJSUj0RyjHnF602OfAarOzGq6wkGodeFkYBt8MmJ6A6ycRgWw==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-process@3.972.45':
-    resolution: {integrity: sha512-QMJXjTGLmHE4Ie03T5H4hHOLfcvMc9DaODO6b5dgte3S8ECf5bBuHUJW4cQREcYZyRkOU8iymqtiBxqF4icxZg==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-process@3.972.46':
-    resolution: {integrity: sha512-VUoNFBIjWrUN8NbFiQiuxQEgFjvziAlBRPK+ddh27aj65gk0BYu6bLZnrdrNZwpW6vAihtSUtEMQ1PUJ32QRPA==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-process@3.972.47':
-    resolution: {integrity: sha512-tAizPm9IFo/PHn06c+LQJlzfY2AGOlyF0CUljFejrU6LcZBjnk8pmbZK3/xoIDdnIzjEdbClfvY3mXfr818ZEg==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-process@3.972.48':
-    resolution: {integrity: sha512-w6VZwojPt12WnEkAUy6Nu4K6sWCbBmR7QX390b0nE6vRvkXbrYr9Lq9VySGkfjiMjpUA87op+J4EgvRmtWIDoQ==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-process@3.972.49':
-    resolution: {integrity: sha512-C8h36lBuC/RnBSsjlO+dn6xZm3KbAl5vpJaVPAfQnMmz2/OISmKOc8XZcqMQgO2ADwBYNRMM6Kf3vz9G/TulMQ==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-sso@3.972.50':
-    resolution: {integrity: sha512-pQ9ww4G53gwHlon1NMz25JhaBo13E9Jv+VVgjh39C/yzvby+xhSnEOb+VDYShKNCh1TbttMF/5CFCHkZrIqOcA==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-sso@3.972.52':
-    resolution: {integrity: sha512-nb2/n4o/HQf+FVpVbZe9vCTFngmuDoIsltMgLAtjixaKzvzhB4J8WSDFyWgnErgLHk55ctWH+I4PU+LIHhyffg==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-sso@3.972.53':
-    resolution: {integrity: sha512-pUXE3fu4tfEDV8BksIgf4dXvuIH10FhwHMl/wu8rBD5T1sMpryQWFVitH3kdPS90wlgrGYJQ/meQTSPacyZfeg==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-sso@3.972.54':
-    resolution: {integrity: sha512-23uZpIpF2SIFDCa1fcWa202tK4gGeyvX6GIIAjiB8WBsvsVRBMnJ/7dCxHzxf7eZT7GToJg837LDIBnZsl/VUg==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-sso@3.972.55':
-    resolution: {integrity: sha512-1FkOz74Ea5QGS9jtIoXp55T/IkSS3spv+nLTT07fRY/+T5xmEOqaYBVIaEmX4zTNvbV6g2lrtlaVKWEoNyJt3w==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-web-identity@3.972.50':
-    resolution: {integrity: sha512-9DbaPaT2aMbz18wtSpq9HVBErjBQwxykqTFgG6n8Bn05GN68mITz+G1869ekYx0mVT/BDjETj5czz/3cPgLwxA==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-web-identity@3.972.52':
-    resolution: {integrity: sha512-lKj6aRSGbqLmpYmM24bY7a1Xmfcq2vkE3hv8CSPYfc1yCu0BPu/XEJ1L4Fm61MsU6ULLNSG8UGsffNoFUBjESA==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-web-identity@3.972.53':
-    resolution: {integrity: sha512-JmMGlhVvSj8uSG9CpeDkJAXT35H89tc6v84iMgEIE75q4yp1MKVVKvopv6Gg28HJIR7hMNkojRF8H2m5W44wyg==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-web-identity@3.972.54':
-    resolution: {integrity: sha512-0Iv5QttS6wcATlodYKgvQj6B9Db51rx7NU9fqu0PoLeS4BIgdYMc/QK4smwLwpm5RFrs02V/eLyEFp3FklvlNQ==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-web-identity@3.972.55':
-    resolution: {integrity: sha512-g2BoECD1q01kTPByi56+VLVvdWDzMkKIcr77qixpqH0okw2t0U5CoPv+6S8v/D1Y2Wa6QKKtn6XAtDzP+Kfpvg==}
+  '@aws-sdk/credential-provider-web-identity@3.972.63':
+    resolution: {integrity: sha512-8qZLFhM69eKcS37m459ctPR05Qimycm/74OPVioe6wNZabMT54GYhwBju0+J656RkMasNSawWQu+c8CmBe3TUQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/dynamodb-codec@3.973.22':
@@ -539,10 +402,6 @@ packages:
     resolution: {integrity: sha512-RJguNudY1LhEJSRhrmKlRR8e/EpfnrcvGJyJgV+tR8S0BoSJqkWgJP4LGIYTAkTF3ofhw3GaahP7dmPYQV85Sg==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/middleware-sdk-rds@3.972.33':
-    resolution: {integrity: sha512-PKHKk49oxEAowl01O4W0Iim3AagL57Qsk/RM+u/0ux+QrePAVyhWEvfavKKP0NBMXoIwPUC+Mnws9XRaoBQrIg==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/middleware-sdk-rds@3.972.37':
     resolution: {integrity: sha512-VuUIRnbkchafWIKb0nqvX+RlKYc8cq0a6tE/mtdF1J4cf44/R/wsKZgq5BHsHeLSuLjCoj5BHtSbLe+CF5OhOg==}
     engines: {node: '>=20.0.0'}
@@ -551,84 +410,36 @@ packages:
     resolution: {integrity: sha512-keWp6Z5cEIJzPwoCf/WRm0ceAeephPDDivhRsK/xXs2ZYXyypJ2/DL9G1IR0bz/s+iZC0EgzmFV4r7rlvLlxQQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/nested-clients@3.997.18':
-    resolution: {integrity: sha512-xBWrodBvW5SHCZV11UZUJG0pSHkLCEREIBoNbff1C1sacOUCmxJnTCPE80sCGLCtqgXg98I2MQJe2z28tcZSsw==}
+  '@aws-sdk/middleware-sdk-sqs@3.972.35':
+    resolution: {integrity: sha512-J1u7OABwjjBB7sUJiET05dPVAfjFeR6vfM5//DInKuPzc7PhPVNEviC7RqbsIsBdZi8xICVnHemFrTuvGmhySA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/nested-clients@3.997.20':
-    resolution: {integrity: sha512-IYJuLpXp2DEILVQpQOy0PMpkftv0AHEOCn52o0atyOaumA0CdWQ3klPyXdViGYLbNpESsVFMVybvHUeZAuiGxA==}
+  '@aws-sdk/nested-clients@3.997.31':
+    resolution: {integrity: sha512-BDHTpwcsZHEBNEJzOg/B1BkFYJxAXY50dau/NyVWs3d51F0WgIUGSWZot/Os+N3KpDhXeaXnz37mWffAvduREw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/nested-clients@3.997.21':
-    resolution: {integrity: sha512-eC7Vl7Qom/BGhZjG9GEqPwdQ/fk45hg1t5LP4EUxG5d1fdshLbaxCiwh/tszUzDX/4mW40mu2QsbeJJRPBbqUw==}
+  '@aws-sdk/signature-v4-multi-region@3.996.39':
+    resolution: {integrity: sha512-8+srXqYIF8KYMLC4FxMLEM5Ek7kUNibJu1R4m8/fUhhNYIZZz26oGtKkCr8I/HiG2fFQxBvaGgQZT4/mqRCSnA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/nested-clients@3.997.22':
-    resolution: {integrity: sha512-4IwtcYSxEIVw5hcp8ogq0CMbFNZFw7jJUetpfFUhFFeqsa1K8j2Ihg2hnxLyOp3stMZnXda6VzOmPi1AFZQXcg==}
+  '@aws-sdk/token-providers@3.1083.0':
+    resolution: {integrity: sha512-s0woKnxuHrExLc5L2ArIH5BMkbonHPtt+5hSBM8oknp9M6QTuUmmAmJ2E0EdzCGONrO+8+ADPqvv6UX0nNcc7A==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/nested-clients@3.997.23':
-    resolution: {integrity: sha512-gO93ZPsI2bxeFZD42f1/qjDw6FAZkNZcKRO94LIiT03fzOmcJ9e/tunxjVjA1Rl69ClmVJzz8H3G9CdKef10PA==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/signature-v4-multi-region@3.996.33':
-    resolution: {integrity: sha512-Hn0RThJEbyOZWV2PV9Z4YD3nitGPxybmyU17dSe9b61WOBcKnqS0WTtM3c1zyZq9WnGiyrfi/i+UBPUk7cM8Ug==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/signature-v4-multi-region@3.996.34':
-    resolution: {integrity: sha512-mx1L5qlumSOt/nKM3BFaHE2HVkWwz0i4Bw0pyYO42FfX/FeLlo8YI6csC0gSPprEk6fTIqI+CZN9RwUwKd5krQ==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/signature-v4-multi-region@3.996.35':
-    resolution: {integrity: sha512-6L/VWs+Wch2stHemCGTmUNqKLMzURxQDK5boNG3Jn3kAOp71meDUuS5sbObpEvFxHDq0uWeSLFDNSYsjNt+Dlg==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/token-providers@3.1064.0':
-    resolution: {integrity: sha512-sjI+iA4JtgeckBgKwPQF7KzWillRoNDmtpiM0TRa0syiAKFHKUSf84kPXSO3+gA7aMMSxrcxzOM2oPSecaJvEA==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/token-providers@3.1066.0':
-    resolution: {integrity: sha512-UqEUJq7dqa44hneLDUcX7UJy95cg8YqEWyakRpvIPnrNS3Mq+UlQHgCDGu5pvwAPtlIW4qcYbvW6reG6++FyvA==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/token-providers@3.1069.0':
-    resolution: {integrity: sha512-ks4X+kngC3PA5howV7Qu1TgG4bfC4jPykKdvw3nmBSXR9yZxRJouBholFSNQ5kY3L+Fgwyw+LCjzQmNi+KR91g==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/token-providers@3.1071.0':
-    resolution: {integrity: sha512-4LDW2Qob6LoLFuqYSYZq2AyTE9koSE9+i+n5UZcm10GpmQOK0zRD9L4uYlzItiTKksIWgC/qMFChAi3RvKYtMg==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/token-providers@3.1074.0':
-    resolution: {integrity: sha512-pv80IzgGW4RnXWtft692chZOM9i6PhebVsLCcnaM4dBEPZva2fE6FXAHs76G7Rc7s3yGyX/68G0nZMrUy+Vmpg==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/types@3.973.12':
-    resolution: {integrity: sha512-43ajd1NF0RMgX5k0hxCNUyEdrtFUsb2aHT2QvpktSC/2Eyb2Jr/JPVqdp0XIoaHWikZJq5tNWSLO6kB5q2eMCA==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/types@3.973.13':
-    resolution: {integrity: sha512-pEHZqRkAlHfnfAU9tK+WpKv/gBNjGJrHMgA3A0iYRGyswBS2t0pfez+lWlwktb3Bqa0ovh7w/QJTFwp3fDxLNg==}
+  '@aws-sdk/types@3.974.0':
+    resolution: {integrity: sha512-QIBrw90CDm4O0UaIIzkU6DrFdeJzEb2Va5EPEVpyldj6sHJxB6cshhStJuhZxk3wR3PmjJlYsjPmY1kNb+KGBg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/util-locate-window@3.965.7':
     resolution: {integrity: sha512-M0D6oIpohdNHjc7udzTHEQyot0+0iuA36jc2I9Hps+f/GtKi2HO/pyijQnCnNcwZqLB5+rtn81z3eZK/GyjAmA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/xml-builder@3.972.29':
-    resolution: {integrity: sha512-fk0niuGFxfi8yIJuMVM4mhwObkiQSuwZFj3tAPrLVx64Pk3BkrEIpqjzHKY4hKoEBUD6Jg/S74Zj9jy+5F3DnQ==}
+  '@aws-sdk/xml-builder@3.972.34':
+    resolution: {integrity: sha512-wHhWL1y7sN3enBA8POrPpQM5jCcmu2ozyhbRei4c8OjVcEaEs6yLucLa/pla457ggS/ysuy7bosagz3HaJkZXA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/xml-builder@3.972.30':
-    resolution: {integrity: sha512-StElZPEoBquWwNqw1AcfpzEyZqJvFxouG+mpDNYlcH6ZOrqd2CuIryv+8LV8gNHZUOyKyJF3Dq9vxaXEmDR9TQ==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/xml-builder@3.972.31':
-    resolution: {integrity: sha512-SzE4Pgyl+hDF+BuyuzxUSpwnuUu9lJuO1YGgteG89/4Qv0+2IQiVQqdbPV32IozLvXWQChPQcdkk/sKvb1QHiQ==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws/lambda-invoke-store@0.2.4':
-    resolution: {integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==}
+  '@aws/lambda-invoke-store@0.3.0':
+    resolution: {integrity: sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==}
     engines: {node: '>=18.0.0'}
 
   '@babel/code-frame@7.29.7':
@@ -1683,9 +1494,6 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
-  '@nodable/entities@2.1.1':
-    resolution: {integrity: sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==}
-
   '@nx/devkit@22.7.5':
     resolution: {integrity: sha512-/63ziS7kdHXYTLLhwWBu9hFwoFFT8xf+PkcQjsNdPqc5JmkYkSew0cE/vp5ORgBpGLWWnFPJgmfqjbJoO2C7jA==}
     peerDependencies:
@@ -1925,16 +1733,16 @@ packages:
   '@sinonjs/fake-timers@15.4.0':
     resolution: {integrity: sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==}
 
-  '@smithy/core@3.24.6':
-    resolution: {integrity: sha512-wBXDRup6UU97VKyaiRo8AssnfStPtG0oAAfpq/bC0a1YYau8pM86YB4kM6ccoVi1mS8l/UHbn9oDM+7uozr/ug==}
+  '@smithy/core@3.29.3':
+    resolution: {integrity: sha512-L+Ys6ecjk5vwPMAKHBpPKlJ3DkqwNcnfEISXBZIsVvWG/XKXfsAP8mwIYlTeLcd2ElHdesPI8OuOmJSFAPhm6A==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/credential-provider-imds@4.3.8':
-    resolution: {integrity: sha512-5cAM+KZC02sTqDt6NaLXyu50M/GNMd1eTzDVR8Lb0BBsVtu7RWHo47VPPEEv1vt3Yub6uzr+M5FHC+GtoT0USg==}
+  '@smithy/credential-provider-imds@4.4.8':
+    resolution: {integrity: sha512-q9J7JTiXrAhB8sDp4px97uEPT7CwKH61Co78grdNQvU8QZAdiuaSRhP0tUVf2ogy36RZTrlMU1rBmDEH+cnkiA==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/fetch-http-handler@5.4.6':
-    resolution: {integrity: sha512-FEwEYJ1jlBKdhe9TPzfghEi1bP55ZeEImlDkEa62bBBYzUcnB6RUCyuiS2mqKt6ZVjUbBgcNhzfIctH+Hevx9g==}
+  '@smithy/fetch-http-handler@5.6.5':
+    resolution: {integrity: sha512-SuqeisTyPoiIPtIYru/sGxGyXzmZ+8nnFOhC+qRPglt06Ebd1yH//CDltZB2J/3WBNVhwfUaZ0EtHB3cm2X32g==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/is-array-buffer@2.2.0':
@@ -1945,16 +1753,16 @@ packages:
     resolution: {integrity: sha512-wZQpnjrGSO2IFxhwWNaeRzHh2swSwRGWaCVgQN9zqYdtP98tcNYyqI7YvPeVTwf9CvQTas7xlmR3NY5L1i32mg==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/node-http-handler@4.7.7':
-    resolution: {integrity: sha512-ZAFvHXrEk6K180EVhmZVg8GU5pUH5BSFqRs27JW3j1qEFx9YyYwWFx17x/MHcjALYimGAji7qEOlF1++be+G5A==}
+  '@smithy/node-http-handler@4.9.5':
+    resolution: {integrity: sha512-bNqdxTQTxmLbomSmlkZFz8L6B/feQ2HHzw4L2zY7Ecp2XffYAZq2uzdWDdxJHJFbEvqd+SRuluJso0P8+xPdbw==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/signature-v4@5.4.6':
-    resolution: {integrity: sha512-Ojg4B6oIDlIr1R86xCDJt1zJWnYa0VINmqdjfe9qxWjdRivHalZ3iSlQgVqYbW0MdpFOC5XfHEWsnbmdnpIILQ==}
+  '@smithy/signature-v4@5.6.4':
+    resolution: {integrity: sha512-B89bpf2t/y/wia6LZ+4JfHXYQT9PnVftsH05rgJKKIStS7r/4XSs9HOjtPoLtgcA6HCW9jVqX5DBbq7E0PAkiQ==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/types@4.14.3':
-    resolution: {integrity: sha512-YupL0ZWmFtJexUN2cHzkvvF/b9pKrtAIfT1o7/oY/Ppu8IYeZ+lDPM5vZdQJaSeA132dJCqojjGC9NhXeF71VQ==}
+  '@smithy/types@4.16.1':
+    resolution: {integrity: sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/util-buffer-from@2.2.0':
@@ -2914,13 +2722,6 @@ packages:
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
 
-  fast-xml-builder@1.2.0:
-    resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
-
-  fast-xml-parser@5.7.3:
-    resolution: {integrity: sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==}
-    hasBin: true
-
   fb-watchman@2.0.2:
     resolution: {integrity: sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==}
 
@@ -3800,10 +3601,6 @@ packages:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
 
-  path-expression-matcher@1.5.0:
-    resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
-    engines: {node: '>=14.0.0'}
-
   path-is-absolute@1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
     engines: {node: '>=0.10.0'}
@@ -4088,9 +3885,6 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
-  strnum@2.3.0:
-    resolution: {integrity: sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==}
-
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -4306,10 +4100,6 @@ packages:
     resolution: {integrity: sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
-  xml-naming@0.1.0:
-    resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==}
-    engines: {node: '>=16.0.0'}
-
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
@@ -4346,20 +4136,20 @@ snapshots:
   '@aws-crypto/crc32@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.13
+      '@aws-sdk/types': 3.974.0
       tslib: 2.8.1
 
   '@aws-crypto/crc32c@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.13
+      '@aws-sdk/types': 3.974.0
       tslib: 2.8.1
 
   '@aws-crypto/sha1-browser@5.2.0':
     dependencies:
       '@aws-crypto/supports-web-crypto': 5.2.0
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.13
+      '@aws-sdk/types': 3.974.0
       '@aws-sdk/util-locate-window': 3.965.7
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
@@ -4369,7 +4159,7 @@ snapshots:
       '@aws-crypto/sha256-js': 5.2.0
       '@aws-crypto/supports-web-crypto': 5.2.0
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.13
+      '@aws-sdk/types': 3.974.0
       '@aws-sdk/util-locate-window': 3.965.7
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
@@ -4377,7 +4167,7 @@ snapshots:
   '@aws-crypto/sha256-js@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.13
+      '@aws-sdk/types': 3.974.0
       tslib: 2.8.1
 
   '@aws-crypto/supports-web-crypto@5.2.0':
@@ -4386,7 +4176,7 @@ snapshots:
 
   '@aws-crypto/util@5.2.0':
     dependencies:
-      '@aws-sdk/types': 3.973.12
+      '@aws-sdk/types': 3.974.0
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
 
@@ -4395,251 +4185,251 @@ snapshots:
       '@aws-crypto/crc32': 5.2.0
       '@aws-crypto/crc32c': 5.2.0
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/core': 3.974.22
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.3
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/client-cloudwatch-logs@3.1073.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.22
-      '@aws-sdk/credential-provider-node': 3.972.57
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.24.6
-      '@smithy/fetch-http-handler': 5.4.6
-      '@smithy/node-http-handler': 4.7.7
-      '@smithy/types': 4.14.3
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/credential-provider-node': 3.972.67
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.3
+      '@smithy/fetch-http-handler': 5.6.5
+      '@smithy/node-http-handler': 4.9.5
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/client-cloudwatch@3.1064.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.19
-      '@aws-sdk/credential-provider-node': 3.972.53
-      '@aws-sdk/types': 3.973.12
-      '@smithy/core': 3.24.6
-      '@smithy/fetch-http-handler': 5.4.6
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/credential-provider-node': 3.972.67
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.3
+      '@smithy/fetch-http-handler': 5.6.5
       '@smithy/middleware-compression': 4.4.6
-      '@smithy/node-http-handler': 4.7.7
-      '@smithy/types': 4.14.3
+      '@smithy/node-http-handler': 4.9.5
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/client-docdb@3.1075.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.23
-      '@aws-sdk/credential-provider-node': 3.972.58
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/credential-provider-node': 3.972.67
       '@aws-sdk/middleware-sdk-rds': 3.972.37
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.24.6
-      '@smithy/fetch-http-handler': 5.4.6
-      '@smithy/node-http-handler': 4.7.7
-      '@smithy/types': 4.14.3
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.3
+      '@smithy/fetch-http-handler': 5.6.5
+      '@smithy/node-http-handler': 4.9.5
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/client-dynamodb@3.1073.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.22
-      '@aws-sdk/credential-provider-node': 3.972.57
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/credential-provider-node': 3.972.67
       '@aws-sdk/dynamodb-codec': 3.973.22
       '@aws-sdk/middleware-endpoint-discovery': 3.972.19
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.24.6
-      '@smithy/fetch-http-handler': 5.4.6
-      '@smithy/node-http-handler': 4.7.7
-      '@smithy/types': 4.14.3
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.3
+      '@smithy/fetch-http-handler': 5.6.5
+      '@smithy/node-http-handler': 4.9.5
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/client-ec2@3.1064.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.19
-      '@aws-sdk/credential-provider-node': 3.972.53
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/credential-provider-node': 3.972.67
       '@aws-sdk/middleware-sdk-ec2': 3.972.33
-      '@aws-sdk/types': 3.973.12
-      '@smithy/core': 3.24.6
-      '@smithy/fetch-http-handler': 5.4.6
-      '@smithy/node-http-handler': 4.7.7
-      '@smithy/types': 4.14.3
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.3
+      '@smithy/fetch-http-handler': 5.6.5
+      '@smithy/node-http-handler': 4.9.5
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/client-efs@3.1073.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.22
-      '@aws-sdk/credential-provider-node': 3.972.57
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.24.6
-      '@smithy/fetch-http-handler': 5.4.6
-      '@smithy/node-http-handler': 4.7.7
-      '@smithy/types': 4.14.3
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/credential-provider-node': 3.972.67
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.3
+      '@smithy/fetch-http-handler': 5.6.5
+      '@smithy/node-http-handler': 4.9.5
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/client-elastic-load-balancing-v2@3.1064.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.19
-      '@aws-sdk/credential-provider-node': 3.972.53
-      '@aws-sdk/types': 3.973.12
-      '@smithy/core': 3.24.6
-      '@smithy/fetch-http-handler': 5.4.6
-      '@smithy/node-http-handler': 4.7.7
-      '@smithy/types': 4.14.3
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/credential-provider-node': 3.972.67
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.3
+      '@smithy/fetch-http-handler': 5.6.5
+      '@smithy/node-http-handler': 4.9.5
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/client-elasticache@3.1073.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.22
-      '@aws-sdk/credential-provider-node': 3.972.57
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.24.6
-      '@smithy/fetch-http-handler': 5.4.6
-      '@smithy/node-http-handler': 4.7.7
-      '@smithy/types': 4.14.3
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/credential-provider-node': 3.972.67
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.3
+      '@smithy/fetch-http-handler': 5.6.5
+      '@smithy/node-http-handler': 4.9.5
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/client-fsx@3.1075.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.23
-      '@aws-sdk/credential-provider-node': 3.972.58
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.24.6
-      '@smithy/fetch-http-handler': 5.4.6
-      '@smithy/node-http-handler': 4.7.7
-      '@smithy/types': 4.14.3
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/credential-provider-node': 3.972.67
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.3
+      '@smithy/fetch-http-handler': 5.6.5
+      '@smithy/node-http-handler': 4.9.5
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/client-kafka@3.1075.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.23
-      '@aws-sdk/credential-provider-node': 3.972.58
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.24.6
-      '@smithy/fetch-http-handler': 5.4.6
-      '@smithy/node-http-handler': 4.7.7
-      '@smithy/types': 4.14.3
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/credential-provider-node': 3.972.67
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.3
+      '@smithy/fetch-http-handler': 5.6.5
+      '@smithy/node-http-handler': 4.9.5
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/client-kinesis@3.1075.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.23
-      '@aws-sdk/credential-provider-node': 3.972.58
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.24.6
-      '@smithy/fetch-http-handler': 5.4.6
-      '@smithy/node-http-handler': 4.7.7
-      '@smithy/types': 4.14.3
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/credential-provider-node': 3.972.67
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.3
+      '@smithy/fetch-http-handler': 5.6.5
+      '@smithy/node-http-handler': 4.9.5
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/client-lambda@3.1073.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.22
-      '@aws-sdk/credential-provider-node': 3.972.57
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.24.6
-      '@smithy/fetch-http-handler': 5.4.6
-      '@smithy/node-http-handler': 4.7.7
-      '@smithy/types': 4.14.3
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/credential-provider-node': 3.972.67
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.3
+      '@smithy/fetch-http-handler': 5.6.5
+      '@smithy/node-http-handler': 4.9.5
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/client-mq@3.1075.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.23
-      '@aws-sdk/credential-provider-node': 3.972.58
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.24.6
-      '@smithy/fetch-http-handler': 5.4.6
-      '@smithy/node-http-handler': 4.7.7
-      '@smithy/types': 4.14.3
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/credential-provider-node': 3.972.67
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.3
+      '@smithy/fetch-http-handler': 5.6.5
+      '@smithy/node-http-handler': 4.9.5
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/client-neptune@3.1075.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.23
-      '@aws-sdk/credential-provider-node': 3.972.58
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/credential-provider-node': 3.972.67
       '@aws-sdk/middleware-sdk-rds': 3.972.37
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.24.6
-      '@smithy/fetch-http-handler': 5.4.6
-      '@smithy/node-http-handler': 4.7.7
-      '@smithy/types': 4.14.3
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.3
+      '@smithy/fetch-http-handler': 5.6.5
+      '@smithy/node-http-handler': 4.9.5
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/client-opensearch@3.1075.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.23
-      '@aws-sdk/credential-provider-node': 3.972.58
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.24.6
-      '@smithy/fetch-http-handler': 5.4.6
-      '@smithy/node-http-handler': 4.7.7
-      '@smithy/types': 4.14.3
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/credential-provider-node': 3.972.67
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.3
+      '@smithy/fetch-http-handler': 5.6.5
+      '@smithy/node-http-handler': 4.9.5
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/client-pricing@3.1070.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.21
-      '@aws-sdk/credential-provider-node': 3.972.56
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.24.6
-      '@smithy/fetch-http-handler': 5.4.6
-      '@smithy/node-http-handler': 4.7.7
-      '@smithy/types': 4.14.3
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/credential-provider-node': 3.972.67
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.3
+      '@smithy/fetch-http-handler': 5.6.5
+      '@smithy/node-http-handler': 4.9.5
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/client-rds@3.1064.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.19
-      '@aws-sdk/credential-provider-node': 3.972.53
-      '@aws-sdk/middleware-sdk-rds': 3.972.33
-      '@aws-sdk/types': 3.973.12
-      '@smithy/core': 3.24.6
-      '@smithy/fetch-http-handler': 5.4.6
-      '@smithy/node-http-handler': 4.7.7
-      '@smithy/types': 4.14.3
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/credential-provider-node': 3.972.67
+      '@aws-sdk/middleware-sdk-rds': 3.972.37
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.3
+      '@smithy/fetch-http-handler': 5.6.5
+      '@smithy/node-http-handler': 4.9.5
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/client-redshift@3.1075.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.23
-      '@aws-sdk/credential-provider-node': 3.972.58
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.24.6
-      '@smithy/fetch-http-handler': 5.4.6
-      '@smithy/node-http-handler': 4.7.7
-      '@smithy/types': 4.14.3
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/credential-provider-node': 3.972.67
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.3
+      '@smithy/fetch-http-handler': 5.6.5
+      '@smithy/node-http-handler': 4.9.5
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/client-s3@3.1073.0':
@@ -4647,525 +4437,159 @@ snapshots:
       '@aws-crypto/sha1-browser': 5.2.0
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.22
-      '@aws-sdk/credential-provider-node': 3.972.57
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/credential-provider-node': 3.972.67
       '@aws-sdk/middleware-flexible-checksums': 3.974.32
       '@aws-sdk/middleware-sdk-s3': 3.972.53
-      '@aws-sdk/signature-v4-multi-region': 3.996.35
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.24.6
-      '@smithy/fetch-http-handler': 5.4.6
-      '@smithy/node-http-handler': 4.7.7
-      '@smithy/types': 4.14.3
+      '@aws-sdk/signature-v4-multi-region': 3.996.39
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.3
+      '@smithy/fetch-http-handler': 5.6.5
+      '@smithy/node-http-handler': 4.9.5
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/client-sqs@3.1075.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/credential-provider-node': 3.972.67
+      '@aws-sdk/middleware-sdk-sqs': 3.972.35
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.3
+      '@smithy/fetch-http-handler': 5.6.5
+      '@smithy/node-http-handler': 4.9.5
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/client-sts@3.1068.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.20
-      '@aws-sdk/credential-provider-node': 3.972.55
-      '@aws-sdk/signature-v4-multi-region': 3.996.34
-      '@aws-sdk/types': 3.973.12
-      '@smithy/core': 3.24.6
-      '@smithy/fetch-http-handler': 5.4.6
-      '@smithy/node-http-handler': 4.7.7
-      '@smithy/types': 4.14.3
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/credential-provider-node': 3.972.67
+      '@aws-sdk/signature-v4-multi-region': 3.996.39
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.3
+      '@smithy/fetch-http-handler': 5.6.5
+      '@smithy/node-http-handler': 4.9.5
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/client-workspaces@3.1075.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.23
-      '@aws-sdk/credential-provider-node': 3.972.58
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.24.6
-      '@smithy/fetch-http-handler': 5.4.6
-      '@smithy/node-http-handler': 4.7.7
-      '@smithy/types': 4.14.3
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/credential-provider-node': 3.972.67
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.3
+      '@smithy/fetch-http-handler': 5.6.5
+      '@smithy/node-http-handler': 4.9.5
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
-  '@aws-sdk/core@3.974.19':
+  '@aws-sdk/core@3.975.1':
     dependencies:
-      '@aws-sdk/types': 3.973.12
-      '@aws-sdk/xml-builder': 3.972.29
-      '@aws/lambda-invoke-store': 0.2.4
-      '@smithy/core': 3.24.6
-      '@smithy/signature-v4': 5.4.6
-      '@smithy/types': 4.14.3
+      '@aws-sdk/types': 3.974.0
+      '@aws-sdk/xml-builder': 3.972.34
+      '@aws/lambda-invoke-store': 0.3.0
+      '@smithy/core': 3.29.3
+      '@smithy/signature-v4': 5.6.4
+      '@smithy/types': 4.16.1
       bowser: 2.14.1
       tslib: 2.8.1
 
-  '@aws-sdk/core@3.974.20':
+  '@aws-sdk/credential-provider-env@3.972.57':
     dependencies:
-      '@aws-sdk/types': 3.973.12
-      '@aws-sdk/xml-builder': 3.972.29
-      '@aws/lambda-invoke-store': 0.2.4
-      '@smithy/core': 3.24.6
-      '@smithy/signature-v4': 5.4.6
-      '@smithy/types': 4.14.3
-      bowser: 2.14.1
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.3
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
-  '@aws-sdk/core@3.974.21':
+  '@aws-sdk/credential-provider-http@3.972.59':
     dependencies:
-      '@aws-sdk/types': 3.973.13
-      '@aws-sdk/xml-builder': 3.972.30
-      '@aws/lambda-invoke-store': 0.2.4
-      '@smithy/core': 3.24.6
-      '@smithy/signature-v4': 5.4.6
-      '@smithy/types': 4.14.3
-      bowser: 2.14.1
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.3
+      '@smithy/fetch-http-handler': 5.6.5
+      '@smithy/node-http-handler': 4.9.5
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
-  '@aws-sdk/core@3.974.22':
+  '@aws-sdk/credential-provider-ini@3.973.1':
     dependencies:
-      '@aws-sdk/types': 3.973.13
-      '@aws-sdk/xml-builder': 3.972.30
-      '@aws/lambda-invoke-store': 0.2.4
-      '@smithy/core': 3.24.6
-      '@smithy/signature-v4': 5.4.6
-      '@smithy/types': 4.14.3
-      bowser: 2.14.1
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/credential-provider-env': 3.972.57
+      '@aws-sdk/credential-provider-http': 3.972.59
+      '@aws-sdk/credential-provider-login': 3.972.63
+      '@aws-sdk/credential-provider-process': 3.972.57
+      '@aws-sdk/credential-provider-sso': 3.973.1
+      '@aws-sdk/credential-provider-web-identity': 3.972.63
+      '@aws-sdk/nested-clients': 3.997.31
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.3
+      '@smithy/credential-provider-imds': 4.4.8
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
-  '@aws-sdk/core@3.974.23':
+  '@aws-sdk/credential-provider-login@3.972.63':
     dependencies:
-      '@aws-sdk/types': 3.973.13
-      '@aws-sdk/xml-builder': 3.972.31
-      '@aws/lambda-invoke-store': 0.2.4
-      '@smithy/core': 3.24.6
-      '@smithy/signature-v4': 5.4.6
-      '@smithy/types': 4.14.3
-      bowser: 2.14.1
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/nested-clients': 3.997.31
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.3
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-env@3.972.45':
+  '@aws-sdk/credential-provider-node@3.972.67':
     dependencies:
-      '@aws-sdk/core': 3.974.19
-      '@aws-sdk/types': 3.973.12
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
+      '@aws-sdk/credential-provider-env': 3.972.57
+      '@aws-sdk/credential-provider-http': 3.972.59
+      '@aws-sdk/credential-provider-ini': 3.973.1
+      '@aws-sdk/credential-provider-process': 3.972.57
+      '@aws-sdk/credential-provider-sso': 3.973.1
+      '@aws-sdk/credential-provider-web-identity': 3.972.63
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.3
+      '@smithy/credential-provider-imds': 4.4.8
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-env@3.972.46':
+  '@aws-sdk/credential-provider-process@3.972.57':
     dependencies:
-      '@aws-sdk/core': 3.974.20
-      '@aws-sdk/types': 3.973.12
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.3
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-env@3.972.47':
+  '@aws-sdk/credential-provider-sso@3.973.1':
     dependencies:
-      '@aws-sdk/core': 3.974.21
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/nested-clients': 3.997.31
+      '@aws-sdk/token-providers': 3.1083.0
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.3
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-env@3.972.48':
+  '@aws-sdk/credential-provider-web-identity@3.972.63':
     dependencies:
-      '@aws-sdk/core': 3.974.22
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-env@3.972.49':
-    dependencies:
-      '@aws-sdk/core': 3.974.23
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-http@3.972.47':
-    dependencies:
-      '@aws-sdk/core': 3.974.19
-      '@aws-sdk/types': 3.973.12
-      '@smithy/core': 3.24.6
-      '@smithy/fetch-http-handler': 5.4.6
-      '@smithy/node-http-handler': 4.7.7
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-http@3.972.48':
-    dependencies:
-      '@aws-sdk/core': 3.974.20
-      '@aws-sdk/types': 3.973.12
-      '@smithy/core': 3.24.6
-      '@smithy/fetch-http-handler': 5.4.6
-      '@smithy/node-http-handler': 4.7.7
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-http@3.972.49':
-    dependencies:
-      '@aws-sdk/core': 3.974.21
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.24.6
-      '@smithy/fetch-http-handler': 5.4.6
-      '@smithy/node-http-handler': 4.7.7
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-http@3.972.50':
-    dependencies:
-      '@aws-sdk/core': 3.974.22
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.24.6
-      '@smithy/fetch-http-handler': 5.4.6
-      '@smithy/node-http-handler': 4.7.7
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-http@3.972.51':
-    dependencies:
-      '@aws-sdk/core': 3.974.23
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.24.6
-      '@smithy/fetch-http-handler': 5.4.6
-      '@smithy/node-http-handler': 4.7.7
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-ini@3.972.51':
-    dependencies:
-      '@aws-sdk/core': 3.974.19
-      '@aws-sdk/credential-provider-env': 3.972.45
-      '@aws-sdk/credential-provider-http': 3.972.47
-      '@aws-sdk/credential-provider-login': 3.972.50
-      '@aws-sdk/credential-provider-process': 3.972.45
-      '@aws-sdk/credential-provider-sso': 3.972.50
-      '@aws-sdk/credential-provider-web-identity': 3.972.50
-      '@aws-sdk/nested-clients': 3.997.18
-      '@aws-sdk/types': 3.973.12
-      '@smithy/core': 3.24.6
-      '@smithy/credential-provider-imds': 4.3.8
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-ini@3.972.53':
-    dependencies:
-      '@aws-sdk/core': 3.974.20
-      '@aws-sdk/credential-provider-env': 3.972.46
-      '@aws-sdk/credential-provider-http': 3.972.48
-      '@aws-sdk/credential-provider-login': 3.972.52
-      '@aws-sdk/credential-provider-process': 3.972.46
-      '@aws-sdk/credential-provider-sso': 3.972.52
-      '@aws-sdk/credential-provider-web-identity': 3.972.52
-      '@aws-sdk/nested-clients': 3.997.20
-      '@aws-sdk/types': 3.973.12
-      '@smithy/core': 3.24.6
-      '@smithy/credential-provider-imds': 4.3.8
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-ini@3.972.54':
-    dependencies:
-      '@aws-sdk/core': 3.974.21
-      '@aws-sdk/credential-provider-env': 3.972.47
-      '@aws-sdk/credential-provider-http': 3.972.49
-      '@aws-sdk/credential-provider-login': 3.972.53
-      '@aws-sdk/credential-provider-process': 3.972.47
-      '@aws-sdk/credential-provider-sso': 3.972.53
-      '@aws-sdk/credential-provider-web-identity': 3.972.53
-      '@aws-sdk/nested-clients': 3.997.21
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.24.6
-      '@smithy/credential-provider-imds': 4.3.8
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-ini@3.972.55':
-    dependencies:
-      '@aws-sdk/core': 3.974.22
-      '@aws-sdk/credential-provider-env': 3.972.48
-      '@aws-sdk/credential-provider-http': 3.972.50
-      '@aws-sdk/credential-provider-login': 3.972.54
-      '@aws-sdk/credential-provider-process': 3.972.48
-      '@aws-sdk/credential-provider-sso': 3.972.54
-      '@aws-sdk/credential-provider-web-identity': 3.972.54
-      '@aws-sdk/nested-clients': 3.997.22
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.24.6
-      '@smithy/credential-provider-imds': 4.3.8
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-ini@3.972.56':
-    dependencies:
-      '@aws-sdk/core': 3.974.23
-      '@aws-sdk/credential-provider-env': 3.972.49
-      '@aws-sdk/credential-provider-http': 3.972.51
-      '@aws-sdk/credential-provider-login': 3.972.55
-      '@aws-sdk/credential-provider-process': 3.972.49
-      '@aws-sdk/credential-provider-sso': 3.972.55
-      '@aws-sdk/credential-provider-web-identity': 3.972.55
-      '@aws-sdk/nested-clients': 3.997.23
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.24.6
-      '@smithy/credential-provider-imds': 4.3.8
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-login@3.972.50':
-    dependencies:
-      '@aws-sdk/core': 3.974.22
-      '@aws-sdk/nested-clients': 3.997.18
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-login@3.972.52':
-    dependencies:
-      '@aws-sdk/core': 3.974.22
-      '@aws-sdk/nested-clients': 3.997.20
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-login@3.972.53':
-    dependencies:
-      '@aws-sdk/core': 3.974.22
-      '@aws-sdk/nested-clients': 3.997.21
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-login@3.972.54':
-    dependencies:
-      '@aws-sdk/core': 3.974.22
-      '@aws-sdk/nested-clients': 3.997.22
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-login@3.972.55':
-    dependencies:
-      '@aws-sdk/core': 3.974.23
-      '@aws-sdk/nested-clients': 3.997.23
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-node@3.972.53':
-    dependencies:
-      '@aws-sdk/credential-provider-env': 3.972.45
-      '@aws-sdk/credential-provider-http': 3.972.47
-      '@aws-sdk/credential-provider-ini': 3.972.51
-      '@aws-sdk/credential-provider-process': 3.972.45
-      '@aws-sdk/credential-provider-sso': 3.972.50
-      '@aws-sdk/credential-provider-web-identity': 3.972.50
-      '@aws-sdk/types': 3.973.12
-      '@smithy/core': 3.24.6
-      '@smithy/credential-provider-imds': 4.3.8
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-node@3.972.55':
-    dependencies:
-      '@aws-sdk/credential-provider-env': 3.972.46
-      '@aws-sdk/credential-provider-http': 3.972.48
-      '@aws-sdk/credential-provider-ini': 3.972.53
-      '@aws-sdk/credential-provider-process': 3.972.46
-      '@aws-sdk/credential-provider-sso': 3.972.52
-      '@aws-sdk/credential-provider-web-identity': 3.972.52
-      '@aws-sdk/types': 3.973.12
-      '@smithy/core': 3.24.6
-      '@smithy/credential-provider-imds': 4.3.8
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-node@3.972.56':
-    dependencies:
-      '@aws-sdk/credential-provider-env': 3.972.47
-      '@aws-sdk/credential-provider-http': 3.972.49
-      '@aws-sdk/credential-provider-ini': 3.972.54
-      '@aws-sdk/credential-provider-process': 3.972.47
-      '@aws-sdk/credential-provider-sso': 3.972.53
-      '@aws-sdk/credential-provider-web-identity': 3.972.53
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.24.6
-      '@smithy/credential-provider-imds': 4.3.8
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-node@3.972.57':
-    dependencies:
-      '@aws-sdk/credential-provider-env': 3.972.48
-      '@aws-sdk/credential-provider-http': 3.972.50
-      '@aws-sdk/credential-provider-ini': 3.972.55
-      '@aws-sdk/credential-provider-process': 3.972.48
-      '@aws-sdk/credential-provider-sso': 3.972.54
-      '@aws-sdk/credential-provider-web-identity': 3.972.54
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.24.6
-      '@smithy/credential-provider-imds': 4.3.8
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-node@3.972.58':
-    dependencies:
-      '@aws-sdk/credential-provider-env': 3.972.49
-      '@aws-sdk/credential-provider-http': 3.972.51
-      '@aws-sdk/credential-provider-ini': 3.972.56
-      '@aws-sdk/credential-provider-process': 3.972.49
-      '@aws-sdk/credential-provider-sso': 3.972.55
-      '@aws-sdk/credential-provider-web-identity': 3.972.55
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.24.6
-      '@smithy/credential-provider-imds': 4.3.8
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-process@3.972.45':
-    dependencies:
-      '@aws-sdk/core': 3.974.19
-      '@aws-sdk/types': 3.973.12
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-process@3.972.46':
-    dependencies:
-      '@aws-sdk/core': 3.974.20
-      '@aws-sdk/types': 3.973.12
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-process@3.972.47':
-    dependencies:
-      '@aws-sdk/core': 3.974.21
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-process@3.972.48':
-    dependencies:
-      '@aws-sdk/core': 3.974.22
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-process@3.972.49':
-    dependencies:
-      '@aws-sdk/core': 3.974.23
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-sso@3.972.50':
-    dependencies:
-      '@aws-sdk/core': 3.974.19
-      '@aws-sdk/nested-clients': 3.997.18
-      '@aws-sdk/token-providers': 3.1064.0
-      '@aws-sdk/types': 3.973.12
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-sso@3.972.52':
-    dependencies:
-      '@aws-sdk/core': 3.974.20
-      '@aws-sdk/nested-clients': 3.997.20
-      '@aws-sdk/token-providers': 3.1066.0
-      '@aws-sdk/types': 3.973.12
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-sso@3.972.53':
-    dependencies:
-      '@aws-sdk/core': 3.974.21
-      '@aws-sdk/nested-clients': 3.997.21
-      '@aws-sdk/token-providers': 3.1069.0
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-sso@3.972.54':
-    dependencies:
-      '@aws-sdk/core': 3.974.22
-      '@aws-sdk/nested-clients': 3.997.22
-      '@aws-sdk/token-providers': 3.1071.0
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-sso@3.972.55':
-    dependencies:
-      '@aws-sdk/core': 3.974.23
-      '@aws-sdk/nested-clients': 3.997.23
-      '@aws-sdk/token-providers': 3.1074.0
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-web-identity@3.972.50':
-    dependencies:
-      '@aws-sdk/core': 3.974.19
-      '@aws-sdk/nested-clients': 3.997.18
-      '@aws-sdk/types': 3.973.12
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-web-identity@3.972.52':
-    dependencies:
-      '@aws-sdk/core': 3.974.20
-      '@aws-sdk/nested-clients': 3.997.20
-      '@aws-sdk/types': 3.973.12
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-web-identity@3.972.53':
-    dependencies:
-      '@aws-sdk/core': 3.974.21
-      '@aws-sdk/nested-clients': 3.997.21
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-web-identity@3.972.54':
-    dependencies:
-      '@aws-sdk/core': 3.974.22
-      '@aws-sdk/nested-clients': 3.997.22
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-web-identity@3.972.55':
-    dependencies:
-      '@aws-sdk/core': 3.974.23
-      '@aws-sdk/nested-clients': 3.997.23
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/nested-clients': 3.997.31
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.3
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/dynamodb-codec@3.973.22':
     dependencies:
-      '@aws-sdk/core': 3.974.22
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
+      '@aws-sdk/core': 3.975.1
+      '@smithy/core': 3.29.3
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/endpoint-cache@3.972.8':
@@ -5176,9 +4600,9 @@ snapshots:
   '@aws-sdk/middleware-endpoint-discovery@3.972.19':
     dependencies:
       '@aws-sdk/endpoint-cache': 3.972.8
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.3
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/middleware-flexible-checksums@3.974.32':
@@ -5188,203 +4612,80 @@ snapshots:
 
   '@aws-sdk/middleware-sdk-ec2@3.972.33':
     dependencies:
-      '@aws-sdk/core': 3.974.19
-      '@aws-sdk/types': 3.973.12
-      '@smithy/core': 3.24.6
-      '@smithy/signature-v4': 5.4.6
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@aws-sdk/middleware-sdk-rds@3.972.33':
-    dependencies:
-      '@aws-sdk/core': 3.974.19
-      '@aws-sdk/types': 3.973.12
-      '@smithy/core': 3.24.6
-      '@smithy/signature-v4': 5.4.6
-      '@smithy/types': 4.14.3
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.3
+      '@smithy/signature-v4': 5.6.4
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/middleware-sdk-rds@3.972.37':
     dependencies:
-      '@aws-sdk/core': 3.974.23
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.24.6
-      '@smithy/signature-v4': 5.4.6
-      '@smithy/types': 4.14.3
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.3
+      '@smithy/signature-v4': 5.6.4
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/middleware-sdk-s3@3.972.53':
     dependencies:
-      '@aws-sdk/core': 3.974.22
-      '@aws-sdk/signature-v4-multi-region': 3.996.35
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/signature-v4-multi-region': 3.996.39
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.3
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
-  '@aws-sdk/nested-clients@3.997.18':
+  '@aws-sdk/middleware-sdk-sqs@3.972.35':
     dependencies:
-      '@aws-crypto/sha256-browser': 5.2.0
-      '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.22
-      '@aws-sdk/signature-v4-multi-region': 3.996.33
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.24.6
-      '@smithy/fetch-http-handler': 5.4.6
-      '@smithy/node-http-handler': 4.7.7
-      '@smithy/types': 4.14.3
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.3
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
-  '@aws-sdk/nested-clients@3.997.20':
+  '@aws-sdk/nested-clients@3.997.31':
     dependencies:
-      '@aws-crypto/sha256-browser': 5.2.0
-      '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.22
-      '@aws-sdk/signature-v4-multi-region': 3.996.34
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.24.6
-      '@smithy/fetch-http-handler': 5.4.6
-      '@smithy/node-http-handler': 4.7.7
-      '@smithy/types': 4.14.3
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/signature-v4-multi-region': 3.996.39
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.3
+      '@smithy/fetch-http-handler': 5.6.5
+      '@smithy/node-http-handler': 4.9.5
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
-  '@aws-sdk/nested-clients@3.997.21':
+  '@aws-sdk/signature-v4-multi-region@3.996.39':
     dependencies:
-      '@aws-crypto/sha256-browser': 5.2.0
-      '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.22
-      '@aws-sdk/signature-v4-multi-region': 3.996.35
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.24.6
-      '@smithy/fetch-http-handler': 5.4.6
-      '@smithy/node-http-handler': 4.7.7
-      '@smithy/types': 4.14.3
+      '@aws-sdk/types': 3.974.0
+      '@smithy/signature-v4': 5.6.4
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
-  '@aws-sdk/nested-clients@3.997.22':
+  '@aws-sdk/token-providers@3.1083.0':
     dependencies:
-      '@aws-crypto/sha256-browser': 5.2.0
-      '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.22
-      '@aws-sdk/signature-v4-multi-region': 3.996.35
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.24.6
-      '@smithy/fetch-http-handler': 5.4.6
-      '@smithy/node-http-handler': 4.7.7
-      '@smithy/types': 4.14.3
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/nested-clients': 3.997.31
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.3
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
-  '@aws-sdk/nested-clients@3.997.23':
+  '@aws-sdk/types@3.974.0':
     dependencies:
-      '@aws-crypto/sha256-browser': 5.2.0
-      '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.23
-      '@aws-sdk/signature-v4-multi-region': 3.996.35
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.24.6
-      '@smithy/fetch-http-handler': 5.4.6
-      '@smithy/node-http-handler': 4.7.7
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@aws-sdk/signature-v4-multi-region@3.996.33':
-    dependencies:
-      '@aws-sdk/types': 3.973.13
-      '@smithy/signature-v4': 5.4.6
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@aws-sdk/signature-v4-multi-region@3.996.34':
-    dependencies:
-      '@aws-sdk/types': 3.973.12
-      '@smithy/signature-v4': 5.4.6
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@aws-sdk/signature-v4-multi-region@3.996.35':
-    dependencies:
-      '@aws-sdk/types': 3.973.13
-      '@smithy/signature-v4': 5.4.6
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@aws-sdk/token-providers@3.1064.0':
-    dependencies:
-      '@aws-sdk/core': 3.974.22
-      '@aws-sdk/nested-clients': 3.997.18
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@aws-sdk/token-providers@3.1066.0':
-    dependencies:
-      '@aws-sdk/core': 3.974.22
-      '@aws-sdk/nested-clients': 3.997.20
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@aws-sdk/token-providers@3.1069.0':
-    dependencies:
-      '@aws-sdk/core': 3.974.22
-      '@aws-sdk/nested-clients': 3.997.21
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@aws-sdk/token-providers@3.1071.0':
-    dependencies:
-      '@aws-sdk/core': 3.974.22
-      '@aws-sdk/nested-clients': 3.997.22
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@aws-sdk/token-providers@3.1074.0':
-    dependencies:
-      '@aws-sdk/core': 3.974.23
-      '@aws-sdk/nested-clients': 3.997.23
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@aws-sdk/types@3.973.12':
-    dependencies:
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@aws-sdk/types@3.973.13':
-    dependencies:
-      '@smithy/types': 4.14.3
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/util-locate-window@3.965.7':
     dependencies:
       tslib: 2.8.1
 
-  '@aws-sdk/xml-builder@3.972.29':
+  '@aws-sdk/xml-builder@3.972.34':
     dependencies:
-      '@smithy/types': 4.14.3
-      fast-xml-parser: 5.7.3
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
-  '@aws-sdk/xml-builder@3.972.30':
-    dependencies:
-      '@smithy/types': 4.14.3
-      fast-xml-parser: 5.7.3
-      tslib: 2.8.1
-
-  '@aws-sdk/xml-builder@3.972.31':
-    dependencies:
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
-  '@aws/lambda-invoke-store@0.2.4': {}
+  '@aws/lambda-invoke-store@0.3.0': {}
 
   '@babel/code-frame@7.29.7':
     dependencies:
@@ -6198,7 +5499,6 @@ snapshots:
     dependencies:
       '@emnapi/wasi-threads': 1.2.1
       tslib: 2.8.1
-    optional: true
 
   '@emnapi/core@1.4.5':
     dependencies:
@@ -6208,7 +5508,6 @@ snapshots:
   '@emnapi/runtime@1.10.0':
     dependencies:
       tslib: 2.8.1
-    optional: true
 
   '@emnapi/runtime@1.4.5':
     dependencies:
@@ -6221,7 +5520,6 @@ snapshots:
   '@emnapi/wasi-threads@1.2.1':
     dependencies:
       tslib: 2.8.1
-    optional: true
 
   '@esbuild/aix-ppc64@0.27.7':
     optional: true
@@ -6715,8 +6013,8 @@ snapshots:
 
   '@napi-rs/wasm-runtime@0.2.4':
     dependencies:
-      '@emnapi/core': 1.4.5
-      '@emnapi/runtime': 1.4.5
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
       '@tybys/wasm-util': 0.9.0
 
   '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
@@ -6725,8 +6023,6 @@ snapshots:
       '@emnapi/runtime': 1.10.0
       '@tybys/wasm-util': 0.10.2
     optional: true
-
-  '@nodable/entities@2.1.1': {}
 
   '@nx/devkit@22.7.5(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))':
     dependencies:
@@ -7042,22 +6338,21 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
-  '@smithy/core@3.24.6':
+  '@smithy/core@3.29.3':
     dependencies:
-      '@aws-crypto/crc32': 5.2.0
-      '@smithy/types': 4.14.3
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
-  '@smithy/credential-provider-imds@4.3.8':
+  '@smithy/credential-provider-imds@4.4.8':
     dependencies:
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
+      '@smithy/core': 3.29.3
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
-  '@smithy/fetch-http-handler@5.4.6':
+  '@smithy/fetch-http-handler@5.6.5':
     dependencies:
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
+      '@smithy/core': 3.29.3
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@smithy/is-array-buffer@2.2.0':
@@ -7066,24 +6361,24 @@ snapshots:
 
   '@smithy/middleware-compression@4.4.6':
     dependencies:
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
+      '@smithy/core': 3.29.3
+      '@smithy/types': 4.16.1
       fflate: 0.8.1
       tslib: 2.8.1
 
-  '@smithy/node-http-handler@4.7.7':
+  '@smithy/node-http-handler@4.9.5':
     dependencies:
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
+      '@smithy/core': 3.29.3
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
-  '@smithy/signature-v4@5.4.6':
+  '@smithy/signature-v4@5.6.4':
     dependencies:
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
+      '@smithy/core': 3.29.3
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
-  '@smithy/types@4.14.3':
+  '@smithy/types@4.16.1':
     dependencies:
       tslib: 2.8.1
 
@@ -7952,7 +7247,7 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
-      hasown: 2.0.2
+      hasown: 2.0.4
 
   esbuild@0.27.7:
     optionalDependencies:
@@ -8120,18 +7415,6 @@ snapshots:
     dependencies:
       fast-string-width: 3.0.2
 
-  fast-xml-builder@1.2.0:
-    dependencies:
-      path-expression-matcher: 1.5.0
-      xml-naming: 0.1.0
-
-  fast-xml-parser@5.7.3:
-    dependencies:
-      '@nodable/entities': 2.1.1
-      fast-xml-builder: 1.2.0
-      path-expression-matcher: 1.5.0
-      strnum: 2.3.0
-
   fb-watchman@2.0.2:
     dependencies:
       bser: 2.1.1
@@ -8201,7 +7484,7 @@ snapshots:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
-      hasown: 2.0.2
+      hasown: 2.0.4
       mime-types: 2.1.35
 
   fs-constants@1.0.0: {}
@@ -8229,7 +7512,7 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       has-symbols: 1.1.0
-      hasown: 2.0.2
+      hasown: 2.0.4
       math-intrinsics: 1.1.0
 
   get-package-type@0.1.0: {}
@@ -9477,8 +8760,6 @@ snapshots:
 
   path-exists@4.0.0: {}
 
-  path-expression-matcher@1.5.0: {}
-
   path-is-absolute@1.0.1: {}
 
   path-key@3.1.1: {}
@@ -9755,8 +9036,6 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
-  strnum@2.3.0: {}
-
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -10000,8 +9279,6 @@ snapshots:
     dependencies:
       imurmurhash: 0.1.4
       signal-exit: 4.1.0
-
-  xml-naming@0.1.0: {}
 
   y18n@5.0.8: {}
 

--- a/scripts/capture-contract-fixtures.mjs
+++ b/scripts/capture-contract-fixtures.mjs
@@ -101,6 +101,7 @@ const captures = [
   { kind: 'kinesis-provisioned-idle-stream', scanner: new adapter.AwsKinesisIdleScanner(pricing, ACCOUNT_ID, new domain.KinesisProvisionedIdleStreamPolicy(po)) },
   { kind: 'vpn-connection-idle', scanner: new adapter.AwsVpnConnectionIdleScanner(pricing, ACCOUNT_ID, new domain.VpnConnectionIdlePolicy(po)) },
   { kind: 'transit-gateway-idle-attachment', scanner: new adapter.AwsTransitGatewayIdleScanner(pricing, ACCOUNT_ID, new domain.TransitGatewayIdleAttachmentPolicy(po)) },
+  { kind: 'lambda-loggroup-orphaned', scanner: new adapter.AwsLambdaLogGroupOrphanedScanner(pricing, ACCOUNT_ID, new domain.LambdaLogGroupOrphanedPolicy(po)) },
 ];
 
 // Recorder on the shared SDK Client base class (every @aws-sdk/client-*

--- a/scripts/e2e-localstack.mjs
+++ b/scripts/e2e-localstack.mjs
@@ -5,10 +5,13 @@
 // directly) — this one is free, repeatable, and exercises the whole CLI
 // (config loading, composition root, formatters, exit codes).
 //
-// Scope: 16 of 29 scanners (see docs/adr/0002-localstack-e2e-scope.md,
-// docs/adr/0036-ec2-underutilized-excluded-from-localstack-e2e.md, and
+// Scope: 17 of 32 scanners (see docs/adr/0002-localstack-e2e-scope.md,
+// docs/adr/0036-ec2-underutilized-excluded-from-localstack-e2e.md,
 // docs/adr/0040-localstack-bumped-4-14-0-cloudwatch-fixed.md for the Phase 5.5
-// additions). Not wired into lint/test/build/typecheck — opt-in via:
+// additions, and docs/adr/0065-vertical-premium-scanners-phase-6-strategy.md
+// for the Phase 6.1 addition; aurora-serverless-overprovisioned from Phase 6.2
+// is not RDS-LocalStack-coverable, see scripts/capture-contract-fixtures.mjs).
+// Not wired into lint/test/build/typecheck — opt-in via:
 //
 //   pnpm nx run cli:e2e-localstack
 //
@@ -52,6 +55,11 @@ const EXPECTED_KINDS = [
   'kinesis-provisioned-idle-stream',
   'vpn-connection-idle',
   'transit-gateway-idle-attachment',
+  // Phase 6.1 (ADR-0065): needs no CloudWatch metric (function deleted, log
+  // group left behind is directly observable via Describe*/List* alone) —
+  // hard-required like the rest. sqs-dlq-abandoned is NOT here; see
+  // scripts/seed-localstack.mjs for why.
+  'lambda-loggroup-orphaned',
 ];
 // Historically partial LocalStack Community support — a missed finding here
 // is a warning, not a hard failure (see docs/adr/0002-localstack-e2e-scope.md).

--- a/scripts/seed-localstack.mjs
+++ b/scripts/seed-localstack.mjs
@@ -19,6 +19,19 @@
 //   LocalStack-mockable.
 // All 8 stay on `scripts/verify-against-aws.mjs` manual verification.
 //
+// Phase 6.1 (ADR-0065): lambda-loggroup-orphaned IS seeded below — its waste
+// condition (function deleted, log group left behind) needs no CloudWatch
+// metric at all, unlike sqs-dlq-abandoned below.
+//
+// Phase 6.1 (ADR-0065): sqs-dlq-abandoned is excluded from this harness too,
+// for a different reason than the ones above. Unlike the idle scanners
+// (waste = missing CloudWatch datapoint, which LocalStack's un-pushed
+// metrics already satisfy for free), this scanner needs a real, large
+// `ApproximateAgeOfOldestMessage` value to trigger a finding — nobody
+// publishes that metric in a freshly seeded LocalStack queue, so a missing
+// datapoint resolves to age 0 (not waste), the opposite of what every other
+// CloudWatch-backed scanner here relies on. Stays on manual verification.
+//
 // CloudWatch-backed scanners (nat-gateway, ebs-idle, lambda-underutilized,
 // dynamodb-overprovisioned, and the 3 seeded above) need no explicit metric
 // seeding: every scanner treats a missing datapoint as zero usage
@@ -68,7 +81,7 @@ import {
   CreateTargetGroupCommand,
 } from '@aws-sdk/client-elastic-load-balancing-v2';
 import { CreateBucketCommand } from '@aws-sdk/client-s3';
-import { CreateFunctionCommand } from '@aws-sdk/client-lambda';
+import { CreateFunctionCommand, DeleteFunctionCommand } from '@aws-sdk/client-lambda';
 import { CreateTableCommand } from '@aws-sdk/client-dynamodb';
 import { CreateLogGroupCommand } from '@aws-sdk/client-cloudwatch-logs';
 
@@ -254,6 +267,25 @@ export async function seedLocalstack(regionCode) {
   await seed('log-group', async () => {
     await logs.send(new CreateLogGroupCommand({ logGroupName: `/cloudrift-e2e/${Date.now()}` }));
     // No PutRetentionPolicy call — missing retention is the waste condition.
+  });
+
+  // Phase 6.1 (ADR-0065): the log group is created explicitly rather than
+  // relying on Lambda's own lazy auto-creation on first invocation (whose
+  // timing/behavior isn't guaranteed identical on LocalStack), so the
+  // "function deleted, log group left behind" condition is deterministic.
+  await seed('lambda-loggroup-orphaned', async () => {
+    const functionName = `cloudrift-e2e-orphan-${Date.now()}`;
+    await lambda.send(
+      new CreateFunctionCommand({
+        FunctionName: functionName,
+        Runtime: 'nodejs18.x',
+        Role: FAKE_LAMBDA_ROLE_ARN,
+        Handler: 'index.handler',
+        Code: { ZipFile: buildLambdaZip() },
+      }),
+    );
+    await logs.send(new CreateLogGroupCommand({ logGroupName: `/aws/lambda/${functionName}` }));
+    await lambda.send(new DeleteFunctionCommand({ FunctionName: functionName }));
   });
 
   await seed('s3-no-lifecycle', async () => {


### PR DESCRIPTION
# Vertical Premium Scanners Initiative (ADR-0065) — Phase 6.1 + 6.2

Questa fase aggiunge le verticali **serverless orphans** e **Aurora Serverless v2**. Vengono introdotti **3 nuovi scanner**, portando il numero di `ResourceKind` da 29 a 32.

## Nuovi Scanner Introdotti

*   **`sqs-dlq-abandoned`**
    *   **Descrizione:** Identifica le code SQS di tipo dead-letter (DLQ) che contengono messaggi non elaborati e fermi da tempo (DLQ stagnanti).
    *   **Impatto economico:** Rilevazione orientata all'igiene del codice/infrastruttura ($0).
*   **`lambda-loggroup-orphaned`**
    *   **Descrizione:** Identifica i gruppi di log di CloudWatch sotto il percorso `/aws/lambda/` la cui funzione Lambda di riferimento non esiste più.
    *   **Nota:** Si distingue dallo scanner di log-group già esistente, il quale segnala la mancanza di retention su gruppi di log ancora associati a funzioni attive.
*   **`aurora-serverless-overprovisioned`**
    *   **Descrizione:** Identifica i cluster Aurora Serverless v2 il cui limite minimo di ACU (*Min ACU floor*) è impostato ben al di sopra del picco di utilizzo reale ed è sempre attivo.
    *   **Nota economica:** Prezzo statico flat basato su ACU-ora, in conformità con ADR-0037.

---

## Modifiche e Documentazione Incluse

### Architectural Decision Records (ADR)
*   **`docs/adr/0065`** – Strategia della Fase 6: piano completo su 5 verticali e 8 scanner (*serverless orphans, Aurora Serverless, SageMaker, Dev/PR ghost environments, EKS*), eseguito in modo incrementale. Questa PR rilascia le prime due verticali.
*   **`docs/adr/0066`** – Gli scanner per EKS utilizzer展望 esclusivamente le API di AWS; gli approcci basati su `kubeconfig` sono stati posticipati.
*   **`docs/adr/0067`** – Note previsionali sugli indizi architetturali per la conformità SaaS (nessuna implementazione in questa fase).

### Configurazione e Pricing
*   Modificato `cloudrift.config.json` con l'aggiunta di `thresholds.auroraMinAcuUtilizationPercent` (valore predefinito: `50`).
*   Aggiunti i contract fixtures e la copertura *scanner-contract* per tutti e 3 i nuovi scanner.
*   Aggiornato `pricing/prices.json` con le tariffe ACU-ora di Aurora Serverless.

### Note di Architettura
Nessuna modifica a `AnalyzeCloudWasteUseCase`, alla struttura dei DTO o al meccanismo di dispatch del presenter. I nuovi tipi di risorse si inseriscono direttamente nello `switch` esaustivo esistente e nel registro dichiarativo degli scanner (ADR-0043).

---

## Test Plan

### Test Automatici
```bash
pnpm nx run-many -t typecheck test lint --projects=cloud-cost-domain,cloud-cost-infrastructure-aws-adapter,cli
```
*   **Esito:** Tutti i controlli sono superati con successo (verdi).
*   **Dettaglio:** Superati `208 + 334 + 68` test.

### Test Manuali
È stata eseguita una scansione manuale sia su LocalStack sia su un ambiente AWS reale utilizzando il comando:
```bash
--scanners sqs-dlq-abandoned lambda-loggroup-orphaned aurora-serverless-overprovisioned
```
*   **Esito:** Risultati (*findings*) e stime dei costi verificati e corretti.
