### PR TITLE
feat(global): new scanner Ghost Environments (ADR-0065) — Phase 6.4

### DIFF
--- a/apps/cli/src/commands/scanner-registry.ts
+++ b/apps/cli/src/commands/scanner-registry.ts
@@ -35,6 +35,7 @@ import {
   SageMakerNotebookIdlePolicy,
   SageMakerEndpointIdlePolicy,
   SageMakerTrainingOrphanedPolicy,
+  EnvironmentGhostPolicy,
   RESOURCE_KINDS,
 } from 'cloud-cost-domain';
 import type {
@@ -79,6 +80,7 @@ import {
   AwsSageMakerNotebookIdleScanner,
   AwsSageMakerEndpointIdleScanner,
   AwsSageMakerTrainingOrphanedScanner,
+  AwsEnvironmentGhostScanner,
 } from 'cloud-cost-infrastructure-aws-adapter';
 import type { AwsPricingApiAdapter } from 'cloud-cost-infrastructure-aws-adapter';
 import type { CloudriftConfig } from '../config/cloudrift.config';
@@ -278,6 +280,21 @@ export const ALWAYS_ON_SCANNERS: ScannerRegistration<ScannerBuildContext>[] = [
     kind: 'sagemaker-training-orphaned',
     create: (ctx) =>
       new AwsSageMakerTrainingOrphanedScanner(ctx.pricing, ctx.accountId, new SageMakerTrainingOrphanedPolicy(ctx.policyOptions)),
+  },
+  // Phase 6.4 (ADR-0065): Dev/PR ghost environments. $0 hygiene flag (see
+  // EnvironmentGhost), so always-on like sqs-dlq-abandoned/eni-orphaned.
+  {
+    kind: 'environment-ghost',
+    create: (ctx) => {
+      const inactivityDays = ctx.config.environmentDetection?.inactivityDays ?? 7;
+      return new AwsEnvironmentGhostScanner(
+        ctx.accountId,
+        new EnvironmentGhostPolicy(ctx.policyOptions, inactivityDays),
+        ctx.config.environmentDetection?.tagKeys,
+        ctx.config.environmentDetection?.namingPatterns,
+        inactivityDays,
+      );
+    },
   },
 ];
 

--- a/apps/cli/src/config/cloudrift.config.ts
+++ b/apps/cli/src/config/cloudrift.config.ts
@@ -60,6 +60,15 @@ export interface CloudriftConfig {
     /** Maximum CPU (%) below which an InService SageMaker notebook instance is "idle". Default 2. */
     sagemakerNotebookCpuPercent?: number;
   };
+  /** Dev/PR "ghost environment" detection (environment-ghost scanner). */
+  environmentDetection?: {
+    /** Tag keys checked, in priority order, to group resources into an environment. Default ["Environment", "env", "branch"]. */
+    tagKeys?: string[];
+    /** Glob naming-convention fallback for resources with no matching tag. Default ["*-pr-*", "*-preview-*", "*-dev-*", "*-feat-*"]. */
+    namingPatterns?: string[];
+    /** Days every resource in a group must look inactive before the group is "ghost". Default 7. */
+    inactivityDays?: number;
+  };
 }
 
 export class ConfigError extends DomainError {
@@ -124,6 +133,13 @@ const configSchema = z.object({
       dynamoCapacityUtilizationPercent: percent.optional(),
       auroraMinAcuUtilizationPercent: percent.optional(),
       sagemakerNotebookCpuPercent: percent.optional(),
+    })
+    .optional(),
+  environmentDetection: z
+    .object({
+      tagKeys: z.array(z.string().min(1)).optional(),
+      namingPatterns: z.array(z.string().min(1)).optional(),
+      inactivityDays: z.number().int().nonnegative().optional(),
     })
     .optional(),
 }) satisfies z.ZodType<CloudriftConfig, unknown>;

--- a/apps/cli/src/formatters/resource-presenters.ts
+++ b/apps/cli/src/formatters/resource-presenters.ts
@@ -407,6 +407,21 @@ export const presenters: PresenterMap = {
     recommend: (m) =>
       `Delete orphaned SageMaker model ${m.id} in ${m.region.code} — not referenced by any endpoint config (verify it isn't a rollback/backup target first)`,
   },
+  'environment-ghost': {
+    title: 'Dev/PR Environments — Ghost (all evaluated resources inactive, hygiene, no direct cost)',
+    head: ['Environment', 'Region', 'Method', 'Resources', 'Types', 'Last Activity'],
+    colWidths: [130, 65, 75, 65, 130, 84, 90],
+    row: (e) => [
+      e.environmentName,
+      e.region.code,
+      e.detectionMethod,
+      `${e.resourceCount}`,
+      e.resourceTypes.join(', '),
+      day(e.lastActivityTimestamp),
+    ],
+    recommend: (e) =>
+      `Review ghost environment "${e.environmentName}" in ${e.region.code} — ${e.wasteReason} (verify before deleting)`,
+  },
 };
 
 /**
@@ -481,6 +496,7 @@ export function rowFor(finding: AnyResourceEntity): string[] {
     case 'sagemaker-notebook-idle': return presenters['sagemaker-notebook-idle'].row(finding);
     case 'sagemaker-endpoint-idle': return presenters['sagemaker-endpoint-idle'].row(finding);
     case 'sagemaker-training-orphaned': return presenters['sagemaker-training-orphaned'].row(finding);
+    case 'environment-ghost': return presenters['environment-ghost'].row(finding);
   }
 }
 
@@ -522,5 +538,6 @@ export function recommendFor(finding: AnyResourceEntity): string {
     case 'sagemaker-notebook-idle': return presenters['sagemaker-notebook-idle'].recommend(finding);
     case 'sagemaker-endpoint-idle': return presenters['sagemaker-endpoint-idle'].recommend(finding);
     case 'sagemaker-training-orphaned': return presenters['sagemaker-training-orphaned'].recommend(finding);
+    case 'environment-ghost': return presenters['environment-ghost'].recommend(finding);
   }
 }

--- a/libs/cloud-cost/domain/src/entities/environment-ghost.entity.ts
+++ b/libs/cloud-cost/domain/src/entities/environment-ghost.entity.ts
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+import { Entity } from 'shared-kernel';
+import { AwsRegion } from '../value-objects/aws-region.value-object';
+import { CostEstimate } from '../value-objects/cost-estimate.value-object';
+import type { WastedResource } from '../wasted-resource';
+
+export type EnvironmentGhostDetectionMethod = 'tag' | 'naming-pattern';
+
+export interface EnvironmentGhostProps {
+  environmentName: string;
+  detectionMethod: EnvironmentGhostDetectionMethod;
+  /** Resources evaluated for this group — only EC2 instances, RDS instances, Lambda functions and load balancers count (see AwsEnvironmentGhostScanner). */
+  resourceCount: number;
+  /** Unique resource-type labels present in the group, e.g. ['ec2-instance', 'rds-instance']. */
+  resourceTypes: string[];
+  inactiveResourceCount: number;
+  /** Most recent per-resource activity proxy across the group (stoppedSince/lastModified/createdTime) — the signal the grace period is measured from. */
+  lastActivityTimestamp: Date;
+  region: AwsRegion;
+  accountId: string;
+  tags: Record<string, string>;
+}
+
+/**
+ * A group of resources (correlated by an environment/branch tag, or as a
+ * fallback by an ephemeral-environment naming convention) that all look
+ * inactive at once — the signature of a Dev/PR environment nobody tore
+ * down. Evaluates only EC2 instances, RDS instances, Lambda functions and
+ * load balancers (ADR-0065 Phase 6.4): the resource types cloudrift already
+ * has a reliable state/idle signal for, out of the many types an ephemeral
+ * environment could contain. Other tagged/named resources in the same group
+ * (S3, DynamoDB, ...) are out of scope for this iteration. No direct AWS
+ * cost is attached to the group itself — like `eni-orphaned`, this is a
+ * hygiene flag pointing at where to look, not a priced saving.
+ */
+export class EnvironmentGhost extends Entity<string> implements WastedResource {
+  private readonly props: Readonly<EnvironmentGhostProps>;
+
+  constructor(props: EnvironmentGhostProps) {
+    super(props.environmentName);
+    this.props = this.deepFreeze({ ...props });
+  }
+
+  get environmentName(): string { return this.props.environmentName; }
+  get detectionMethod(): EnvironmentGhostDetectionMethod { return this.props.detectionMethod; }
+  get resourceCount(): number { return this.props.resourceCount; }
+  get resourceTypes(): string[] { return this.props.resourceTypes; }
+  get inactiveResourceCount(): number { return this.props.inactiveResourceCount; }
+  get lastActivityTimestamp(): Date { return this.props.lastActivityTimestamp; }
+  get region(): AwsRegion { return this.props.region; }
+  get accountId(): string { return this.props.accountId; }
+  get tags(): Record<string, string> { return this.props.tags; }
+
+  get detectedAt(): Date { return new Date(); }
+  get kind(): 'environment-ghost' { return 'environment-ghost'; }
+  get wasteReason(): string {
+    return `${this.props.resourceCount} resource(s) inactive (${this.props.detectionMethod}), last activity ${this.props.lastActivityTimestamp.toISOString().split('T')[0]}`;
+  }
+
+  get costEstimate(): CostEstimate {
+    return CostEstimate.of(0, 'Ghost environment (hygiene flag, no direct cost — verify before deleting)');
+  }
+}

--- a/libs/cloud-cost/domain/src/group-by-kind.ts
+++ b/libs/cloud-cost/domain/src/group-by-kind.ts
@@ -35,6 +35,7 @@ import type { AuroraServerlessOverprovisioned } from './entities/aurora-serverle
 import type { SageMakerNotebookIdle } from './entities/sagemaker-notebook-idle.entity';
 import type { SageMakerEndpointIdle } from './entities/sagemaker-endpoint-idle.entity';
 import type { SageMakerTrainingOrphaned } from './entities/sagemaker-training-orphaned.entity';
+import type { EnvironmentGhost } from './entities/environment-ghost.entity';
 
 /**
  * Map kind → concrete entity. Allows consumers (formatters, frontend)
@@ -76,6 +77,7 @@ export interface ResourceKindMap {
   'sagemaker-notebook-idle': SageMakerNotebookIdle;
   'sagemaker-endpoint-idle': SageMakerEndpointIdle;
   'sagemaker-training-orphaned': SageMakerTrainingOrphaned;
+  'environment-ghost': EnvironmentGhost;
 }
 
 export type FindingsByKind = {

--- a/libs/cloud-cost/domain/src/index.ts
+++ b/libs/cloud-cost/domain/src/index.ts
@@ -87,6 +87,8 @@ export { SageMakerEndpointIdle } from './entities/sagemaker-endpoint-idle.entity
 export type { SageMakerEndpointIdleProps } from './entities/sagemaker-endpoint-idle.entity';
 export { SageMakerTrainingOrphaned } from './entities/sagemaker-training-orphaned.entity';
 export type { SageMakerTrainingOrphanedProps } from './entities/sagemaker-training-orphaned.entity';
+export { EnvironmentGhost } from './entities/environment-ghost.entity';
+export type { EnvironmentGhostProps, EnvironmentGhostDetectionMethod } from './entities/environment-ghost.entity';
 
 // Value Objects
 export { AwsRegion, InvalidAwsRegionError } from './value-objects/aws-region.value-object';
@@ -137,6 +139,7 @@ export {
   SageMakerNotebookIdlePolicy,
   SageMakerEndpointIdlePolicy,
   SageMakerTrainingOrphanedPolicy,
+  EnvironmentGhostPolicy,
 } from './policies/resource-waste-policies';
 
 // Outbound Ports

--- a/libs/cloud-cost/domain/src/policies/resource-waste-policies.ts
+++ b/libs/cloud-cost/domain/src/policies/resource-waste-policies.ts
@@ -35,6 +35,7 @@ import type { AuroraServerlessOverprovisioned } from '../entities/aurora-serverl
 import type { SageMakerNotebookIdle } from '../entities/sagemaker-notebook-idle.entity';
 import type { SageMakerEndpointIdle } from '../entities/sagemaker-endpoint-idle.entity';
 import type { SageMakerTrainingOrphaned } from '../entities/sagemaker-training-orphaned.entity';
+import type { EnvironmentGhost } from '../entities/environment-ghost.entity';
 
 export class EbsVolumeWastePolicy extends WastePolicy<EbsVolume> {
   protected judge(volume: EbsVolume, now: Date): WasteVerdict {
@@ -449,6 +450,29 @@ export class SageMakerTrainingOrphanedPolicy extends WastePolicy<SageMakerTraini
       return notWaste(`created less than ${this.minAgeDays}d ago`);
     }
     return waste('not referenced by any endpoint config');
+  }
+}
+
+export class EnvironmentGhostPolicy extends WastePolicy<EnvironmentGhost> {
+  /** inactivityDays: how long every resource in the group must have looked inactive before the group is "ghost". Default 7 — distinct from `minAgeDays`, which the base class's grace period does not apply here (there is no single "creation date" for a heterogeneous group). */
+  constructor(options: WastePolicyOptions = {}, private readonly inactivityDays = 7) {
+    super(options);
+  }
+
+  protected judge(env: EnvironmentGhost, now: Date): WasteVerdict {
+    if (env.resourceCount === 0) {
+      return notWaste('no evaluable resources in group (unsupported types only)');
+    }
+    if (env.inactiveResourceCount < env.resourceCount) {
+      return notWaste('at least one resource still active');
+    }
+    const idleDays = this.ageInDays(env.lastActivityTimestamp, now);
+    if (idleDays < this.inactivityDays) {
+      return notWaste(`inactive ${idleDays.toFixed(1)}d, within ${this.inactivityDays}d threshold`);
+    }
+    return waste(
+      `${env.resourceCount} resource(s) (${env.resourceTypes.join(', ')}) inactive for ${idleDays.toFixed(1)}d`,
+    );
   }
 }
 

--- a/libs/cloud-cost/domain/src/wasted-resource.ts
+++ b/libs/cloud-cost/domain/src/wasted-resource.ts
@@ -38,6 +38,7 @@ export const RESOURCE_KINDS = [
   'sagemaker-notebook-idle',
   'sagemaker-endpoint-idle',
   'sagemaker-training-orphaned',
+  'environment-ghost',
 ] as const;
 
 export type ResourceKind = (typeof RESOURCE_KINDS)[number];
@@ -133,6 +134,14 @@ export const RESOURCE_KIND_META: Record<ResourceKind, ResourceKindMeta> = {
     label: 'SageMaker Models (orphaned, no endpoint)',
     category: 'optimization',
     estimated: true,
+  },
+  // Phase 6.4 (ADR-0065): Dev/PR ghost environments. $0 hygiene flag, same
+  // rationale as 'eni-orphaned'/'sqs-dlq-abandoned' — no direct AWS cost,
+  // signals a group of resources nobody tore down.
+  'environment-ghost': {
+    label: 'Dev/PR Environments (ghost, all resources inactive)',
+    category: 'waste',
+    estimated: false,
   },
 };
 

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/index.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/index.ts
@@ -46,6 +46,7 @@ export type { SageMakerNotebookInstancePricingSource } from './scanners/aws-sage
 export { AwsSageMakerEndpointIdleScanner } from './scanners/aws-sagemaker-endpoint-idle.scanner';
 export type { SageMakerEndpointInstancePricingSource } from './scanners/aws-sagemaker-endpoint-idle.scanner';
 export { AwsSageMakerTrainingOrphanedScanner } from './scanners/aws-sagemaker-training-orphaned.scanner';
+export { AwsEnvironmentGhostScanner } from './scanners/aws-environment-ghost.scanner';
 export { AwsAdapterError } from './errors/aws-adapter.error';
 export {
   StaticPriceTableAdapter,

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-environment-ghost.scanner.spec.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-environment-ghost.scanner.spec.ts
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: Apache-2.0
+import { ResourceGroupsTaggingAPIClient } from '@aws-sdk/client-resource-groups-tagging-api';
+import { EC2Client } from '@aws-sdk/client-ec2';
+import { RDSClient } from '@aws-sdk/client-rds';
+import { LambdaClient } from '@aws-sdk/client-lambda';
+import { ElasticLoadBalancingV2Client } from '@aws-sdk/client-elastic-load-balancing-v2';
+import { CloudWatchClient } from '@aws-sdk/client-cloudwatch';
+import { AwsEnvironmentGhostScanner } from './aws-environment-ghost.scanner';
+import { AwsRegion, EnvironmentGhostPolicy } from 'cloud-cost-domain';
+import { AwsAdapterError } from '../errors/aws-adapter.error';
+
+jest.mock('@aws-sdk/client-resource-groups-tagging-api');
+jest.mock('@aws-sdk/client-ec2');
+jest.mock('@aws-sdk/client-rds');
+jest.mock('@aws-sdk/client-lambda');
+jest.mock('@aws-sdk/client-elastic-load-balancing-v2');
+jest.mock('@aws-sdk/client-cloudwatch');
+
+const mockTaggingSend = jest.fn();
+const mockEc2Send = jest.fn();
+const mockRdsSend = jest.fn();
+const mockLambdaSend = jest.fn();
+const mockElbSend = jest.fn();
+const mockCwSend = jest.fn();
+const destroyMocks = {
+  tagging: jest.fn(),
+  ec2: jest.fn(),
+  rds: jest.fn(),
+  lambda: jest.fn(),
+  elb: jest.fn(),
+  cw: jest.fn(),
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (ResourceGroupsTaggingAPIClient as jest.Mock).mockImplementation(() => ({ send: mockTaggingSend, destroy: destroyMocks.tagging }));
+  (EC2Client as jest.Mock).mockImplementation(() => ({ send: mockEc2Send, destroy: destroyMocks.ec2 }));
+  (RDSClient as jest.Mock).mockImplementation(() => ({ send: mockRdsSend, destroy: destroyMocks.rds }));
+  (LambdaClient as jest.Mock).mockImplementation(() => ({ send: mockLambdaSend, destroy: destroyMocks.lambda }));
+  (ElasticLoadBalancingV2Client as jest.Mock).mockImplementation(() => ({ send: mockElbSend, destroy: destroyMocks.elb }));
+  (CloudWatchClient as jest.Mock).mockImplementation(() => ({ send: mockCwSend, destroy: destroyMocks.cw }));
+  // Safe "nothing here" defaults; tests override the calls they care about.
+  mockTaggingSend.mockResolvedValue({ ResourceTagMappingList: [] });
+  mockEc2Send.mockResolvedValue({ Reservations: [] });
+  mockRdsSend.mockResolvedValue({ DBInstances: [] });
+  mockLambdaSend.mockResolvedValue({ Functions: [] });
+  mockElbSend.mockResolvedValue({ LoadBalancers: [] });
+});
+
+const region = AwsRegion.create('us-east-1');
+const OLD_TRANSITION = 'User initiated (2020-01-15 08:00:00 GMT)';
+
+function scanner(inactivityDays = 0, tagKeys = ['Environment']) {
+  return new AwsEnvironmentGhostScanner(
+    '000000000000',
+    new EnvironmentGhostPolicy({}, inactivityDays),
+    tagKeys,
+    undefined,
+    inactivityDays,
+  );
+}
+
+describe('AwsEnvironmentGhostScanner', () => {
+  it('exposes its resource kind', () => {
+    expect(scanner().kind).toBe('environment-ghost');
+  });
+
+  it('reports a tagged environment whose only resource (EC2) is stopped', async () => {
+    mockTaggingSend.mockResolvedValueOnce({
+      ResourceTagMappingList: [
+        { ResourceARN: 'arn:aws:ec2:us-east-1:000000000000:instance/i-0abc', Tags: [{ Key: 'Environment', Value: 'pr-1234' }] },
+      ],
+    });
+    mockEc2Send.mockResolvedValueOnce({
+      Reservations: [
+        {
+          Instances: [
+            {
+              InstanceId: 'i-0abc',
+              State: { Name: 'stopped' },
+              StateTransitionReason: OLD_TRANSITION,
+              LaunchTime: new Date('2019-01-01'),
+              Tags: [{ Key: 'Environment', Value: 'pr-1234' }],
+            },
+          ],
+        },
+      ],
+    });
+
+    const result = await scanner().scan(region);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.map((f) => f.id)).toEqual(['pr-1234']);
+    expect(result.value[0].costEstimate.monthlyCostUsd).toBe(0);
+  });
+
+  it('does not report a group where at least one resource is still active', async () => {
+    mockTaggingSend.mockResolvedValueOnce({
+      ResourceTagMappingList: [
+        { ResourceARN: 'arn:aws:ec2:us-east-1:000000000000:instance/i-0abc', Tags: [{ Key: 'Environment', Value: 'pr-1234' }] },
+        { ResourceARN: 'arn:aws:rds:us-east-1:000000000000:db:pr-1234-db', Tags: [{ Key: 'Environment', Value: 'pr-1234' }] },
+      ],
+    });
+    mockEc2Send.mockResolvedValueOnce({
+      Reservations: [
+        {
+          Instances: [
+            { InstanceId: 'i-0abc', State: { Name: 'stopped' }, StateTransitionReason: OLD_TRANSITION, LaunchTime: new Date('2019-01-01'), Tags: [] },
+          ],
+        },
+      ],
+    });
+    mockRdsSend.mockResolvedValueOnce({
+      DBInstances: [
+        { DBInstanceArn: 'arn:aws:rds:us-east-1:000000000000:db:pr-1234-db', DBInstanceIdentifier: 'pr-1234-db', DBInstanceStatus: 'available', InstanceCreateTime: new Date('2019-01-01') },
+      ],
+    });
+
+    const result = await scanner().scan(region);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toHaveLength(0);
+  });
+
+  it('falls back to naming-pattern detection for an untagged resource matching a configured pattern', async () => {
+    mockEc2Send.mockResolvedValueOnce({
+      Reservations: [
+        {
+          Instances: [
+            {
+              InstanceId: 'i-0xyz',
+              State: { Name: 'stopped' },
+              StateTransitionReason: OLD_TRANSITION,
+              LaunchTime: new Date('2019-01-01'),
+              Tags: [{ Key: 'Name', Value: 'myapp-pr-5678-web' }],
+            },
+          ],
+        },
+      ],
+    });
+
+    const result = await scanner().scan(region);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.map((f) => f.id)).toEqual(['myapp-pr-5678-web']);
+    expect((result.value[0] as unknown as { detectionMethod: string }).detectionMethod).toBe('naming-pattern');
+  });
+
+  it('does not report a group within the inactivity grace period', async () => {
+    mockTaggingSend.mockResolvedValueOnce({
+      ResourceTagMappingList: [
+        { ResourceARN: 'arn:aws:ec2:us-east-1:000000000000:instance/i-0abc', Tags: [{ Key: 'Environment', Value: 'pr-1234' }] },
+      ],
+    });
+    mockEc2Send.mockResolvedValueOnce({
+      Reservations: [
+        {
+          Instances: [
+            {
+              InstanceId: 'i-0abc',
+              State: { Name: 'stopped' },
+              StateTransitionReason: `User initiated (${new Date().toISOString().slice(0, 19).replace('T', ' ')} GMT)`,
+              LaunchTime: new Date(),
+              Tags: [],
+            },
+          ],
+        },
+      ],
+    });
+
+    const result = await scanner(7).scan(region);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toHaveLength(0);
+  });
+
+  it('returns Result.fail wrapping AwsAdapterError and destroys every client on error', async () => {
+    mockTaggingSend.mockRejectedValueOnce(new Error('boom'));
+
+    const result = await scanner().scan(region);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect((result.error as AwsAdapterError).service).toBe('ResourceGroupsTaggingAPI');
+    expect(destroyMocks.tagging).toHaveBeenCalledTimes(1);
+    expect(destroyMocks.ec2).toHaveBeenCalledTimes(1);
+    expect(destroyMocks.rds).toHaveBeenCalledTimes(1);
+    expect(destroyMocks.lambda).toHaveBeenCalledTimes(1);
+    expect(destroyMocks.elb).toHaveBeenCalledTimes(1);
+    expect(destroyMocks.cw).toHaveBeenCalledTimes(1);
+  });
+});

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-environment-ghost.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-environment-ghost.scanner.ts
@@ -1,0 +1,389 @@
+// SPDX-License-Identifier: Apache-2.0
+import {
+  ResourceGroupsTaggingAPIClient,
+  GetResourcesCommand,
+  type ResourceTagMapping,
+} from '@aws-sdk/client-resource-groups-tagging-api';
+import { EC2Client, DescribeInstancesCommand, type Instance, type Reservation } from '@aws-sdk/client-ec2';
+import { RDSClient, DescribeDBInstancesCommand, type DBInstance } from '@aws-sdk/client-rds';
+import { LambdaClient, ListFunctionsCommand, type FunctionConfiguration } from '@aws-sdk/client-lambda';
+import {
+  ElasticLoadBalancingV2Client,
+  DescribeLoadBalancersCommand,
+  DescribeTargetGroupsCommand,
+  DescribeTargetHealthCommand,
+  type LoadBalancer as AwsLoadBalancer,
+  type TargetGroup,
+} from '@aws-sdk/client-elastic-load-balancing-v2';
+import { CloudWatchClient } from '@aws-sdk/client-cloudwatch';
+import { Result } from 'shared-kernel';
+import type { AwsRegion, WasteScannerPort, WastedResource } from 'cloud-cost-domain';
+import { EnvironmentGhost, EnvironmentGhostPolicy, type WastePolicy } from 'cloud-cost-domain';
+import { AwsAdapterError } from '../errors/aws-adapter.error';
+import { paginate } from '../utils/paginate';
+import { createAwsClientConfig } from '../utils/client-config';
+import { sumMetric, metricWindow } from '../utils/cloudwatch-metrics';
+
+// Only these 4 resource types carry a state/idle signal cloudrift already
+// knows how to read reliably (stopped, invocation count, registered
+// targets). Other tagged/named resource types (S3, DynamoDB, ...) can be
+// part of a ghost environment in principle but are out of scope for this
+// iteration — see the Option A vs B tradeoff recorded for Phase 6.4
+// (ADR-0065): a small, testable allowlist over a generic per-resource-type
+// CloudWatch metric map that would be much larger and harder to verify.
+const ALLOWED_RESOURCE_TYPE_FILTERS = ['ec2:instance', 'rds:db', 'lambda:function', 'elasticloadbalancing:loadbalancer'];
+
+const DEFAULT_TAG_KEYS = ['Environment', 'env', 'branch'];
+const DEFAULT_NAMING_PATTERNS = ['*-pr-*', '*-preview-*', '*-dev-*', '*-feat-*'];
+const DEFAULT_INACTIVITY_DAYS = 7;
+
+type ResourceType = 'ec2-instance' | 'rds-instance' | 'lambda-function' | 'load-balancer';
+
+interface ResourceRef {
+  type: ResourceType;
+  /** EC2: instance ID (DescribeInstances doesn't return an ARN). RDS/Lambda/ELB: the resource's own ARN field, which matches what GetResources returns. */
+  key: string;
+}
+
+interface ResourceActivity {
+  type: ResourceType;
+  active: boolean;
+  /** Proxy for "since when has this resource looked like this" — the best available field per type, same caveats as the single-resource-type policies (e.g. RdsInstanceWastePolicy) that already accept this limitation. */
+  sinceTimestamp: Date;
+}
+
+interface ResourceLists {
+  ec2Instances: Instance[];
+  dbInstances: DBInstance[];
+  functions: FunctionConfiguration[];
+  loadBalancers: AwsLoadBalancer[];
+}
+
+interface ResourceLookups {
+  ec2ById: Map<string, Instance>;
+  rdsByArn: Map<string, DBInstance>;
+  lambdaByArn: Map<string, FunctionConfiguration>;
+  lbByArn: Map<string, AwsLoadBalancer>;
+}
+
+// AWS only reports the stop time inside StateTransitionReason, as a string
+// like "User initiated (2026-06-01 12:34:56 GMT)" — same parsing as
+// AwsEc2InstanceScanner.
+function parseStoppedSince(stateTransitionReason: string | undefined): Date | undefined {
+  const match = stateTransitionReason?.match(/\((.+) GMT\)/);
+  if (!match) return undefined;
+  const parsed = new Date(`${match[1]} UTC`);
+  return Number.isNaN(parsed.getTime()) ? undefined : parsed;
+}
+
+function globToRegExp(pattern: string): RegExp {
+  const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*');
+  return new RegExp(`^${escaped}$`, 'i');
+}
+
+function resourceRefFromArn(arn: string): ResourceRef | undefined {
+  switch (arn.split(':')[2]) {
+    case 'ec2':
+      return { type: 'ec2-instance', key: arn.slice(arn.lastIndexOf('/') + 1) };
+    case 'rds':
+      return { type: 'rds-instance', key: arn };
+    case 'lambda':
+      return { type: 'lambda-function', key: arn };
+    case 'elasticloadbalancing':
+      return { type: 'load-balancer', key: arn };
+    default:
+      return undefined;
+  }
+}
+
+interface TagGroup {
+  refs: ResourceRef[];
+  tags: Record<string, string>;
+}
+
+/**
+ * Detects groups of resources — correlated by an environment/branch tag, or
+ * (fallback, for untagged resources) an ephemeral-environment naming
+ * convention — that all look inactive at once: the signature of a Dev/PR
+ * environment nobody tore down. See `EnvironmentGhost` for the resource-type
+ * scope and cost-model rationale.
+ */
+export class AwsEnvironmentGhostScanner implements WasteScannerPort {
+  readonly kind = 'environment-ghost' as const;
+
+  constructor(
+    private readonly accountId = 'unknown',
+    private readonly policy: WastePolicy<EnvironmentGhost> = new EnvironmentGhostPolicy(),
+    private readonly tagKeys: string[] = DEFAULT_TAG_KEYS,
+    private readonly namingPatterns: string[] = DEFAULT_NAMING_PATTERNS,
+    private readonly inactivityDays = DEFAULT_INACTIVITY_DAYS,
+  ) {}
+
+  async scan(region: AwsRegion): Promise<Result<WastedResource[]>> {
+    const taggingClient = new ResourceGroupsTaggingAPIClient({ ...createAwsClientConfig(), region: region.code });
+    const ec2Client = new EC2Client({ ...createAwsClientConfig(), region: region.code });
+    const rdsClient = new RDSClient({ ...createAwsClientConfig(), region: region.code });
+    const lambdaClient = new LambdaClient({ ...createAwsClientConfig(), region: region.code });
+    const elbClient = new ElasticLoadBalancingV2Client({ ...createAwsClientConfig(), region: region.code });
+    const cwClient = new CloudWatchClient({ ...createAwsClientConfig(), region: region.code });
+
+    try {
+      const [ec2Instances, dbInstances, functions, loadBalancers] = await Promise.all([
+        this.listEc2Instances(ec2Client),
+        this.listRdsInstances(rdsClient),
+        this.listLambdaFunctions(lambdaClient),
+        this.listLoadBalancers(elbClient),
+      ]);
+      const lists: ResourceLists = { ec2Instances, dbInstances, functions, loadBalancers };
+      const lookups: ResourceLookups = {
+        ec2ById: new Map(ec2Instances.filter((i): i is Instance & { InstanceId: string } => !!i.InstanceId).map((i) => [i.InstanceId, i])),
+        rdsByArn: new Map(dbInstances.filter((d): d is DBInstance & { DBInstanceArn: string } => !!d.DBInstanceArn).map((d) => [d.DBInstanceArn, d])),
+        lambdaByArn: new Map(functions.filter((f): f is FunctionConfiguration & { FunctionArn: string } => !!f.FunctionArn).map((f) => [f.FunctionArn, f])),
+        lbByArn: new Map(loadBalancers.filter((l): l is AwsLoadBalancer & { LoadBalancerArn: string } => !!l.LoadBalancerArn).map((l) => [l.LoadBalancerArn, l])),
+      };
+
+      const tagGroups = await this.groupByTag(taggingClient);
+      const claimed = new Set<string>();
+      for (const group of tagGroups.values()) {
+        for (const ref of group.refs) claimed.add(`${ref.type}:${ref.key}`);
+      }
+      const namingCandidates = this.findNamingPatternCandidates(lists, claimed);
+
+      const now = new Date();
+      const entities: EnvironmentGhost[] = [];
+      for (const [envName, group] of tagGroups) {
+        const entity = await this.buildGroup(envName, 'tag', group.refs, group.tags, region, now, lookups, elbClient, cwClient);
+        if (entity) entities.push(entity);
+      }
+      for (const candidate of namingCandidates) {
+        const entity = await this.buildGroup(candidate.name, 'naming-pattern', [candidate.ref], {}, region, now, lookups, elbClient, cwClient);
+        if (entity) entities.push(entity);
+      }
+
+      return Result.ok(entities.filter((e) => this.policy.evaluate(e, now).isWaste));
+    } catch (err) {
+      return Result.fail(new AwsAdapterError('ResourceGroupsTaggingAPI', err as Error));
+    } finally {
+      taggingClient.destroy();
+      ec2Client.destroy();
+      rdsClient.destroy();
+      lambdaClient.destroy();
+      elbClient.destroy();
+      cwClient.destroy();
+    }
+  }
+
+  private async listEc2Instances(client: EC2Client): Promise<Instance[]> {
+    const reservations = await paginate<Reservation>(async (cursor) => {
+      const r = await client.send(
+        new DescribeInstancesCommand({
+          Filters: [{ Name: 'instance-state-name', Values: ['pending', 'running', 'shutting-down', 'stopping', 'stopped'] }],
+          NextToken: cursor,
+        }),
+      );
+      return { items: r.Reservations ?? [], cursor: r.NextToken };
+    });
+    return reservations.flatMap((r) => r.Instances ?? []);
+  }
+
+  private listRdsInstances(client: RDSClient): Promise<DBInstance[]> {
+    return paginate<DBInstance>(async (cursor) => {
+      const r = await client.send(new DescribeDBInstancesCommand({ Marker: cursor }));
+      return { items: r.DBInstances ?? [], cursor: r.Marker };
+    });
+  }
+
+  private listLambdaFunctions(client: LambdaClient): Promise<FunctionConfiguration[]> {
+    return paginate<FunctionConfiguration>(async (cursor) => {
+      const r = await client.send(new ListFunctionsCommand({ Marker: cursor }));
+      return { items: r.Functions ?? [], cursor: r.NextMarker };
+    });
+  }
+
+  private listLoadBalancers(client: ElasticLoadBalancingV2Client): Promise<AwsLoadBalancer[]> {
+    return paginate<AwsLoadBalancer>(async (cursor) => {
+      const r = await client.send(new DescribeLoadBalancersCommand({ Marker: cursor }));
+      return { items: r.LoadBalancers ?? [], cursor: r.NextMarker };
+    });
+  }
+
+  /**
+   * One `GetResources` call per configured tag key (multiple `TagFilters` in
+   * a single call are ANDed together by AWS, but we want an OR across
+   * `Environment`/`env`/`branch`) — a resource already claimed by an
+   * earlier-priority key is skipped for the later ones, so it never ends up
+   * double-counted across two groups.
+   */
+  private async groupByTag(client: ResourceGroupsTaggingAPIClient): Promise<Map<string, TagGroup>> {
+    const groups = new Map<string, TagGroup>();
+    const claimed = new Set<string>();
+
+    for (const tagKey of this.tagKeys) {
+      const mappings = await paginate<ResourceTagMapping>(async (cursor) => {
+        const r = await client.send(
+          new GetResourcesCommand({
+            TagFilters: [{ Key: tagKey }],
+            ResourceTypeFilters: ALLOWED_RESOURCE_TYPE_FILTERS,
+            PaginationToken: cursor,
+          }),
+        );
+        return { items: r.ResourceTagMappingList ?? [], cursor: r.PaginationToken || undefined };
+      });
+
+      for (const mapping of mappings) {
+        if (!mapping.ResourceARN) continue;
+        const ref = resourceRefFromArn(mapping.ResourceARN);
+        if (!ref) continue;
+        const claimKey = `${ref.type}:${ref.key}`;
+        if (claimed.has(claimKey)) continue;
+        const tagRecord = Object.fromEntries((mapping.Tags ?? []).map((t) => [t.Key ?? '', t.Value ?? '']));
+        const envName = tagRecord[tagKey];
+        if (!envName) continue;
+        claimed.add(claimKey);
+        const group = groups.get(envName) ?? { refs: [], tags: {} };
+        group.refs.push(ref);
+        Object.assign(group.tags, tagRecord);
+        groups.set(envName, group);
+      }
+    }
+    return groups;
+  }
+
+  /**
+   * Fallback for resources with no matching Environment/env/branch tag:
+   * matches the resource's own name against the configured naming patterns.
+   * Each match becomes its own single-resource group — unlike tag grouping,
+   * there's no reliable shared identifier to safely correlate multiple
+   * naming-matched resources into one environment (name collisions across
+   * resource types are possible, and guessing a shared "slug" out of an
+   * arbitrary glob match risks grouping unrelated resources together).
+   */
+  private findNamingPatternCandidates(
+    lists: ResourceLists,
+    claimed: ReadonlySet<string>,
+  ): Array<{ name: string; ref: ResourceRef }> {
+    const patterns = this.namingPatterns.map(globToRegExp);
+    const matches = (name: string) => patterns.some((p) => p.test(name));
+    const out: Array<{ name: string; ref: ResourceRef }> = [];
+
+    for (const inst of lists.ec2Instances) {
+      if (!inst.InstanceId || claimed.has(`ec2-instance:${inst.InstanceId}`)) continue;
+      const name = inst.Tags?.find((t) => t.Key === 'Name')?.Value ?? inst.InstanceId;
+      if (matches(name)) out.push({ name, ref: { type: 'ec2-instance', key: inst.InstanceId } });
+    }
+    for (const db of lists.dbInstances) {
+      if (!db.DBInstanceArn || !db.DBInstanceIdentifier || claimed.has(`rds-instance:${db.DBInstanceArn}`)) continue;
+      if (matches(db.DBInstanceIdentifier)) out.push({ name: db.DBInstanceIdentifier, ref: { type: 'rds-instance', key: db.DBInstanceArn } });
+    }
+    for (const fn of lists.functions) {
+      if (!fn.FunctionArn || !fn.FunctionName || claimed.has(`lambda-function:${fn.FunctionArn}`)) continue;
+      if (matches(fn.FunctionName)) out.push({ name: fn.FunctionName, ref: { type: 'lambda-function', key: fn.FunctionArn } });
+    }
+    for (const lb of lists.loadBalancers) {
+      if (!lb.LoadBalancerArn || !lb.LoadBalancerName || claimed.has(`load-balancer:${lb.LoadBalancerArn}`)) continue;
+      if (matches(lb.LoadBalancerName)) out.push({ name: lb.LoadBalancerName, ref: { type: 'load-balancer', key: lb.LoadBalancerArn } });
+    }
+    return out;
+  }
+
+  private async buildGroup(
+    environmentName: string,
+    detectionMethod: 'tag' | 'naming-pattern',
+    refs: ResourceRef[],
+    tags: Record<string, string>,
+    region: AwsRegion,
+    now: Date,
+    lookups: ResourceLookups,
+    elbClient: ElasticLoadBalancingV2Client,
+    cwClient: CloudWatchClient,
+  ): Promise<EnvironmentGhost | undefined> {
+    const activities = (
+      await Promise.all(refs.map((ref) => this.resolveActivity(ref, lookups, elbClient, cwClient, now)))
+    ).filter((a): a is ResourceActivity => a !== undefined);
+    if (activities.length === 0) return undefined;
+
+    const inactiveResourceCount = activities.filter((a) => !a.active).length;
+    const lastActivityTimestamp = activities.reduce(
+      (max, a) => (a.sinceTimestamp > max ? a.sinceTimestamp : max),
+      new Date(0),
+    );
+
+    return new EnvironmentGhost({
+      environmentName,
+      detectionMethod,
+      resourceCount: activities.length,
+      resourceTypes: [...new Set(activities.map((a) => a.type))],
+      inactiveResourceCount,
+      lastActivityTimestamp,
+      region,
+      accountId: this.accountId,
+      tags,
+    });
+  }
+
+  private async resolveActivity(
+    ref: ResourceRef,
+    lookups: ResourceLookups,
+    elbClient: ElasticLoadBalancingV2Client,
+    cwClient: CloudWatchClient,
+    now: Date,
+  ): Promise<ResourceActivity | undefined> {
+    switch (ref.type) {
+      case 'ec2-instance': {
+        const inst = lookups.ec2ById.get(ref.key);
+        if (!inst) return undefined;
+        const stopped = inst.State?.Name === 'stopped';
+        return {
+          type: 'ec2-instance',
+          active: !stopped,
+          sinceTimestamp: stopped ? parseStoppedSince(inst.StateTransitionReason) ?? inst.LaunchTime ?? new Date(0) : now,
+        };
+      }
+      case 'rds-instance': {
+        const db = lookups.rdsByArn.get(ref.key);
+        if (!db) return undefined;
+        // AWS auto-restarts an RDS instance left stopped for 7 days: if we
+        // observe `stopped`, it is by definition recent — same caveat
+        // RdsInstanceWastePolicy already accepts for the single-instance scanner.
+        const stopped = db.DBInstanceStatus === 'stopped';
+        return { type: 'rds-instance', active: !stopped, sinceTimestamp: stopped ? db.InstanceCreateTime ?? new Date(0) : now };
+      }
+      case 'lambda-function': {
+        const fn = lookups.lambdaByArn.get(ref.key);
+        if (!fn?.FunctionName) return undefined;
+        const invocations = await sumMetric(
+          cwClient,
+          'AWS/Lambda',
+          'Invocations',
+          [{ Name: 'FunctionName', Value: fn.FunctionName }],
+          metricWindow(this.inactivityDays * 24),
+        );
+        const active = invocations > 0;
+        return { type: 'lambda-function', active, sinceTimestamp: active ? now : fn.LastModified ? new Date(fn.LastModified) : new Date(0) };
+      }
+      case 'load-balancer': {
+        const lb = lookups.lbByArn.get(ref.key);
+        if (!lb) return undefined;
+        const registeredTargets = await this.countRegisteredTargets(elbClient, lb);
+        const active = registeredTargets > 0;
+        return { type: 'load-balancer', active, sinceTimestamp: active ? now : lb.CreatedTime ?? new Date(0) };
+      }
+    }
+  }
+
+  // Same approach as AwsLoadBalancerScanner: more precise than "target groups
+  // exist" — an LB can have target groups configured but empty.
+  private async countRegisteredTargets(client: ElasticLoadBalancingV2Client, lb: AwsLoadBalancer): Promise<number> {
+    const targetGroups = await paginate<TargetGroup>(async (cursor) => {
+      const r = await client.send(new DescribeTargetGroupsCommand({ LoadBalancerArn: lb.LoadBalancerArn, Marker: cursor }));
+      return { items: r.TargetGroups ?? [], cursor: r.NextMarker };
+    });
+
+    let total = 0;
+    for (const tg of targetGroups) {
+      const healthResponse = await client.send(new DescribeTargetHealthCommand({ TargetGroupArn: tg.TargetGroupArn }));
+      total += (healthResponse.TargetHealthDescriptions ?? []).length;
+    }
+    return total;
+  }
+}

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/scanner-contract.spec.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/scanner-contract.spec.ts
@@ -50,6 +50,7 @@ import {
   SageMakerNotebookIdlePolicy,
   SageMakerEndpointIdlePolicy,
   SageMakerTrainingOrphanedPolicy,
+  EnvironmentGhostPolicy,
 } from 'cloud-cost-domain';
 import type { ResourceKind, WasteScannerPort } from 'cloud-cost-domain';
 import { AwsEbsVolumeScanner } from './aws-ebs-volume.scanner';
@@ -87,6 +88,7 @@ import { AwsAuroraServerlessIdleScanner } from './aws-aurora-serverless-idle.sca
 import { AwsSageMakerNotebookIdleScanner } from './aws-sagemaker-notebook-idle.scanner';
 import { AwsSageMakerEndpointIdleScanner } from './aws-sagemaker-endpoint-idle.scanner';
 import { AwsSageMakerTrainingOrphanedScanner } from './aws-sagemaker-training-orphaned.scanner';
+import { AwsEnvironmentGhostScanner } from './aws-environment-ghost.scanner';
 import { StaticPriceTableAdapter } from '../pricing/static-price-table.adapter';
 
 interface ContractFixture {
@@ -217,6 +219,8 @@ const scannerFactories: Record<ResourceKind, () => WasteScannerPort> = {
     new AwsSageMakerEndpointIdleScanner(livePrices, ACCOUNT, new SageMakerEndpointIdlePolicy(po)),
   'sagemaker-training-orphaned': () =>
     new AwsSageMakerTrainingOrphanedScanner(pricing, ACCOUNT, new SageMakerTrainingOrphanedPolicy(po)),
+  'environment-ghost': () =>
+    new AwsEnvironmentGhostScanner(ACCOUNT, new EnvironmentGhostPolicy(po, 7), undefined, undefined, 7),
 };
 
 const byId = (a: { id: string }, b: { id: string }) => a.id.localeCompare(b.id);

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/testing/contract-fixtures/environment-ghost.json
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/testing/contract-fixtures/environment-ghost.json
@@ -1,0 +1,64 @@
+{
+  "kind": "environment-ghost",
+  "source": "hand-transcribed from the ResourceGroupsTaggingAPI/EC2 API reference, 2026-07-15",
+  "region": "us-east-1",
+  "accountId": "000000000000",
+  "pages": {
+    "GetResourcesCommand": [
+      {
+        "ResourceTagMappingList": [
+          {
+            "ResourceARN": "arn:aws:ec2:us-east-1:000000000000:instance/i-0abc123def456",
+            "Tags": [{ "Key": "Environment", "Value": "pr-1234" }]
+          }
+        ],
+        "$metadata": { "httpStatusCode": 200, "requestId": "9a1b2c3d-1111-4a2b-9c3d-000000000001", "attempts": 1, "totalRetryDelay": 0 }
+      }
+    ],
+    "DescribeInstancesCommand": [
+      {
+        "Reservations": [
+          {
+            "Instances": [
+              {
+                "InstanceId": "i-0abc123def456",
+                "InstanceType": "t3.micro",
+                "State": { "Name": "stopped" },
+                "StateTransitionReason": "User initiated (2020-01-15 08:00:00 GMT)",
+                "LaunchTime": "2019-01-01T00:00:00.000Z",
+                "Tags": [{ "Key": "Environment", "Value": "pr-1234" }]
+              }
+            ]
+          }
+        ],
+        "$metadata": { "httpStatusCode": 200, "requestId": "9a1b2c3d-1111-4a2b-9c3d-000000000002", "attempts": 1, "totalRetryDelay": 0 }
+      }
+    ],
+    "DescribeDBInstancesCommand": [
+      {
+        "DBInstances": [],
+        "$metadata": { "httpStatusCode": 200, "requestId": "9a1b2c3d-1111-4a2b-9c3d-000000000003", "attempts": 1, "totalRetryDelay": 0 }
+      }
+    ],
+    "ListFunctionsCommand": [
+      {
+        "Functions": [],
+        "$metadata": { "httpStatusCode": 200, "requestId": "9a1b2c3d-1111-4a2b-9c3d-000000000004", "attempts": 1, "totalRetryDelay": 0 }
+      }
+    ],
+    "DescribeLoadBalancersCommand": [
+      {
+        "LoadBalancers": [],
+        "$metadata": { "httpStatusCode": 200, "requestId": "9a1b2c3d-1111-4a2b-9c3d-000000000005", "attempts": 1, "totalRetryDelay": 0 }
+      }
+    ]
+  },
+  "expected": {
+    "findings": [
+      {
+        "id": "pr-1234",
+        "monthlyCostUsd": 0
+      }
+    ]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "@aws-sdk/client-pricing": "^3.1070.0",
     "@aws-sdk/client-rds": "^3.741.0",
     "@aws-sdk/client-redshift": "^3.1075.0",
+    "@aws-sdk/client-resource-groups-tagging-api": "^3.1075.0",
     "@aws-sdk/client-s3": "^3.1073.0",
     "@aws-sdk/client-sagemaker": "^3.1075.0",
     "@aws-sdk/client-sqs": "~3.1075.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       '@aws-sdk/client-redshift':
         specifier: ^3.1075.0
         version: 3.1075.0
+      '@aws-sdk/client-resource-groups-tagging-api':
+        specifier: ^3.1075.0
+        version: 3.1087.0
       '@aws-sdk/client-s3':
         specifier: ^3.1073.0
         version: 3.1073.0
@@ -333,6 +336,10 @@ packages:
     resolution: {integrity: sha512-dut7rohWVI3imqtwPm+d51m6ubvnSHRohmS2m9CslNDmWSkeQXs+UjaOxsXSsJZVTxebrI1Q/GvrIGxoItztOA==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/client-resource-groups-tagging-api@3.1087.0':
+    resolution: {integrity: sha512-KQwboQijsmvTRDtTKyMHZfBiFHmHnGzPS3IaFqkWDmTRD/t0UlKwz55srAjbaUeLJYjDk/4lcXbcyuDNDouTmA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/client-s3@3.1073.0':
     resolution: {integrity: sha512-/Dvhrff0I4D2YUWSdm8uLKa1bfXdw9BMRDUME6ZeoTrrdQKQDeo2scLDjdpC5X2YdvTc/ZnUCR2HAvD7qXvS1w==}
     engines: {node: '>=20.0.0'}
@@ -357,36 +364,72 @@ packages:
     resolution: {integrity: sha512-8qh/6EYb7hl/ZwVfQufhbMEZs1gQIc7GbdrIf4eprQJ7cv042+74nE6l3YDfyWNzb9iPXb8fRyYSHkNIk5eE6Q==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/core@3.975.2':
+    resolution: {integrity: sha512-iyeXwziyjJpixq5OmhsIyrSWx8vwcI7gDo4yRUC3EP7NQtOo9iAJiIEc3G+/HkhtNXqOhofiCK7Lc34Sq+fJWg==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-env@3.972.57':
     resolution: {integrity: sha512-1RfJaF7SW1TOnvNGU7kaYjwUf5H3sfm+synGH1bHhRlqcnxCt3szebH3dmKEyY4tuGcbQ6ffzUT89cRitBV8OQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.58':
+    resolution: {integrity: sha512-vyGtvK1rY940eq7JT0yIGKuZ+2kpPSJcHibSvGlit5oiMFDamzC7cxBGLl4FLnd6suihMXDI2FSF2dL6TmBqPA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-http@3.972.59':
     resolution: {integrity: sha512-sRCkpTiFnCdQvuaRVjQ6SVoHu6i7RUpurVo1c4F81HWhPvUJ7Wdp5MNtSdX1O29CNXc8em3O5m52hCjVtAD9SA==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-http@3.972.60':
+    resolution: {integrity: sha512-g9b9YzDrD5pcKiPBJfCSXRfFMrA39eR0guUhZ5SRm+7vMAVc43+effxbcamxBjSd5bUhrdKo5te/yQuWurLXLA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-ini@3.973.1':
     resolution: {integrity: sha512-6d8H6ZAh3ZPKZ6fe1nG2OWeZEZPtt9ravoD1dezPdPtsSkJRoxGAnFSHwKT3E/Te6fHE30zRzjV6TD12rvF6yQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.973.2':
+    resolution: {integrity: sha512-Yr7yxNyQ8aHt9Ww0RPFUZx+xiem+vl7vuwhP0tniTijoesJNV5jou9HCgVpI0GEPAF+89TkOvilE5uRrZJnjaw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-login@3.972.63':
     resolution: {integrity: sha512-GREWRrMj0XnNKMaVa/Mauoaui26qBEHu71WWqXbwZOu/jFQOnPZjTf7u0KtGKC8VGa6VUs9kDWGgocrKNLS9vw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-login@3.972.64':
+    resolution: {integrity: sha512-YQoSI4d6kXvoenoG/0Jv/PqaAuukHzGmGXGyHBQYeEUNsYovlNAn/Sw1wp/WQbhcQ3HsEMGgjEahvD3igz6ecQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-node@3.972.67':
     resolution: {integrity: sha512-oYlzWst56rlhhjbYnexwv5hVLYe1cW4liLObhDfxDLI4RAQzleMVHQgQgx7XsC4HKj4e3kjT8v9DId+Pi/dndw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.68':
+    resolution: {integrity: sha512-4akjzW9CjorByYfqXBXmYUh/h7Io3U4DtVgGGh9TQraZ7ZlyJqNyHwDRGiUFnHD+BTOeTbCesCa4sJaK7BGZ7A==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-process@3.972.57':
     resolution: {integrity: sha512-TiVQhuU0pbhIZAUZacbPHMyzrIdiH+lnx+PMY/Pu/b93dJrq3wdZwzUJ0TPpvNxaqbHsxJvQZW3/h/beLiKq7Q==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-process@3.972.58':
+    resolution: {integrity: sha512-1nYitRCaDmXWUrpBJt6WlcGjLx1JVsMY8rlYuHHsTYTSaYikbixYdQSyINN2VYq1F798uTO9qHAzytL25M8g3A==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-sso@3.973.1':
     resolution: {integrity: sha512-3foTZUJ4821Ij60X7K3NJroygiZLnbBmarN+T//O2cjkISan90zElN3NBmgSlDrTQ7Gs6z/yO8V7h60QNcDZHQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-sso@3.973.2':
+    resolution: {integrity: sha512-pjMLaLU/JZi5lVfmR14V1OZqRBTuMHf6AwGNZA0K9hK+JKtO3jcLBarfD8iq5oc8cSowvc/9R32sqMVXZPo6xQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-web-identity@3.972.63':
     resolution: {integrity: sha512-8qZLFhM69eKcS37m459ctPR05Qimycm/74OPVioe6wNZabMT54GYhwBju0+J656RkMasNSawWQu+c8CmBe3TUQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.64':
+    resolution: {integrity: sha512-7Buc7p0OvDHW7iBsu4b+YdS0WnaFBDGKDfbVQqaac9dkWiSiUtIoarBDsA1RmOVXZijaZJDoHJFIQiicQvWRlQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/dynamodb-codec@3.973.22':
@@ -425,16 +468,32 @@ packages:
     resolution: {integrity: sha512-BDHTpwcsZHEBNEJzOg/B1BkFYJxAXY50dau/NyVWs3d51F0WgIUGSWZot/Os+N3KpDhXeaXnz37mWffAvduREw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/nested-clients@3.997.32':
+    resolution: {integrity: sha512-6Yj2fr9XF67cndITea48rchTdVr3VGx6PN47bIKNinJAjLkmaIlz/4EBPCgJ8UmhVopiXmeAuPLI3+DXDDbMhQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/signature-v4-multi-region@3.996.39':
     resolution: {integrity: sha512-8+srXqYIF8KYMLC4FxMLEM5Ek7kUNibJu1R4m8/fUhhNYIZZz26oGtKkCr8I/HiG2fFQxBvaGgQZT4/mqRCSnA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.40':
+    resolution: {integrity: sha512-wrGZ/authosokclY1DXsiWT/1WjfCI22FuZGgdcilF+XLTXs5dCjAtiFYSPsEToZkbm3Lj2YP8PoWg0yoMNu0g==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/token-providers@3.1083.0':
     resolution: {integrity: sha512-s0woKnxuHrExLc5L2ArIH5BMkbonHPtt+5hSBM8oknp9M6QTuUmmAmJ2E0EdzCGONrO+8+ADPqvv6UX0nNcc7A==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/token-providers@3.1087.0':
+    resolution: {integrity: sha512-umM+qNq16f2fH+VLM5MqXW4ORNQAjk+TOSto73xbUHcKaU41L48j786r3UWQYlejeJk37NlvRYgxBT+MBkfaYQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/types@3.974.0':
     resolution: {integrity: sha512-QIBrw90CDm4O0UaIIzkU6DrFdeJzEb2Va5EPEVpyldj6sHJxB6cshhStJuhZxk3wR3PmjJlYsjPmY1kNb+KGBg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.974.1':
+    resolution: {integrity: sha512-W0IQZR0eaBqlBFIIofMapaWkw1W0U+Xi4dvW+BqwmCEMd8Ng2U6IhkxuPSjMVnR8klLjfuS9PeZWUl1N6UaZdg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/util-locate-window@3.965.7':
@@ -443,6 +502,10 @@ packages:
 
   '@aws-sdk/xml-builder@3.972.34':
     resolution: {integrity: sha512-wHhWL1y7sN3enBA8POrPpQM5jCcmu2ozyhbRei4c8OjVcEaEs6yLucLa/pla457ggS/ysuy7bosagz3HaJkZXA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.35':
+    resolution: {integrity: sha512-pXzaWe3evZhjxDXAlMnqISe/XefTCGwBJG4nFTXaWSgAnMkqPEhxEPqJNhhpGesEvKFhvNpnozJJ4GTL11bRYw==}
     engines: {node: '>=20.0.0'}
 
   '@aws/lambda-invoke-store@0.3.0':
@@ -4439,6 +4502,17 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
+  '@aws-sdk/client-resource-groups-tagging-api@3.1087.0':
+    dependencies:
+      '@aws-sdk/core': 3.975.2
+      '@aws-sdk/credential-provider-node': 3.972.68
+      '@aws-sdk/types': 3.974.1
+      '@smithy/core': 3.29.3
+      '@smithy/fetch-http-handler': 5.6.5
+      '@smithy/node-http-handler': 4.9.5
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/client-s3@3.1073.0':
     dependencies:
       '@aws-crypto/sha1-browser': 5.2.0
@@ -4519,6 +4593,17 @@ snapshots:
       bowser: 2.14.1
       tslib: 2.8.1
 
+  '@aws-sdk/core@3.975.2':
+    dependencies:
+      '@aws-sdk/types': 3.974.1
+      '@aws-sdk/xml-builder': 3.972.35
+      '@aws/lambda-invoke-store': 0.3.0
+      '@smithy/core': 3.29.3
+      '@smithy/signature-v4': 5.6.4
+      '@smithy/types': 4.16.1
+      bowser: 2.14.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-env@3.972.57':
     dependencies:
       '@aws-sdk/core': 3.975.1
@@ -4527,10 +4612,28 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-env@3.972.58':
+    dependencies:
+      '@aws-sdk/core': 3.975.2
+      '@aws-sdk/types': 3.974.1
+      '@smithy/core': 3.29.3
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-http@3.972.59':
     dependencies:
       '@aws-sdk/core': 3.975.1
       '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.3
+      '@smithy/fetch-http-handler': 5.6.5
+      '@smithy/node-http-handler': 4.9.5
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.60':
+    dependencies:
+      '@aws-sdk/core': 3.975.2
+      '@aws-sdk/types': 3.974.1
       '@smithy/core': 3.29.3
       '@smithy/fetch-http-handler': 5.6.5
       '@smithy/node-http-handler': 4.9.5
@@ -4553,11 +4656,36 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-ini@3.973.2':
+    dependencies:
+      '@aws-sdk/core': 3.975.2
+      '@aws-sdk/credential-provider-env': 3.972.58
+      '@aws-sdk/credential-provider-http': 3.972.60
+      '@aws-sdk/credential-provider-login': 3.972.64
+      '@aws-sdk/credential-provider-process': 3.972.58
+      '@aws-sdk/credential-provider-sso': 3.973.2
+      '@aws-sdk/credential-provider-web-identity': 3.972.64
+      '@aws-sdk/nested-clients': 3.997.32
+      '@aws-sdk/types': 3.974.1
+      '@smithy/core': 3.29.3
+      '@smithy/credential-provider-imds': 4.4.8
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-login@3.972.63':
     dependencies:
       '@aws-sdk/core': 3.975.1
       '@aws-sdk/nested-clients': 3.997.31
       '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.3
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.64':
+    dependencies:
+      '@aws-sdk/core': 3.975.2
+      '@aws-sdk/nested-clients': 3.997.32
+      '@aws-sdk/types': 3.974.1
       '@smithy/core': 3.29.3
       '@smithy/types': 4.16.1
       tslib: 2.8.1
@@ -4576,10 +4704,32 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-node@3.972.68':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.58
+      '@aws-sdk/credential-provider-http': 3.972.60
+      '@aws-sdk/credential-provider-ini': 3.973.2
+      '@aws-sdk/credential-provider-process': 3.972.58
+      '@aws-sdk/credential-provider-sso': 3.973.2
+      '@aws-sdk/credential-provider-web-identity': 3.972.64
+      '@aws-sdk/types': 3.974.1
+      '@smithy/core': 3.29.3
+      '@smithy/credential-provider-imds': 4.4.8
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-process@3.972.57':
     dependencies:
       '@aws-sdk/core': 3.975.1
       '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.3
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.58':
+    dependencies:
+      '@aws-sdk/core': 3.975.2
+      '@aws-sdk/types': 3.974.1
       '@smithy/core': 3.29.3
       '@smithy/types': 4.16.1
       tslib: 2.8.1
@@ -4594,11 +4744,30 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-sso@3.973.2':
+    dependencies:
+      '@aws-sdk/core': 3.975.2
+      '@aws-sdk/nested-clients': 3.997.32
+      '@aws-sdk/token-providers': 3.1087.0
+      '@aws-sdk/types': 3.974.1
+      '@smithy/core': 3.29.3
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-web-identity@3.972.63':
     dependencies:
       '@aws-sdk/core': 3.975.1
       '@aws-sdk/nested-clients': 3.997.31
       '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.3
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.64':
+    dependencies:
+      '@aws-sdk/core': 3.975.2
+      '@aws-sdk/nested-clients': 3.997.32
+      '@aws-sdk/types': 3.974.1
       '@smithy/core': 3.29.3
       '@smithy/types': 4.16.1
       tslib: 2.8.1
@@ -4673,9 +4842,27 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
+  '@aws-sdk/nested-clients@3.997.32':
+    dependencies:
+      '@aws-sdk/core': 3.975.2
+      '@aws-sdk/signature-v4-multi-region': 3.996.40
+      '@aws-sdk/types': 3.974.1
+      '@smithy/core': 3.29.3
+      '@smithy/fetch-http-handler': 5.6.5
+      '@smithy/node-http-handler': 4.9.5
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/signature-v4-multi-region@3.996.39':
     dependencies:
       '@aws-sdk/types': 3.974.0
+      '@smithy/signature-v4': 5.6.4
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.40':
+    dependencies:
+      '@aws-sdk/types': 3.974.1
       '@smithy/signature-v4': 5.6.4
       '@smithy/types': 4.16.1
       tslib: 2.8.1
@@ -4689,7 +4876,21 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
+  '@aws-sdk/token-providers@3.1087.0':
+    dependencies:
+      '@aws-sdk/core': 3.975.2
+      '@aws-sdk/nested-clients': 3.997.32
+      '@aws-sdk/types': 3.974.1
+      '@smithy/core': 3.29.3
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/types@3.974.0':
+    dependencies:
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.974.1':
     dependencies:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
@@ -4699,6 +4900,11 @@ snapshots:
       tslib: 2.8.1
 
   '@aws-sdk/xml-builder@3.972.34':
+    dependencies:
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.35':
     dependencies:
       '@smithy/types': 4.16.1
       tslib: 2.8.1


### PR DESCRIPTION
# Ghost Environments (ADR-0065) — Phase 6.4

Questa fase aggiunge la verticale **Dev/PR ghost environments**. Viene introdotto **1 nuovo scanner**, portando il numero di `ResourceKind` da 35 a 36.

## Nuovo Scanner Introdotto

* **`environment-ghost`** *(always-on)*
  * **Descrizione:** Raggruppa le risorse per ambiente (tag `Environment`/`env`/`branch`, con fallback su naming convention tipo `*-pr-*`/`*-preview-*`/`*-dev-*`/`*-feat-*`) e segnala i gruppi in cui **tutte** le risorse valutate risultano inattive da più di N giorni (default 7) — la firma tipica di un ambiente Dev/PR effimero mai smantellato.
  * **Copertura risorse:** vengono valutate solo le 4 tipologie per cui cloudrift ha già un segnale di stato/idle affidabile — istanze EC2, istanze RDS, funzioni Lambda, load balancer. Altre risorse taggate/nominate nello stesso gruppo (S3, DynamoDB, ...) restano fuori scope per questa iterazione (tradeoff documentato nei commenti dell'entity/scanner, sotto ADR-0065).
  * **Nota economica:** nessun costo AWS diretto associato al gruppo stesso — come `eni-orphaned`/`sqs-dlq-abandoned`, è un flag di igiene ($0), non un risparmio stimato. Scanner sempre attivo, nessun gate `--live-pricing`.
  * **Config:** nuovo blocco `environmentDetection` (`tagKeys`, `namingPatterns`, `inactivityDays`, default 7) in `cloudrift.config.ts`.

---

## Modifiche e Documentazione Incluse

### Architectural Decision Records (ADR)
Nessuna nuova ADR: il design (allowlist dei 4 resource type vs. mappa generica per-tipo, grace period senza singola "data di creazione" per un gruppo eterogeneo) è documentato inline nei commenti di `environment-ghost.entity.ts` e `aws-environment-ghost.scanner.ts`, sotto l'ombrello di ADR-0065.

### Configurazione e Pricing
* Aggiunto `environmentDetection` a `CloudriftConfig` (`tagKeys`, `namingPatterns`, `inactivityDays`) con validazione Zod.
* Nuova dipendenza `@aws-sdk/client-resource-groups-tagging-api` per il grouping via tag.
* Registrato `environment-ghost` in `scanner-registry.ts` come scanner always-on.
* Aggiunti i contract fixtures e la copertura *scanner-contract* per il nuovo scanner.

### Note di Architettura
Nessuna modifica a `AnalyzeCloudWasteUseCase`, alla struttura dei DTO o al meccanismo di dispatch del presenter. Il nuovo tipo di risorsa si inserisce direttamente nello `switch` esaustivo esistente e nel registro dichiarativo degli scanner (ADR-0043).
