### PR TITLE
feat(cloud-cost): new EKS Cost Visibility vertical (ADR-0065/ADR-0066)

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,12 +144,23 @@ If everything is configured correctly you'll see tables listing the wasted resou
 | **Site-to-Site VPN Connections (idle)** | Zero tunnel traffic in the last 48h | ~$36.50/month fixed |
 | **Transit Gateway Attachments (idle)** | Zero traffic in the last 48h | ~$36.50/month fixed |
 | **Kinesis Streams (idle, Provisioned mode)** | Zero incoming records in the last 48h (On-Demand mode out of scope — pay-per-use) | ~$10.95/month per shard |
+| **SQS Dead Letter Queues (abandoned)** | Identified as a DLQ (RedrivePolicy/naming), oldest unconsumed message older than 14 days | $0 (hygiene flag — SQS has no storage cost) |
+| **CloudWatch Log Groups (orphaned Lambda)** | `/aws/lambda/*` log group whose function no longer exists | $0.03/GB-month (stored log data) |
+| **Aurora Serverless v2 (overprovisioned Min ACU)** | Min ACU floor set well above the observed peak ACU over 7 days — rightsizing candidate | Saving: (Min ACU − suggested Min ACU) × $87.60/ACU-month |
+| **SageMaker Notebook Instances (idle)** | `InService`, max CPU ≤ 2% over 7 days, requires `--live-pricing` | Full instance-hour cost |
+| **SageMaker Endpoints (idle)** | `InService`, zero invocations over 7 days, requires `--live-pricing` | Full instance-hour cost × instance count |
+| **SageMaker Models (orphaned, no endpoint)** | Not referenced by any endpoint config — model-namespace hygiene | Estimated S3 Standard storage cost |
+| **Dev/PR Environments (ghost, all resources inactive)** | Resources grouped by tag or naming pattern, all inactive for 7+ days | Estimated total cost of the resource group |
+| **EKS Node Groups (overprovisioned)** | CPU requested < 30% of allocatable per Container Insights, requires `--live-pricing` | Saving: (nodes − suggested nodes) × instance price |
+| **EKS Orphaned PVC Volumes** | Kubernetes-provisioned EBS volume unattached, or its owning cluster no longer exists | gp3: $0.08/GB-mo · gp2: $0.10/GB-mo (same table as EBS Volumes) |
 
-Every finding is also tagged `waste` or `optimization`: `waste` is money being spent now and feeds the headline total and the CI gate; `optimization` (gp2→gp3, EC2/RDS underutilized, S3 no-lifecycle, Lambda underutilized, DynamoDB overprovisioned) is a saving opportunity that keeps the resource, shown separately and never gated. `EC2/RDS Instances (underutilized)`, `S3 Buckets (no lifecycle)` and `DynamoDB Tables (overprovisioned)` are additionally *estimates* — verify before acting.
+Every finding is also tagged `waste` or `optimization`: `waste` is money being spent now and feeds the headline total and the CI gate; `optimization` (gp2→gp3, EC2/RDS underutilized, S3 no-lifecycle, Lambda underutilized, DynamoDB overprovisioned, Aurora Serverless overprovisioned, SageMaker Models orphaned, EKS Node Groups overprovisioned) is a saving opportunity that keeps the resource, shown separately and never gated. `EC2/RDS Instances (underutilized)`, `S3 Buckets (no lifecycle)`, `DynamoDB Tables (overprovisioned)`, `Aurora Serverless v2 (overprovisioned Min ACU)`, `SageMaker Models (orphaned)` and `EKS Node Groups (overprovisioned)` are additionally *estimates* — verify before acting.
 
 > **Honest caveat (Lambda):** we only check invocation count over the lookback window, nothing else. We do **not** rightsize memory allocation — that requires Lambda Insights (extra cost, must be enabled per-function), which isn't part of a zero-extra-IAM read-only scan. A function with zero invocations has, by definition, $0 direct cost (pay-per-use); the value of this finding is hygiene (dead code, unnecessary IAM roles/event sources), not a dollar saving. It also won't catch idle **Provisioned Concurrency**, which *is* billed regardless of invocations — out of scope for now.
 
 > **Honest caveat (rightsizing):** the underutilized check is a single-metric heuristic — max CPU below a threshold over the lookback window, nothing else. It does **not** look at RAM, network throughput, IOPS or connection counts, so it can't tell you *which* smaller instance type actually fits. We do this because it requires no extra IAM permissions and works the same on every account; we don't replace [AWS Compute Optimizer](https://aws.amazon.com/compute-optimizer/), which models multiple metrics and recommends a specific target type. Treat our finding as "go check this instance," not as a sizing recommendation — cross-check with Compute Optimizer (or your own metrics) before resizing.
+
+> **Honest caveat (EKS):** the node-overprovisioned check reads Container Insights' **node-level** CPU/memory aggregates (`node_cpu_request`/`node_cpu_limit`) via the AWS API only — it never sees individual Pod requests/limits and never talks to the Kubernetes API (no kubeconfig, see ADR-0066). If Container Insights isn't enabled on the cluster, the scanner reports nothing rather than guessing. Treat the suggested node count as a starting point for investigation, not a sizing recommendation. Separately, the orphaned-PVC-volume check can only recover the owning cluster's name from the legacy `kubernetes.io/cluster/<name>` tag — CSI-driver-provisioned volumes without `--extra-tags` won't carry it, so those volumes are only ever flagged via the unattached check, never the deleted-cluster check.
 
 **False-positive guards (waste policies):**
 
@@ -416,6 +427,7 @@ The AWS principal needs the following read-only permissions:
     "ec2:DescribeNetworkInterfaces",
     "cloudwatch:GetMetricStatistics",
     "rds:DescribeDBInstances",
+    "rds:DescribeDBClusters",
     "elasticloadbalancing:DescribeLoadBalancers",
     "elasticloadbalancing:DescribeTargetGroups",
     "elasticloadbalancing:DescribeTargetHealth",
@@ -434,6 +446,14 @@ The AWS principal needs the following read-only permissions:
     "sagemaker:ListEndpointConfigs",
     "sagemaker:ListModels",
     "sagemaker:DescribeModel",
+    "sqs:ListQueues",
+    "sqs:GetQueueAttributes",
+    "sqs:ListDeadLetterSourceQueues",
+    "sqs:ListQueueTags",
+    "tag:GetResources",
+    "eks:ListClusters",
+    "eks:ListNodegroups",
+    "eks:DescribeNodegroup",
     "sts:GetCallerIdentity"
   ],
   "Resource": "*"
@@ -492,6 +512,7 @@ Full documentation is in the [`docs/`](./docs/) folder — English in [`docs/en/
 | [docs/en/testing.md](./docs/en/testing.md)                      | Test pyramid, where each level lives, manual AWS verification |
 | [docs/en/policy-as-code.md](./docs/en/policy-as-code.md)        | From-zero OPA walkthrough for the example policies in `policy/` |
 | [docs/en/releasing.md](./docs/en/releasing.md)                  | How `@cloudrift/cli` is built and published to npm     |
+| [docs/en/vertical-scanners.md](./docs/en/vertical-scanners.md)  | The Phase 6 vertical scanners (Serverless, Aurora, SageMaker, Dev/PR, EKS) — what they detect, their caveats, and how to configure them |
 
 ### Adding a new resource type
 
@@ -645,12 +666,23 @@ Se tutto è configurato correttamente vedrai tabelle con le risorse sprecate tro
 | **Connessioni VPN Site-to-Site (idle)** | Zero traffico nei tunnel nelle ultime 48h | ~$36,50/mese fisso |
 | **Transit Gateway Attachments (idle)** | Zero traffico nelle ultime 48h | ~$36,50/mese fisso |
 | **Kinesis Streams (idle, modalità Provisioned)** | Zero record in ingresso nelle ultime 48h (modalità On-Demand fuori scope — pay-per-use) | ~$10,95/mese per shard |
+| **Code SQS Dead Letter (abbandonate)** | Identificata come DLQ (RedrivePolicy/naming), messaggio più vecchio non consumato da oltre 14 giorni | $0 (segnalazione di igiene — SQS non ha costo di storage) |
+| **CloudWatch Log Groups (Lambda orfani)** | Log group `/aws/lambda/*` la cui funzione non esiste più | $0,03/GB-mese (dati di log memorizzati) |
+| **Aurora Serverless v2 (Min ACU sovradimensionato)** | Min ACU molto superiore al picco osservato in 7 giorni — candidato a rightsizing | Risparmio: (Min ACU − Min ACU suggerito) × $87,60/ACU-mese |
+| **SageMaker Notebook Instances (idle)** | `InService`, CPU massima ≤ 2% in 7 giorni, richiede `--live-pricing` | Costo pieno instance-hour |
+| **SageMaker Endpoints (idle)** | `InService`, zero invocazioni in 7 giorni, richiede `--live-pricing` | Costo pieno instance-hour × numero di istanze |
+| **SageMaker Models (orfani, nessun endpoint)** | Non referenziati da nessuna endpoint config — igiene del namespace modelli | Costo stimato storage S3 Standard |
+| **Ambienti Dev/PR fantasma (tutte le risorse inattive)** | Risorse raggruppate per tag o naming pattern, tutte inattive da 7+ giorni | Costo stimato totale del gruppo di risorse |
+| **EKS Node Groups (sovradimensionati)** | CPU richiesta < 30% dell'allocabile secondo Container Insights, richiede `--live-pricing` | Risparmio: (nodi − nodi suggeriti) × prezzo istanza |
+| **EKS Volumi PVC orfani** | Volume EBS creato da Kubernetes non attaccato, oppure cluster proprietario non più esistente | gp3: $0,08/GB-mese · gp2: $0,10/GB-mese (stessa tabella di EBS Volumes) |
 
-Ogni finding è anche etichettato `waste` o `optimization`: `waste` è denaro speso ora e contribuisce al totale principale e al gate CI; `optimization` (gp2→gp3, EC2/RDS underutilized, S3 no-lifecycle, Lambda underutilized, DynamoDB overprovisioned) è un'opportunità di risparmio che mantiene la risorsa, mostrata a parte e mai usata come gate. `EC2/RDS Instances (underutilized)`, `S3 Buckets (no lifecycle)` e `DynamoDB Tables (overprovisioned)` sono inoltre delle *stime* — da verificare prima di agire.
+Ogni finding è anche etichettato `waste` o `optimization`: `waste` è denaro speso ora e contribuisce al totale principale e al gate CI; `optimization` (gp2→gp3, EC2/RDS underutilized, S3 no-lifecycle, Lambda underutilized, DynamoDB overprovisioned, Aurora Serverless overprovisioned, SageMaker Models orfani, EKS Node Groups sovradimensionati) è un'opportunità di risparmio che mantiene la risorsa, mostrata a parte e mai usata come gate. `EC2/RDS Instances (underutilized)`, `S3 Buckets (no lifecycle)`, `DynamoDB Tables (overprovisioned)`, `Aurora Serverless v2 (Min ACU sovradimensionato)`, `SageMaker Models (orfani)` e `EKS Node Groups (sovradimensionati)` sono inoltre delle *stime* — da verificare prima di agire.
 
 > **Nota onesta (Lambda):** controlliamo solo il numero di invocazioni nella finestra di osservazione, nient'altro. **Non** facciamo rightsizing della memoria — richiederebbe Lambda Insights (costo extra, da attivare per ogni funzione), fuori scope per uno scan read-only senza permessi IAM aggiuntivi. Una funzione con zero invocazioni ha per definizione $0 di costo diretto (pay-per-use); il valore di questo finding è igiene (codice morto, ruoli IAM/event source inutili), non un risparmio in dollari. Non rileva nemmeno la **Provisioned Concurrency** idle, che invece *è* fatturata indipendentemente dalle invocazioni — fuori scope per ora.
 
 > **Nota onesta (rightsizing):** il check di sottoutilizzo è un'euristica su una singola metrica — CPU massima sotto una soglia nella finestra di osservazione, nient'altro. **Non** guarda RAM, throughput di rete, IOPS o numero di connessioni, quindi non può dirti *quale* instance type più piccolo sia davvero adatto. Lo facciamo così perché non richiede permessi IAM aggiuntivi e funziona uguale su ogni account; non sostituiamo [AWS Compute Optimizer](https://aws.amazon.com/compute-optimizer/), che modella più metriche e raccomanda un target specifico. Tratta il nostro finding come "vai a controllare questa istanza", non come una raccomandazione di sizing — verifica con Compute Optimizer (o con le tue metriche) prima di ridimensionare.
+
+> **Nota onesta (EKS):** il check sul sovradimensionamento dei nodi legge gli aggregati **a livello di nodo** di Container Insights (`node_cpu_request`/`node_cpu_limit`) tramite la sola AWS API — non vede mai le richieste/limiti dei singoli Pod e non parla con la Kubernetes API (nessun kubeconfig, vedi ADR-0066). Se Container Insights non è attivo sul cluster, lo scanner non segnala nulla invece di indovinare. Tratta il numero di nodi suggerito come punto di partenza per l'indagine, non come raccomandazione di sizing. Separatamente, il check sui volumi PVC orfani può recuperare il nome del cluster proprietario solo dal tag legacy `kubernetes.io/cluster/<nome>` — i volumi creati dal CSI driver senza `--extra-tags` non lo portano, quindi vengono segnalati solo tramite il check "non attaccato", mai tramite quello sul cluster cancellato.
 
 **Protezioni contro i falsi positivi (waste policies):**
 
@@ -932,6 +964,7 @@ Il principal AWS deve avere le seguenti permission in sola lettura:
     "ec2:DescribeNetworkInterfaces",
     "cloudwatch:GetMetricStatistics",
     "rds:DescribeDBInstances",
+    "rds:DescribeDBClusters",
     "elasticloadbalancing:DescribeLoadBalancers",
     "elasticloadbalancing:DescribeTargetGroups",
     "elasticloadbalancing:DescribeTargetHealth",
@@ -950,6 +983,14 @@ Il principal AWS deve avere le seguenti permission in sola lettura:
     "sagemaker:ListEndpointConfigs",
     "sagemaker:ListModels",
     "sagemaker:DescribeModel",
+    "sqs:ListQueues",
+    "sqs:GetQueueAttributes",
+    "sqs:ListDeadLetterSourceQueues",
+    "sqs:ListQueueTags",
+    "tag:GetResources",
+    "eks:ListClusters",
+    "eks:ListNodegroups",
+    "eks:DescribeNodegroup",
     "sts:GetCallerIdentity"
   ],
   "Resource": "*"
@@ -1008,6 +1049,7 @@ Tutta la documentazione è nella cartella [`docs/`](./docs/) — italiano in [`d
 | [docs/it/test.md](./docs/it/test.md)                                 | Piramide dei test, dove vive ogni livello, verifica manuale AWS   |
 | [docs/it/policy-as-code.md](./docs/it/policy-as-code.md)             | Guida OPA da zero per le policy di esempio in `policy/`           |
 | [docs/it/rilascio.md](./docs/it/rilascio.md)                         | Come `@cloudrift/cli` viene buildato e pubblicato su npm           |
+| [docs/it/scanner-verticali-guida.md](./docs/it/scanner-verticali-guida.md) | Gli scanner verticali di Phase 6 (Serverless, Aurora, SageMaker, Dev/PR, EKS) — cosa rilevano, i loro limiti, come configurarli |
 
 ## Licenza
 

--- a/apps/cli/src/commands/scanner-registry.ts
+++ b/apps/cli/src/commands/scanner-registry.ts
@@ -36,6 +36,8 @@ import {
   SageMakerEndpointIdlePolicy,
   SageMakerTrainingOrphanedPolicy,
   EnvironmentGhostPolicy,
+  EksNodeOverprovisionedPolicy,
+  EksOrphanPvcPolicy,
   RESOURCE_KINDS,
 } from 'cloud-cost-domain';
 import type {
@@ -81,6 +83,8 @@ import {
   AwsSageMakerEndpointIdleScanner,
   AwsSageMakerTrainingOrphanedScanner,
   AwsEnvironmentGhostScanner,
+  AwsEksNodeOverprovisionedScanner,
+  AwsEksOrphanPvcScanner,
 } from 'cloud-cost-infrastructure-aws-adapter';
 import type { AwsPricingApiAdapter } from 'cloud-cost-infrastructure-aws-adapter';
 import type { CloudriftConfig } from '../config/cloudrift.config';
@@ -296,6 +300,12 @@ export const ALWAYS_ON_SCANNERS: ScannerRegistration<ScannerBuildContext>[] = [
       );
     },
   },
+  // Phase 6.5 (ADR-0065/ADR-0066): EKS cost visibility vertical. Static EBS
+  // pricing, so always-on (ADR-0037) — pairs with eks-node-overprovisioned above.
+  {
+    kind: 'eks-orphan-pvc',
+    create: (ctx) => new AwsEksOrphanPvcScanner(ctx.pricing, ctx.accountId, new EksOrphanPvcPolicy(ctx.policyOptions)),
+  },
 ];
 
 // Gated on --live-pricing: the price per instance type/RDS class/ElastiCache
@@ -421,6 +431,18 @@ export const LIVE_PRICING_SCANNERS: ScannerRegistration<LivePricingScannerBuildC
         ctx.accountId,
         new SageMakerEndpointIdlePolicy(ctx.policyOptions),
         ctx.cloudwatchWindowHours,
+      ),
+  },
+  // Phase 6.5 (ADR-0065/ADR-0066): EKS cost visibility vertical. Per-instance-
+  // type pricing, same reasoning as EC2/RDS/SageMaker above (ADR-0037).
+  {
+    kind: 'eks-node-overprovisioned',
+    create: (ctx) =>
+      new AwsEksNodeOverprovisionedScanner(
+        ctx.livePricingAdapter,
+        ctx.accountId,
+        new EksNodeOverprovisionedPolicy(ctx.policyOptions, ctx.config.thresholds?.eksNodeUtilizationPercent ?? 30),
+        ctx.utilizationWindowHours,
       ),
   },
 ];

--- a/apps/cli/src/config/cloudrift.config.ts
+++ b/apps/cli/src/config/cloudrift.config.ts
@@ -59,6 +59,8 @@ export interface CloudriftConfig {
     auroraMinAcuUtilizationPercent?: number;
     /** Maximum CPU (%) below which an InService SageMaker notebook instance is "idle". Default 2. */
     sagemakerNotebookCpuPercent?: number;
+    /** Maximum CPU-requested-to-allocatable ratio (%) below which an EKS node group is "overprovisioned". Default 30. */
+    eksNodeUtilizationPercent?: number;
   };
   /** Dev/PR "ghost environment" detection (environment-ghost scanner). */
   environmentDetection?: {
@@ -133,6 +135,7 @@ const configSchema = z.object({
       dynamoCapacityUtilizationPercent: percent.optional(),
       auroraMinAcuUtilizationPercent: percent.optional(),
       sagemakerNotebookCpuPercent: percent.optional(),
+      eksNodeUtilizationPercent: percent.optional(),
     })
     .optional(),
   environmentDetection: z

--- a/apps/cli/src/formatters/resource-presenters.ts
+++ b/apps/cli/src/formatters/resource-presenters.ts
@@ -20,6 +20,11 @@ function day(date: Date): string {
   return date.toISOString().split('T')[0];
 }
 
+function clusterDisplay(clusterName: string | undefined, clusterExists: boolean): string {
+  if (clusterName === undefined) return 'unknown';
+  return clusterExists ? clusterName : `${clusterName} (deleted)`;
+}
+
 type PresenterMap = { [K in ResourceKind]: ResourcePresenter<ResourceKindMap[K]> };
 
 export const presenters: PresenterMap = {
@@ -422,6 +427,37 @@ export const presenters: PresenterMap = {
     recommend: (e) =>
       `Review ghost environment "${e.environmentName}" in ${e.region.code} — ${e.wasteReason} (verify before deleting)`,
   },
+  'eks-node-overprovisioned': {
+    title:
+      'EKS Node Groups — Overprovisioned (rightsizing candidate, Container Insights node-level aggregate only, verify before acting)',
+    head: ['Cluster / Node Group', 'Region', 'Instance Type', 'Nodes', 'CPU Requested', 'Suggested Nodes'],
+    colWidths: [150, 72, 100, 50, 80, 80, 80],
+    row: (n) => [
+      n.id,
+      n.region.code,
+      n.instanceType,
+      `${n.nodeCount}`,
+      `${n.cpuRequestedPercent.toFixed(1)}%`,
+      `${n.suggestedNodeCount}`,
+    ],
+    recommend: (n) =>
+      `Scale EKS node group ${n.id} (${n.instanceType}) in ${n.region.code} ${n.nodeCount}→${n.suggestedNodeCount} nodes — CPU requested ${n.cpuRequestedPercent.toFixed(1)}% of allocatable over ${n.windowHours}h (Container Insights node-level aggregate, not individual Pod requests — verify real workload peaks first)`,
+  },
+  'eks-orphan-pvc': {
+    title: 'EKS Orphaned PVC Volumes — Unattached or owning cluster deleted',
+    head: ['Volume ID', 'PVC Name', 'Namespace', 'Cluster', 'Size', 'Type'],
+    colWidths: [130, 100, 90, 110, 48, 48, 80],
+    row: (v) => [
+      v.id,
+      v.pvcName,
+      v.pvcNamespace,
+      clusterDisplay(v.clusterName, v.clusterExists),
+      `${v.sizeGb} GB`,
+      v.volumeType,
+    ],
+    recommend: (v) =>
+      `Delete orphaned Kubernetes PVC volume ${v.id} (${v.pvcNamespace}/${v.pvcName}) in ${v.region.code} — ${v.wasteReason}`,
+  },
 };
 
 /**
@@ -497,6 +533,8 @@ export function rowFor(finding: AnyResourceEntity): string[] {
     case 'sagemaker-endpoint-idle': return presenters['sagemaker-endpoint-idle'].row(finding);
     case 'sagemaker-training-orphaned': return presenters['sagemaker-training-orphaned'].row(finding);
     case 'environment-ghost': return presenters['environment-ghost'].row(finding);
+    case 'eks-node-overprovisioned': return presenters['eks-node-overprovisioned'].row(finding);
+    case 'eks-orphan-pvc': return presenters['eks-orphan-pvc'].row(finding);
   }
 }
 
@@ -539,5 +577,7 @@ export function recommendFor(finding: AnyResourceEntity): string {
     case 'sagemaker-endpoint-idle': return presenters['sagemaker-endpoint-idle'].recommend(finding);
     case 'sagemaker-training-orphaned': return presenters['sagemaker-training-orphaned'].recommend(finding);
     case 'environment-ghost': return presenters['environment-ghost'].recommend(finding);
+    case 'eks-node-overprovisioned': return presenters['eks-node-overprovisioned'].recommend(finding);
+    case 'eks-orphan-pvc': return presenters['eks-orphan-pvc'].recommend(finding);
   }
 }

--- a/cloudrift.config.example.json
+++ b/cloudrift.config.example.json
@@ -16,6 +16,13 @@
     "ebsIdleMaxOps": 0,
     "ec2CpuPercent": 5,
     "rdsCpuPercent": 5,
-    "sagemakerNotebookCpuPercent": 2
+    "auroraMinAcuUtilizationPercent": 50,
+    "sagemakerNotebookCpuPercent": 2,
+    "eksNodeUtilizationPercent": 30
+  },
+  "environmentDetection": {
+    "tagKeys": ["Environment", "env", "branch"],
+    "namingPatterns": ["*-pr-*", "*-preview-*", "*-dev-*", "*-feat-*"],
+    "inactivityDays": 7
   }
 }

--- a/docs/en/vertical-scanners.md
+++ b/docs/en/vertical-scanners.md
@@ -1,0 +1,81 @@
+# Vertical scanners (Phase 6)
+
+> 🇮🇹 [Versione italiana](../it/scanner-verticali-guida.md)
+
+Phase 6 added 9 `ResourceKind`s across 5 verticals on top of the 29 generalist scanners: event-driven hygiene (SQS/Lambda), Aurora Serverless v2, the SageMaker suite, Dev/PR ghost environments, and EKS cost visibility. Rationale and alternatives considered are in [ADR-0065](../adr/0065-vertical-premium-scanners-phase-6-strategy.md) (overall strategy) and [ADR-0066](../adr/0066-eks-scanners-aws-api-only-kubeconfig-deferred.md) (EKS specifically). This doc is the practical reference: what each scanner flags, its accuracy ceiling, and how to tune it — the README's [What it detects](../../README.md#what-it-detects) table has the one-line summary and cost formula for each.
+
+Run any of them standalone with `--scanners <kind>`, e.g.:
+
+```sh
+node apps/cli/dist/main.js analyze --scanners eks-node-overprovisioned --live-pricing
+```
+
+## Serverless orphans
+
+**`sqs-dlq-abandoned`** — an SQS queue identified as a Dead Letter Queue (via its `RedrivePolicy`, being referenced as the target of another queue's redrive policy, or a `*-dlq`/`*-dead-letter` name match) whose oldest unconsumed message is older than 14 days. This is a `$0` hygiene flag, same rationale as the `eni-orphaned` scanner: SQS has no storage cost, the value is catching ignored errors and dead integrations, not a dollar saving.
+
+**`lambda-loggroup-orphaned`** — a CloudWatch Log Group under `/aws/lambda/` whose Lambda function no longer exists. Distinct from the generalist `log-group` scanner, which flags *missing retention* on log groups that still belong to a live function; this one flags log groups whose owning function is gone entirely. Cost is the stored log data at the standard CloudWatch Logs storage rate.
+
+No dedicated config thresholds beyond the standard `--min-age-days` / `cloudrift:ignore` tag.
+
+## Aurora Serverless v2
+
+**`aurora-serverless-overprovisioned`** — an Aurora Serverless v2 cluster whose `MinACU` floor sits well above the peak `ServerlessDatabaseCapacity` actually observed over a 7-day window. The suggested Min ACU is `ceil(peakACU * 1.2)` — 20% headroom above the observed peak, not right at the edge. Saving is `(MinACU − suggestedMinACU) × $87.60/ACU-month` (the static `aurora-acu` price key, `$0.12/ACU-hour`).
+
+Config: `thresholds.auroraMinAcuUtilizationPercent` (default `50`) — flagged when peak ACU is below this percentage of the Min ACU floor.
+
+**Risk:** a rare weekly peak that falls outside the 7-day window looks like permanent overprovisioning. The 20% suggested-floor headroom is the mitigation, not a guarantee — verify against a longer observation window for spiky workloads before lowering Min ACU.
+
+## SageMaker suite
+
+Three scanners, meant to be read together — a model lifecycle view (notebook → endpoint → orphaned artifact):
+
+**`sagemaker-notebook-idle`** (gated on `--live-pricing`) — a notebook instance `InService` with max CPU ≤ `thresholds.sagemakerNotebookCpuPercent` (default `2`) over a 7-day window.
+
+> **Caveat:** CPU-only. GPU notebook instances can cost hundreds to thousands of dollars a day and this check says nothing about GPU utilization — it also can't tell "idle kernel" from "someone reading a notebook without running cells." Treat a finding as "go check this," not as confirmed waste.
+
+**`sagemaker-endpoint-idle`** (gated on `--live-pricing`) — an endpoint `InService` with zero `Invocations` summed over a 7-day window. Cost is the full instance-hour cost across every production variant's instance count.
+
+**`sagemaker-training-orphaned`** — a registered SageMaker Model not referenced by any Endpoint Config (`sagemaker:ListModels` cross-referenced against `sagemaker:ListEndpointConfigs`). This is namespace hygiene, not a direct SageMaker cost (a Model resource itself is free) — the estimated cost is the S3 Standard storage of `ModelDataUrl`, priced via the existing `s3-standard` key.
+
+**Risk:** a model kept around deliberately for rollback/backup looks identical to a truly abandoned one from the AWS-API-only view; the grace period (`--min-age-days`) is the only mitigation.
+
+## Dev/PR ghost environments
+
+**`environment-ghost`** — groups resources (EC2, RDS, Lambda, Load Balancers) by a tag value or a naming-pattern match, then flags a group as a "ghost environment" only when *every* resource in it has been inactive for `environmentDetection.inactivityDays` (default `7`) or longer.
+
+Config (`cloudriftrc` / `cloudrift.config.json`):
+
+```json
+{
+  "environmentDetection": {
+    "tagKeys": ["Environment", "env", "branch"],
+    "namingPatterns": ["*-pr-*", "*-preview-*", "*-dev-*", "*-feat-*"],
+    "inactivityDays": 7
+  }
+}
+```
+
+`tagKeys` is tried first (`resourcegroupstaggingapi:GetResources`, grouped by tag value); `namingPatterns` is the fallback for resources without a matching tag. This is the most experimental scanner in Phase 6 — it depends entirely on your account's tagging/naming discipline, and a team with neither will see nothing. Start by adding a `tagKeys` entry that matches how your org actually tags ephemeral environments before trusting the naming-pattern fallback.
+
+## EKS cost visibility
+
+Both scanners are **AWS-API-only** — no kubeconfig, no cluster-internal connectivity, ever. See [ADR-0066](../adr/0066-eks-scanners-aws-api-only-kubeconfig-deferred.md) for why: requiring cluster RBAC read access would break the "just an IAM role" trust model that's central to how cloudrift is used. The tradeoff is a real accuracy ceiling — read both caveats below before acting on either finding.
+
+**`eks-node-overprovisioned`** (gated on `--live-pricing`) — an EKS Node Group whose CPU requested-to-allocatable ratio, per CloudWatch **Container Insights** node-level aggregates (`node_cpu_request`/`node_cpu_limit`, namespace `ContainerInsights`), is below `thresholds.eksNodeUtilizationPercent` (default `30`) over a 7-day window. The suggested node count scales down toward a 70%-target utilization, never below 1 node and never above the current count (`suggestNodeCount` in the scanner). Saving is `(nodeCount − suggestedNodeCount) × <instance type monthly price>`.
+
+If Container Insights isn't enabled on a cluster, the scanner degrades gracefully — it emits a scan warning and produces **no finding** for that cluster, rather than guessing from missing data.
+
+> **Caveat:** this reads Node-group-level aggregates only, never individual Pod `resources.requests`/`resources.limits` — it cannot tell you *which* Pods are oversized, only that the group as a whole looks overprovisioned. A `KubernetesDataPort` for Pod-level accuracy is an explicit, undefined-for-now extension point for a future phase (ADR-0066), not something to expect from this scanner today.
+
+**`eks-orphan-pvc`** — an EBS volume provisioned for a Kubernetes PersistentVolumeClaim (identified via the CSI driver's `kubernetes.io/created-for/pvc/name` tag) that is either:
+- unattached (`state: available`), or
+- still tagged for an EKS cluster that no longer exists, via the legacy in-tree provisioner's `kubernetes.io/cluster/<name>` tag correlated against `eks:ListClusters`.
+
+Cost uses the same static EBS pricing table as the `ebs-volume` scanner (no `--live-pricing` needed).
+
+> **Caveat:** the cluster-name tag is a legacy in-tree-provisioner convention. Volumes provisioned by the modern EBS CSI driver without `--extra-tags` carry no recoverable cluster name — those volumes are only ever caught by the unattached check, never the deleted-cluster one. This is not a bug to fix; it's a hard limit of reading tags instead of talking to the Kubernetes API.
+
+## IAM permissions
+
+All 9 scanners' required actions are already folded into the README's [Required IAM permissions](../../README.md#required-iam-permissions) policy block: `sqs:ListQueues`/`GetQueueAttributes`/`ListDeadLetterSourceQueues`/`ListQueueTags`, `rds:DescribeDBClusters`, `tag:GetResources`, `eks:ListClusters`/`ListNodegroups`/`DescribeNodegroup`, plus the pre-existing `sagemaker:*` read actions. `eks-node-overprovisioned` and the SageMaker idle scanners additionally need `pricing:GetProducts` when run with `--live-pricing`, same as every other per-instance-type-priced scanner.

--- a/docs/it/scanner-verticali-guida.md
+++ b/docs/it/scanner-verticali-guida.md
@@ -1,0 +1,81 @@
+# Scanner verticali (Phase 6)
+
+> 🇬🇧 [English version](../en/vertical-scanners.md)
+
+La Phase 6 ha aggiunto 9 `ResourceKind` distribuiti su 5 verticali, sopra i 29 scanner generalisti già esistenti: igiene event-driven (SQS/Lambda), Aurora Serverless v2, la suite SageMaker, ambienti Dev/PR fantasma, e visibilità sui costi EKS. Motivazioni e alternative valutate sono in [ADR-0065](../adr/0065-vertical-premium-scanners-phase-6-strategy.md) (strategia generale) e [ADR-0066](../adr/0066-eks-scanners-aws-api-only-kubeconfig-deferred.md) (EKS nello specifico). Questo documento è il riferimento pratico: cosa rileva ogni scanner, il suo limite di accuratezza, e come configurarlo — la tabella [Cosa rileva](../../README.md#cosa-rileva) del README ha il riepilogo in una riga e la formula del costo per ciascuno.
+
+Esegui uno qualsiasi standalone con `--scanners <kind>`, es.:
+
+```sh
+node apps/cli/dist/main.js analyze --scanners eks-node-overprovisioned --live-pricing
+```
+
+## Orfani serverless
+
+**`sqs-dlq-abandoned`** — una coda SQS identificata come Dead Letter Queue (tramite `RedrivePolicy`, essendo referenziata come target della redrive policy di un'altra coda, o un nome che matcha `*-dlq`/`*-dead-letter`) il cui messaggio più vecchio non consumato ha più di 14 giorni. È una segnalazione di igiene a `$0`, stessa logica dello scanner `eni-orphaned`: SQS non ha costo di storage, il valore è intercettare errori ignorati e integrazioni morte, non un risparmio in dollari.
+
+**`lambda-loggroup-orphaned`** — un CloudWatch Log Group sotto `/aws/lambda/` la cui funzione Lambda non esiste più. Distinto dallo scanner generalista `log-group`, che segnala la *retention mancante* su log group ancora appartenenti a una funzione viva; questo segnala log group la cui funzione proprietaria è del tutto sparita. Il costo è il dato di log memorizzato alla tariffa standard di storage di CloudWatch Logs.
+
+Nessuna soglia di configurazione dedicata oltre allo standard `--min-age-days` / tag `cloudrift:ignore`.
+
+## Aurora Serverless v2
+
+**`aurora-serverless-overprovisioned`** — un cluster Aurora Serverless v2 il cui floor `MinACU` è molto superiore al picco di `ServerlessDatabaseCapacity` osservato realmente in una finestra di 7 giorni. Il Min ACU suggerito è `ceil(picco * 1.2)` — 20% di margine sopra il picco osservato, non esattamente al limite. Il risparmio è `(MinACU − MinACU suggerito) × $87,60/ACU-mese` (la chiave di prezzo statica `aurora-acu`, `$0,12/ACU-ora`).
+
+Config: `thresholds.auroraMinAcuUtilizationPercent` (default `50`) — segnalato quando il picco ACU è sotto questa percentuale del floor Min ACU.
+
+**Rischio:** un picco settimanale raro che cade fuori dalla finestra di 7 giorni sembra sovradimensionamento permanente. Il margine del 20% sul floor suggerito è la mitigazione, non una garanzia — verifica con una finestra di osservazione più lunga per workload a picchi prima di abbassare il Min ACU.
+
+## Suite SageMaker
+
+Tre scanner, pensati per essere letti insieme — una vista sul ciclo di vita del modello (notebook → endpoint → artefatto orfano):
+
+**`sagemaker-notebook-idle`** (richiede `--live-pricing`) — un'istanza notebook `InService` con CPU massima ≤ `thresholds.sagemakerNotebookCpuPercent` (default `2`) in una finestra di 7 giorni.
+
+> **Nota:** solo CPU. Le istanze notebook GPU possono costare centinaia o migliaia di dollari al giorno e questo check non dice nulla sull'utilizzo GPU — non distingue nemmeno un "kernel idle" da "qualcuno che legge il notebook senza eseguire celle". Tratta un finding come "vai a controllare", non come spreco confermato.
+
+**`sagemaker-endpoint-idle`** (richiede `--live-pricing`) — un endpoint `InService` con zero `Invocations` sommate in una finestra di 7 giorni. Il costo è il costo pieno instance-hour su tutte le istanze di ogni production variant.
+
+**`sagemaker-training-orphaned`** — un Model SageMaker registrato non referenziato da nessuna Endpoint Config (`sagemaker:ListModels` incrociato con `sagemaker:ListEndpointConfigs`). È igiene del namespace, non un costo SageMaker diretto (la risorsa Model in sé è gratuita) — il costo stimato è lo storage S3 Standard di `ModelDataUrl`, valorizzato con la chiave esistente `s3-standard`.
+
+**Rischio:** un modello tenuto deliberatamente per rollback/backup appare identico a uno davvero abbandonato dal punto di vista AWS-API-only; il periodo di grazia (`--min-age-days`) è l'unica mitigazione.
+
+## Ambienti Dev/PR fantasma
+
+**`environment-ghost`** — raggruppa risorse (EC2, RDS, Lambda, Load Balancer) per valore di tag o per match su naming pattern, poi segnala un gruppo come "ambiente fantasma" solo quando *tutte* le risorse al suo interno sono inattive da `environmentDetection.inactivityDays` (default `7`) o più.
+
+Config (`cloudriftrc` / `cloudrift.config.json`):
+
+```json
+{
+  "environmentDetection": {
+    "tagKeys": ["Environment", "env", "branch"],
+    "namingPatterns": ["*-pr-*", "*-preview-*", "*-dev-*", "*-feat-*"],
+    "inactivityDays": 7
+  }
+}
+```
+
+`tagKeys` viene provato per primo (`resourcegroupstaggingapi:GetResources`, raggruppato per valore di tag); `namingPatterns` è il fallback per risorse senza tag corrispondente. È lo scanner più sperimentale della Phase 6 — dipende interamente dalla disciplina di tagging/naming del tuo account, e un team senza nessuna delle due non vedrà nulla. Inizia aggiungendo un `tagKeys` che rispecchi come la tua organizzazione effettivamente tagga gli ambienti effimeri, prima di fidarti del fallback sui naming pattern.
+
+## Visibilità costi EKS
+
+Entrambi gli scanner sono **AWS-API-only** — nessun kubeconfig, nessuna connettività interna al cluster, mai. Vedi [ADR-0066](../adr/0066-eks-scanners-aws-api-only-kubeconfig-deferred.md) per il perché: richiedere accesso RBAC in lettura al cluster romperebbe il modello di fiducia "solo un ruolo IAM" che è centrale nel modo in cui cloudrift viene usato. Il compromesso è un vero limite di accuratezza — leggi entrambe le note prima di agire su uno dei due finding.
+
+**`eks-node-overprovisioned`** (richiede `--live-pricing`) — un Node Group EKS il cui rapporto CPU richiesta/allocabile, secondo gli aggregati **a livello di nodo** di CloudWatch Container Insights (`node_cpu_request`/`node_cpu_limit`, namespace `ContainerInsights`), è sotto `thresholds.eksNodeUtilizationPercent` (default `30`) in una finestra di 7 giorni. Il numero di nodi suggerito scala verso un target di utilizzo del 70%, mai sotto 1 nodo e mai sopra il conteggio attuale (`suggestNodeCount` nello scanner). Il risparmio è `(nodeCount − nodeCount suggerito) × <prezzo mensile instance type>`.
+
+Se Container Insights non è attivo su un cluster, lo scanner degrada in modo controllato — emette un warning di scan e non produce **nessun finding** per quel cluster, invece di indovinare da dati mancanti.
+
+> **Nota:** legge solo aggregati a livello di Node Group, mai le `resources.requests`/`resources.limits` dei singoli Pod — non può dirti *quali* Pod sono sovradimensionati, solo che il gruppo nel suo complesso appare sovradimensionato. Un `KubernetesDataPort` per l'accuratezza a livello di Pod è un punto di estensione esplicito, non ancora definito, per una fase futura (ADR-0066) — non aspettartelo da questo scanner oggi.
+
+**`eks-orphan-pvc`** — un volume EBS creato per una PersistentVolumeClaim Kubernetes (identificato tramite il tag del CSI driver `kubernetes.io/created-for/pvc/name`) che è:
+- non attaccato (`state: available`), oppure
+- ancora taggato per un cluster EKS che non esiste più, tramite il tag legacy del provisioner in-tree `kubernetes.io/cluster/<nome>` correlato con `eks:ListClusters`.
+
+Il costo usa la stessa tabella di prezzi EBS statica dello scanner `ebs-volume` (non serve `--live-pricing`).
+
+> **Nota:** il tag col nome del cluster è una convenzione legacy del provisioner in-tree. I volumi creati dal moderno EBS CSI driver senza `--extra-tags` non portano un nome cluster recuperabile — quei volumi vengono intercettati solo dal check "non attaccato", mai da quello sul cluster cancellato. Non è un bug da correggere; è un limite intrinseco di leggere i tag invece di parlare con la Kubernetes API.
+
+## Permessi IAM
+
+Le azioni richieste da tutti e 9 gli scanner sono già incluse nel blocco di policy [Permessi IAM necessari](../../README.md#permessi-iam-necessari) del README: `sqs:ListQueues`/`GetQueueAttributes`/`ListDeadLetterSourceQueues`/`ListQueueTags`, `rds:DescribeDBClusters`, `tag:GetResources`, `eks:ListClusters`/`ListNodegroups`/`DescribeNodegroup`, più le azioni `sagemaker:*` in lettura già preesistenti. `eks-node-overprovisioned` e gli scanner idle di SageMaker richiedono inoltre `pricing:GetProducts` quando eseguiti con `--live-pricing`, come ogni altro scanner con prezzo per-instance-type.

--- a/libs/cloud-cost/domain/src/entities/eks-node-overprovisioned.entity.ts
+++ b/libs/cloud-cost/domain/src/entities/eks-node-overprovisioned.entity.ts
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+import { Entity } from 'shared-kernel';
+import { AwsRegion } from '../value-objects/aws-region.value-object';
+import { CostEstimate } from '../value-objects/cost-estimate.value-object';
+import type { WastedResource } from '../wasted-resource';
+
+/**
+ * EKS Node Group whose allocated capacity is far above what's actually
+ * requested by scheduled Pods, per Container Insights' node-level
+ * aggregates (`node_cpu_request`/`node_cpu_limit`). AWS-API-only, no
+ * kubeconfig — see ADR-0066: this sees Node-group-level aggregates, never
+ * individual Pod requests/limits.
+ *
+ * Advisory (`estimated`): `monthlyCostUsd` here is the potential *saving*
+ * from scaling the group down to `suggestedNodeCount`, not the group's
+ * current cost (same convention as {@link AuroraServerlessOverprovisioned}).
+ */
+export interface EksNodeOverprovisionedProps {
+  clusterName: string;
+  nodegroupName: string;
+  region: AwsRegion;
+  accountId: string;
+  instanceType: string;
+  nodeCount: number;
+  suggestedNodeCount: number;
+  cpuAllocatableMillis: number;
+  cpuRequestedMillis: number;
+  memoryAllocatableBytes: number;
+  memoryRequestedBytes: number;
+  /**
+   * Whether Container Insights actually returned a datapoint for the
+   * window. `false` means "no evidence" (Container Insights likely not
+   * enabled on the cluster) — the policy must not treat it as an idle floor.
+   */
+  hasDatapoint: boolean;
+  windowHours: number;
+  nodegroupCreateTime: Date;
+  detectedAt: Date;
+  tags: Record<string, string>;
+  monthlyCostUsd: number;
+}
+
+export class EksNodeOverprovisioned extends Entity<string> implements WastedResource {
+  private readonly props: Readonly<EksNodeOverprovisionedProps>;
+
+  constructor(props: EksNodeOverprovisionedProps) {
+    super(`${props.clusterName}/${props.nodegroupName}`);
+    this.props = this.deepFreeze({ ...props });
+  }
+
+  get region(): AwsRegion { return this.props.region; }
+  get accountId(): string { return this.props.accountId; }
+  get clusterName(): string { return this.props.clusterName; }
+  get nodegroupName(): string { return this.props.nodegroupName; }
+  get instanceType(): string { return this.props.instanceType; }
+  get nodeCount(): number { return this.props.nodeCount; }
+  get suggestedNodeCount(): number { return this.props.suggestedNodeCount; }
+  get cpuAllocatableMillis(): number { return this.props.cpuAllocatableMillis; }
+  get cpuRequestedMillis(): number { return this.props.cpuRequestedMillis; }
+  get memoryAllocatableBytes(): number { return this.props.memoryAllocatableBytes; }
+  get memoryRequestedBytes(): number { return this.props.memoryRequestedBytes; }
+  get hasDatapoint(): boolean { return this.props.hasDatapoint; }
+  get windowHours(): number { return this.props.windowHours; }
+  get nodegroupCreateTime(): Date { return this.props.nodegroupCreateTime; }
+  get detectedAt(): Date { return this.props.detectedAt; }
+  get tags(): Record<string, string> { return this.props.tags; }
+
+  get kind(): 'eks-node-overprovisioned' { return 'eks-node-overprovisioned'; }
+
+  get cpuRequestedPercent(): number {
+    return this.props.cpuAllocatableMillis > 0
+      ? (this.props.cpuRequestedMillis / this.props.cpuAllocatableMillis) * 100
+      : 0;
+  }
+
+  get wasteReason(): string {
+    return `CPU requested ${this.cpuRequestedPercent.toFixed(1)}% of allocatable across ${this.props.nodeCount} node(s) over ${this.props.windowHours}h — Container Insights node-level aggregate, not Pod-level (ADR-0066)`;
+  }
+
+  get costEstimate(): CostEstimate {
+    return CostEstimate.of(
+      this.props.monthlyCostUsd,
+      `EKS node group ${this.props.clusterName}/${this.props.nodegroupName} ${this.props.instanceType} ${this.props.nodeCount}→${this.props.suggestedNodeCount} nodes — estimated saving`,
+    );
+  }
+}

--- a/libs/cloud-cost/domain/src/entities/eks-orphan-pvc.entity.ts
+++ b/libs/cloud-cost/domain/src/entities/eks-orphan-pvc.entity.ts
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+import { Entity } from 'shared-kernel';
+import { AwsRegion } from '../value-objects/aws-region.value-object';
+import { CostEstimate } from '../value-objects/cost-estimate.value-object';
+import type { WastedResource } from '../wasted-resource';
+
+export interface EksOrphanPvcProps {
+  volumeId: string;
+  region: AwsRegion;
+  accountId: string;
+  pvcName: string;
+  pvcNamespace: string;
+  /**
+   * Owning cluster, recovered from the `kubernetes.io/cluster/<name>` tag
+   * (legacy in-tree provisioner convention — CSI-driver-provisioned volumes
+   * without `--extra-tags` won't carry it). Undefined means "no evidence
+   * either way", not "no cluster" — see ADR-0066.
+   */
+  clusterName?: string;
+  /** Whether `clusterName` still appears in `eks:ListClusters`. `true` when `clusterName` is undefined. */
+  clusterExists: boolean;
+  sizeGb: number;
+  volumeType: string;
+  state: string;
+  createdTime: Date;
+  detectedAt: Date;
+  tags: Record<string, string>;
+  monthlyCostUsd: number;
+}
+
+/**
+ * EBS volume provisioned for a Kubernetes PersistentVolumeClaim on EKS
+ * (identified via the CSI driver's `kubernetes.io/created-for/pvc/name` tag)
+ * that is either unattached, or still tagged for a cluster that no longer
+ * exists. AWS-API-only, no kubeconfig — see ADR-0066.
+ */
+export class EksOrphanPvc extends Entity<string> implements WastedResource {
+  private readonly props: Readonly<EksOrphanPvcProps>;
+
+  constructor(props: EksOrphanPvcProps) {
+    super(props.volumeId);
+    this.props = this.deepFreeze({ ...props });
+  }
+
+  get region(): AwsRegion { return this.props.region; }
+  get accountId(): string { return this.props.accountId; }
+  get pvcName(): string { return this.props.pvcName; }
+  get pvcNamespace(): string { return this.props.pvcNamespace; }
+  get clusterName(): string | undefined { return this.props.clusterName; }
+  get clusterExists(): boolean { return this.props.clusterExists; }
+  get sizeGb(): number { return this.props.sizeGb; }
+  get volumeType(): string { return this.props.volumeType; }
+  get state(): string { return this.props.state; }
+  get createdTime(): Date { return this.props.createdTime; }
+  get detectedAt(): Date { return this.props.detectedAt; }
+  get tags(): Record<string, string> { return this.props.tags; }
+
+  get kind(): 'eks-orphan-pvc' { return 'eks-orphan-pvc'; }
+
+  isUnattached(): boolean {
+    return this.props.state === 'available';
+  }
+
+  get isOrphanedByMissingCluster(): boolean {
+    return this.props.clusterName !== undefined && !this.props.clusterExists;
+  }
+
+  get wasteReason(): string {
+    return this.isOrphanedByMissingCluster
+      ? `owning EKS cluster "${this.props.clusterName}" no longer exists`
+      : 'unattached (Kubernetes PVC volume, no Pod using it)';
+  }
+
+  get costEstimate(): CostEstimate {
+    return CostEstimate.of(
+      this.props.monthlyCostUsd,
+      `${this.props.sizeGb} GB ${this.props.volumeType} orphaned Kubernetes PVC volume (${this.props.pvcNamespace}/${this.props.pvcName})`,
+    );
+  }
+}

--- a/libs/cloud-cost/domain/src/group-by-kind.ts
+++ b/libs/cloud-cost/domain/src/group-by-kind.ts
@@ -36,6 +36,8 @@ import type { SageMakerNotebookIdle } from './entities/sagemaker-notebook-idle.e
 import type { SageMakerEndpointIdle } from './entities/sagemaker-endpoint-idle.entity';
 import type { SageMakerTrainingOrphaned } from './entities/sagemaker-training-orphaned.entity';
 import type { EnvironmentGhost } from './entities/environment-ghost.entity';
+import type { EksNodeOverprovisioned } from './entities/eks-node-overprovisioned.entity';
+import type { EksOrphanPvc } from './entities/eks-orphan-pvc.entity';
 
 /**
  * Map kind → concrete entity. Allows consumers (formatters, frontend)
@@ -78,6 +80,8 @@ export interface ResourceKindMap {
   'sagemaker-endpoint-idle': SageMakerEndpointIdle;
   'sagemaker-training-orphaned': SageMakerTrainingOrphaned;
   'environment-ghost': EnvironmentGhost;
+  'eks-node-overprovisioned': EksNodeOverprovisioned;
+  'eks-orphan-pvc': EksOrphanPvc;
 }
 
 export type FindingsByKind = {

--- a/libs/cloud-cost/domain/src/index.ts
+++ b/libs/cloud-cost/domain/src/index.ts
@@ -89,6 +89,10 @@ export { SageMakerTrainingOrphaned } from './entities/sagemaker-training-orphane
 export type { SageMakerTrainingOrphanedProps } from './entities/sagemaker-training-orphaned.entity';
 export { EnvironmentGhost } from './entities/environment-ghost.entity';
 export type { EnvironmentGhostProps, EnvironmentGhostDetectionMethod } from './entities/environment-ghost.entity';
+export { EksNodeOverprovisioned } from './entities/eks-node-overprovisioned.entity';
+export type { EksNodeOverprovisionedProps } from './entities/eks-node-overprovisioned.entity';
+export { EksOrphanPvc } from './entities/eks-orphan-pvc.entity';
+export type { EksOrphanPvcProps } from './entities/eks-orphan-pvc.entity';
 
 // Value Objects
 export { AwsRegion, InvalidAwsRegionError } from './value-objects/aws-region.value-object';
@@ -140,6 +144,8 @@ export {
   SageMakerEndpointIdlePolicy,
   SageMakerTrainingOrphanedPolicy,
   EnvironmentGhostPolicy,
+  EksNodeOverprovisionedPolicy,
+  EksOrphanPvcPolicy,
 } from './policies/resource-waste-policies';
 
 // Outbound Ports

--- a/libs/cloud-cost/domain/src/policies/resource-waste-policies.ts
+++ b/libs/cloud-cost/domain/src/policies/resource-waste-policies.ts
@@ -36,6 +36,8 @@ import type { SageMakerNotebookIdle } from '../entities/sagemaker-notebook-idle.
 import type { SageMakerEndpointIdle } from '../entities/sagemaker-endpoint-idle.entity';
 import type { SageMakerTrainingOrphaned } from '../entities/sagemaker-training-orphaned.entity';
 import type { EnvironmentGhost } from '../entities/environment-ghost.entity';
+import type { EksNodeOverprovisioned } from '../entities/eks-node-overprovisioned.entity';
+import type { EksOrphanPvc } from '../entities/eks-orphan-pvc.entity';
 
 export class EbsVolumeWastePolicy extends WastePolicy<EbsVolume> {
   protected judge(volume: EbsVolume, now: Date): WasteVerdict {
@@ -473,6 +475,47 @@ export class EnvironmentGhostPolicy extends WastePolicy<EnvironmentGhost> {
     return waste(
       `${env.resourceCount} resource(s) (${env.resourceTypes.join(', ')}) inactive for ${idleDays.toFixed(1)}d`,
     );
+  }
+}
+
+export class EksNodeOverprovisionedPolicy extends WastePolicy<EksNodeOverprovisioned> {
+  /** cpuUtilizationPercent: CPU-requested-to-allocatable ratio (%) below which a node group is "overprovisioned". Default 30. */
+  constructor(options: WastePolicyOptions = {}, private readonly cpuUtilizationPercent = 30) {
+    super(options);
+  }
+
+  protected judge(nodegroup: EksNodeOverprovisioned, now: Date): WasteVerdict {
+    // No Container Insights datapoint is "no evidence" (likely not enabled
+    // on the cluster), not "confirmed zero requests" — same reasoning as
+    // AuroraServerlessOverprovisionedPolicy's hasDatapoint guard.
+    if (!nodegroup.hasDatapoint) return notWaste('no Container Insights datapoint in window');
+    if (nodegroup.cpuRequestedPercent >= this.cpuUtilizationPercent) {
+      return notWaste('CPU requested above threshold');
+    }
+    if (nodegroup.suggestedNodeCount >= nodegroup.nodeCount) {
+      return notWaste('no node count reduction available');
+    }
+    if (this.isWithinGracePeriod(nodegroup.nodegroupCreateTime, now)) {
+      return notWaste(`created less than ${this.minAgeDays}d ago`);
+    }
+    return waste(
+      `CPU requested ${nodegroup.cpuRequestedPercent.toFixed(1)}% of allocatable across ${nodegroup.nodeCount} node(s) over ${nodegroup.windowHours}h`,
+    );
+  }
+}
+
+export class EksOrphanPvcPolicy extends WastePolicy<EksOrphanPvc> {
+  protected judge(volume: EksOrphanPvc, now: Date): WasteVerdict {
+    const orphanedByMissingCluster = volume.isOrphanedByMissingCluster;
+    if (!volume.isUnattached() && !orphanedByMissingCluster) {
+      return notWaste('attached and owning cluster still exists (or unknown)');
+    }
+    if (this.isWithinGracePeriod(volume.createdTime, now)) {
+      return notWaste(`created less than ${this.minAgeDays}d ago`);
+    }
+    return orphanedByMissingCluster
+      ? waste(`owning EKS cluster "${volume.clusterName}" no longer exists`)
+      : waste('unattached (Kubernetes PVC volume, no Pod using it)');
   }
 }
 

--- a/libs/cloud-cost/domain/src/wasted-resource.ts
+++ b/libs/cloud-cost/domain/src/wasted-resource.ts
@@ -39,6 +39,8 @@ export const RESOURCE_KINDS = [
   'sagemaker-endpoint-idle',
   'sagemaker-training-orphaned',
   'environment-ghost',
+  'eks-node-overprovisioned',
+  'eks-orphan-pvc',
 ] as const;
 
 export type ResourceKind = (typeof RESOURCE_KINDS)[number];
@@ -140,6 +142,20 @@ export const RESOURCE_KIND_META: Record<ResourceKind, ResourceKindMeta> = {
   // signals a group of resources nobody tore down.
   'environment-ghost': {
     label: 'Dev/PR Environments (ghost, all resources inactive)',
+    category: 'waste',
+    estimated: false,
+  },
+  // Phase 6.5 (ADR-0065/ADR-0066): EKS cost visibility vertical. Per-instance-
+  // type pricing (requires --live-pricing); the suggested node count is a
+  // heuristic (Container Insights aggregate, not Pod-level), hence estimated.
+  'eks-node-overprovisioned': {
+    label: 'EKS Node Groups (overprovisioned)',
+    category: 'optimization',
+    estimated: true,
+  },
+  // Phase 6.5 (ADR-0065/ADR-0066): EBS pricing is static, no --live-pricing gate.
+  'eks-orphan-pvc': {
+    label: 'EKS Orphaned PVC Volumes',
     category: 'waste',
     estimated: false,
   },

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/index.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/index.ts
@@ -47,6 +47,9 @@ export { AwsSageMakerEndpointIdleScanner } from './scanners/aws-sagemaker-endpoi
 export type { SageMakerEndpointInstancePricingSource } from './scanners/aws-sagemaker-endpoint-idle.scanner';
 export { AwsSageMakerTrainingOrphanedScanner } from './scanners/aws-sagemaker-training-orphaned.scanner';
 export { AwsEnvironmentGhostScanner } from './scanners/aws-environment-ghost.scanner';
+export { AwsEksNodeOverprovisionedScanner, suggestNodeCount } from './scanners/aws-eks-node-overprovisioned.scanner';
+export type { EksNodeInstancePricingSource } from './scanners/aws-eks-node-overprovisioned.scanner';
+export { AwsEksOrphanPvcScanner } from './scanners/aws-eks-orphan-pvc.scanner';
 export { AwsAdapterError } from './errors/aws-adapter.error';
 export {
   StaticPriceTableAdapter,

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-eks-node-overprovisioned.scanner.spec.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-eks-node-overprovisioned.scanner.spec.ts
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: Apache-2.0
+import { EKSClient } from '@aws-sdk/client-eks';
+import { CloudWatchClient, GetMetricStatisticsCommand } from '@aws-sdk/client-cloudwatch';
+import { AwsEksNodeOverprovisionedScanner, suggestNodeCount } from './aws-eks-node-overprovisioned.scanner';
+import type { EksNodeInstancePricingSource } from './aws-eks-node-overprovisioned.scanner';
+import { AwsRegion } from 'cloud-cost-domain';
+import { AwsAdapterError } from '../errors/aws-adapter.error';
+
+jest.mock('@aws-sdk/client-eks');
+jest.mock('@aws-sdk/client-cloudwatch');
+
+const mockEksSend = jest.fn();
+const mockEksDestroy = jest.fn();
+const mockCwSend = jest.fn();
+const mockCwDestroy = jest.fn();
+const mockGetEc2InstancePrice = jest.fn();
+
+const mockPricing: EksNodeInstancePricingSource = {
+  getEc2InstancePricePerMonth: mockGetEc2InstancePrice,
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (EKSClient as jest.Mock).mockImplementation(() => ({ send: mockEksSend, destroy: mockEksDestroy }));
+  (CloudWatchClient as jest.Mock).mockImplementation(() => ({ send: mockCwSend, destroy: mockCwDestroy }));
+  mockGetEc2InstancePrice.mockResolvedValue(70); // $/mo
+});
+
+const region = AwsRegion.create('us-east-1');
+const scanner = new AwsEksNodeOverprovisionedScanner(mockPricing);
+const OLD_DATE = new Date('2024-03-01');
+
+function mockNodegroup(
+  clusterName: string,
+  nodegroupName: string,
+  {
+    desiredSize = 10,
+    instanceTypes = ['m5.xlarge'],
+    createdAt = OLD_DATE,
+    status = 'ACTIVE',
+  }: { desiredSize?: number; instanceTypes?: string[]; createdAt?: Date; status?: string } = {},
+) {
+  mockEksSend.mockResolvedValueOnce({ clusters: [clusterName] });
+  mockEksSend.mockResolvedValueOnce({ nodegroups: [nodegroupName] });
+  mockEksSend.mockResolvedValueOnce({
+    nodegroup: {
+      nodegroupName,
+      clusterName,
+      status,
+      instanceTypes,
+      scalingConfig: { desiredSize },
+      createdAt,
+      tags: {},
+    },
+  });
+}
+
+function mockUtilization(cpuRequest: number | undefined, cpuLimit: number | undefined, memRequest = 0, memLimit = 0) {
+  mockCwSend.mockResolvedValueOnce({ Datapoints: cpuRequest === undefined ? [] : [{ Average: cpuRequest }] });
+  mockCwSend.mockResolvedValueOnce({ Datapoints: cpuLimit === undefined ? [] : [{ Average: cpuLimit }] });
+  mockCwSend.mockResolvedValueOnce({ Datapoints: [{ Average: memRequest }] });
+  mockCwSend.mockResolvedValueOnce({ Datapoints: [{ Average: memLimit }] });
+}
+
+describe('suggestNodeCount', () => {
+  it('scales down toward the 70% CPU-requested target, never below 1', () => {
+    expect(suggestNodeCount(10, 17.5)).toBe(3); // 10 * 17.5/70 = 2.5 → ceil 3
+    expect(suggestNodeCount(10, 0)).toBe(1);
+  });
+
+  it('never exceeds the current node count', () => {
+    expect(suggestNodeCount(2, 90)).toBe(2);
+  });
+
+  it('returns 0 for a zero-size group', () => {
+    expect(suggestNodeCount(0, 50)).toBe(0);
+  });
+});
+
+describe('AwsEksNodeOverprovisionedScanner', () => {
+  it('exposes its resource kind', () => {
+    expect(scanner.kind).toBe('eks-node-overprovisioned');
+  });
+
+  it('reports a node group whose CPU requested is far below allocatable', async () => {
+    mockNodegroup('prod-cluster', 'app-workers', { desiredSize: 10 });
+    mockUtilization(700, 4000); // 700/4000 = 17.5% < 30% → overprovisioned
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.map((n) => n.id)).toEqual(['prod-cluster/app-workers']);
+    // suggested = suggestNodeCount(10, 17.5) = 3; saving = (10 - 3) * 70
+    expect(result.value[0].costEstimate.monthlyCostUsd).toBeCloseTo(7 * 70, 2);
+  });
+
+  it('does not report a node group whose CPU requested is above the threshold', async () => {
+    mockNodegroup('prod-cluster', 'busy-workers', { desiredSize: 10 });
+    mockUtilization(3500, 4000); // 87.5% >= 30% → not overprovisioned
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toHaveLength(0);
+  });
+
+  it('does not report a just-created node group within the grace period', async () => {
+    mockNodegroup('prod-cluster', 'fresh-workers', { desiredSize: 10, createdAt: new Date() });
+    mockUtilization(700, 4000);
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toHaveLength(0);
+  });
+
+  it('does not report a single-node group with no reduction available', async () => {
+    mockNodegroup('prod-cluster', 'tiny-workers', { desiredSize: 1 });
+    mockUtilization(100, 4000);
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toHaveLength(0);
+  });
+
+  it('does not report a node group with no Container Insights datapoint (no evidence, not confirmed idle)', async () => {
+    mockNodegroup('prod-cluster', 'no-insights-workers', { desiredSize: 10 });
+    mockUtilization(undefined, undefined);
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toHaveLength(0);
+  });
+
+  it('ignores node groups that are not ACTIVE', async () => {
+    mockNodegroup('prod-cluster', 'creating-workers', { desiredSize: 10, status: 'CREATING' });
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toHaveLength(0);
+    expect(mockCwSend).not.toHaveBeenCalled();
+  });
+
+  it('queries Container Insights CPU/memory request+limit metrics keyed by cluster and node group', async () => {
+    mockNodegroup('prod-cluster', 'app-workers');
+    mockUtilization(700, 4000);
+
+    await scanner.scan(region);
+
+    const calls = (GetMetricStatisticsCommand as unknown as jest.Mock).mock.calls.map((c) => c[0]);
+    expect(calls).toHaveLength(4);
+    for (const args of calls) {
+      expect(args.Namespace).toBe('ContainerInsights');
+      expect(args.Dimensions).toEqual([
+        { Name: 'ClusterName', Value: 'prod-cluster' },
+        { Name: 'NodegroupName', Value: 'app-workers' },
+      ]);
+    }
+    expect(calls.map((a) => a.MetricName)).toEqual([
+      'node_cpu_request',
+      'node_cpu_limit',
+      'node_memory_request',
+      'node_memory_limit',
+    ]);
+  });
+
+  it('returns Result.fail wrapping AwsAdapterError and destroys both clients on error', async () => {
+    mockEksSend.mockRejectedValueOnce(new Error('boom'));
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect((result.error as AwsAdapterError).service).toBe('EKS');
+    expect(mockEksDestroy).toHaveBeenCalledTimes(1);
+    expect(mockCwDestroy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-eks-node-overprovisioned.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-eks-node-overprovisioned.scanner.ts
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: Apache-2.0
+import {
+  EKSClient,
+  ListClustersCommand,
+  ListNodegroupsCommand,
+  DescribeNodegroupCommand,
+  type Nodegroup,
+} from '@aws-sdk/client-eks';
+import type { CloudWatchClient } from '@aws-sdk/client-cloudwatch';
+import { createLogger } from 'shared-kernel';
+import type { AwsRegion, WastePolicy } from 'cloud-cost-domain';
+import { EksNodeOverprovisioned, EksNodeOverprovisionedPolicy } from 'cloud-cost-domain';
+import { createAwsClientConfig } from '../utils/client-config';
+import { paginate } from '../utils/paginate';
+import { mapWithConcurrency } from '../utils/map-with-concurrency';
+import { getMetricDatapoint, type MetricWindow } from '../utils/cloudwatch-metrics';
+import { CloudWatchIdleScanner } from './cloudwatch-idle.scanner';
+
+// Rightsizing signal — the longer window, same reasoning as Aurora/EC2/RDS
+// underutilized scanners (a rare weekly peak shouldn't look like an idle floor).
+const DEFAULT_LOOKBACK_HOURS = 168;
+const LIST_CONCURRENCY = 5;
+const PRICING_CONCURRENCY = 5;
+// Target CPU-requested-to-allocatable ratio the suggested node count aims
+// for — headroom above the "overprovisioned" alarm threshold so the
+// suggestion isn't itself right at the edge.
+const TARGET_CPU_UTILIZATION_PERCENT = 70;
+const logger = createLogger('cloudrift:scanner');
+
+export interface EksNodeInstancePricingSource {
+  getEc2InstancePricePerMonth(region: AwsRegion, instanceType: string): Promise<number | undefined>;
+}
+
+type ActiveNodegroup = Nodegroup & {
+  clusterName: string;
+  nodegroupName: string;
+  instanceTypes: string[];
+  scalingConfig: { desiredSize: number };
+};
+
+interface NodegroupUtilization {
+  cpuAllocatableMillis: number;
+  cpuRequestedMillis: number;
+  memoryAllocatableBytes: number;
+  memoryRequestedBytes: number;
+  /** false when Container Insights returned no datapoint (likely not enabled). */
+  hasDatapoint: boolean;
+}
+
+/**
+ * Recommended node count: scale down until the CPU-requested-to-allocatable
+ * ratio would reach {@link TARGET_CPU_UTILIZATION_PERCENT}, never below 1
+ * node and never above the current count.
+ */
+export function suggestNodeCount(nodeCount: number, cpuRequestedPercent: number): number {
+  if (nodeCount <= 0) return 0;
+  const suggested = Math.ceil(nodeCount * (cpuRequestedPercent / TARGET_CPU_UTILIZATION_PERCENT));
+  return Math.max(1, Math.min(nodeCount, suggested));
+}
+
+/**
+ * Detects EKS Node Groups whose allocated capacity is far above what's
+ * requested by scheduled Pods, per Container Insights' node-level
+ * aggregates. AWS-API-only (ADR-0066): `eks:ListClusters` →
+ * `eks:ListNodegroups` → `eks:DescribeNodegroup`, plus CloudWatch Container
+ * Insights metrics. If Container Insights isn't enabled on a cluster, no
+ * datapoint comes back and the policy refuses to flag it (graceful degrade,
+ * same convention as {@link AwsAuroraServerlessIdleScanner}'s `hasDatapoint`).
+ * Per-instance-type pricing, so gated on `--live-pricing` (ADR-0037).
+ */
+export class AwsEksNodeOverprovisionedScanner extends CloudWatchIdleScanner<
+  EKSClient,
+  ActiveNodegroup,
+  NodegroupUtilization,
+  EksNodeOverprovisioned
+> {
+  readonly kind = 'eks-node-overprovisioned' as const;
+  protected readonly serviceLabel = 'EKS';
+
+  constructor(
+    private readonly pricing: EksNodeInstancePricingSource,
+    private readonly accountId = 'unknown',
+    policy: WastePolicy<EksNodeOverprovisioned> = new EksNodeOverprovisionedPolicy(),
+    windowHours = DEFAULT_LOOKBACK_HOURS,
+  ) {
+    super(policy, windowHours);
+  }
+
+  protected createPrimaryClient(region: AwsRegion): EKSClient {
+    return new EKSClient({ ...createAwsClientConfig(), region: region.code });
+  }
+
+  protected destroyPrimaryClient(client: EKSClient): void {
+    client.destroy();
+  }
+
+  protected async listResources(client: EKSClient): Promise<ActiveNodegroup[]> {
+    const clusterNames = await paginate<string>(async (cursor) => {
+      const r = await client.send(new ListClustersCommand({ nextToken: cursor }));
+      return { items: r.clusters ?? [], cursor: r.nextToken };
+    });
+
+    const nodegroupRefs = (
+      await mapWithConcurrency(clusterNames, LIST_CONCURRENCY, async (clusterName) => {
+        const nodegroupNames = await paginate<string>(async (cursor) => {
+          const r = await client.send(new ListNodegroupsCommand({ clusterName, nextToken: cursor }));
+          return { items: r.nodegroups ?? [], cursor: r.nextToken };
+        });
+        return nodegroupNames.map((nodegroupName) => ({ clusterName, nodegroupName }));
+      })
+    ).flat();
+
+    const nodegroups = await mapWithConcurrency(nodegroupRefs, LIST_CONCURRENCY, async ({ clusterName, nodegroupName }) => {
+      const r = await client.send(new DescribeNodegroupCommand({ clusterName, nodegroupName }));
+      return r.nodegroup;
+    });
+
+    const active = nodegroups.filter(
+      (ng): ng is ActiveNodegroup =>
+        !!ng &&
+        ng.status === 'ACTIVE' &&
+        !!ng.clusterName &&
+        !!ng.nodegroupName &&
+        Array.isArray(ng.instanceTypes) &&
+        ng.instanceTypes.length > 0 &&
+        typeof ng.scalingConfig?.desiredSize === 'number',
+    );
+    if (active.length !== nodegroups.length) {
+      logger.debug(`${this.kind}: skipped ${nodegroups.length - active.length} non-ACTIVE (or incomplete) node groups`);
+    }
+    return active;
+  }
+
+  protected async fetchMetric(
+    cw: CloudWatchClient,
+    _region: AwsRegion,
+    ng: ActiveNodegroup,
+    window: MetricWindow,
+  ): Promise<NodegroupUtilization> {
+    const dimensions = [
+      { Name: 'ClusterName', Value: ng.clusterName },
+      { Name: 'NodegroupName', Value: ng.nodegroupName },
+    ];
+    const [cpuRequest, cpuLimit, memRequest, memLimit] = await Promise.all([
+      getMetricDatapoint(cw, 'ContainerInsights', 'node_cpu_request', dimensions, window, ['Average']),
+      getMetricDatapoint(cw, 'ContainerInsights', 'node_cpu_limit', dimensions, window, ['Average']),
+      getMetricDatapoint(cw, 'ContainerInsights', 'node_memory_request', dimensions, window, ['Average']),
+      getMetricDatapoint(cw, 'ContainerInsights', 'node_memory_limit', dimensions, window, ['Average']),
+    ]);
+    return {
+      cpuRequestedMillis: cpuRequest.Average ?? 0,
+      cpuAllocatableMillis: cpuLimit.Average ?? 0,
+      memoryRequestedBytes: memRequest.Average ?? 0,
+      memoryAllocatableBytes: memLimit.Average ?? 0,
+      // node_cpu_limit missing is the reliable "Container Insights isn't
+      // reporting for this node group" signal (allocatable capacity is
+      // always non-zero once it IS reporting; request can legitimately be 0).
+      hasDatapoint: cpuLimit.Average !== undefined,
+    };
+  }
+
+  protected override async resolvePrices(raw: ActiveNodegroup[], region: AwsRegion): Promise<Map<string, number>> {
+    const instanceTypes = [...new Set(raw.map((ng) => ng.instanceTypes[0] ?? 'unknown'))];
+    const entries = await mapWithConcurrency(instanceTypes, PRICING_CONCURRENCY, async (instanceType) => ({
+      instanceType,
+      price: (await this.pricing.getEc2InstancePricePerMonth(region, instanceType)) ?? 0,
+    }));
+    return new Map(entries.map((e) => [e.instanceType, e.price]));
+  }
+
+  protected toEntity(
+    ng: ActiveNodegroup,
+    metric: NodegroupUtilization,
+    prices: Map<string, number>,
+    region: AwsRegion,
+    now: Date,
+  ): EksNodeOverprovisioned {
+    const instanceType = ng.instanceTypes[0] ?? 'unknown';
+    const nodeCount = ng.scalingConfig.desiredSize;
+    const cpuRequestedPercent =
+      metric.cpuAllocatableMillis > 0 ? (metric.cpuRequestedMillis / metric.cpuAllocatableMillis) * 100 : 0;
+    const suggestedNodeCount = suggestNodeCount(nodeCount, cpuRequestedPercent);
+    const instancePrice = prices.get(instanceType) ?? 0;
+    // Not gated on hasDatapoint: an entity is still built so the (notWaste)
+    // policy verdict can be reasoned about, same convention as Aurora.
+    const monthlySavingsUsd = Math.max(0, nodeCount - suggestedNodeCount) * instancePrice;
+    return new EksNodeOverprovisioned({
+      clusterName: ng.clusterName,
+      nodegroupName: ng.nodegroupName,
+      region,
+      accountId: this.accountId,
+      instanceType,
+      nodeCount,
+      suggestedNodeCount,
+      cpuAllocatableMillis: metric.cpuAllocatableMillis,
+      cpuRequestedMillis: metric.cpuRequestedMillis,
+      memoryAllocatableBytes: metric.memoryAllocatableBytes,
+      memoryRequestedBytes: metric.memoryRequestedBytes,
+      hasDatapoint: metric.hasDatapoint,
+      windowHours: this.windowHours,
+      nodegroupCreateTime: ng.createdAt ?? new Date(0),
+      detectedAt: now,
+      tags: ng.tags ?? {},
+      monthlyCostUsd: +monthlySavingsUsd.toFixed(4),
+    });
+  }
+}

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-eks-orphan-pvc.scanner.spec.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-eks-orphan-pvc.scanner.spec.ts
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: Apache-2.0
+import { EC2Client, DescribeVolumesCommand } from '@aws-sdk/client-ec2';
+import { EKSClient, ListClustersCommand } from '@aws-sdk/client-eks';
+import { AwsEksOrphanPvcScanner } from './aws-eks-orphan-pvc.scanner';
+import { AwsRegion, type PricingPort } from 'cloud-cost-domain';
+import { AwsAdapterError } from '../errors/aws-adapter.error';
+import { mockPricing } from '../testing/mock-pricing';
+
+jest.mock('@aws-sdk/client-ec2');
+jest.mock('@aws-sdk/client-eks');
+
+const mockEc2Send = jest.fn();
+const mockEc2Destroy = jest.fn();
+const mockEksSend = jest.fn();
+const mockEksDestroy = jest.fn();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (EC2Client as jest.Mock).mockImplementation(() => ({ send: mockEc2Send, destroy: mockEc2Destroy }));
+  (EKSClient as jest.Mock).mockImplementation(() => ({ send: mockEksSend, destroy: mockEksDestroy }));
+  mockEksSend.mockResolvedValue({ clusters: [] });
+});
+
+const region = AwsRegion.create('us-east-1');
+const scanner = new AwsEksOrphanPvcScanner(mockPricing);
+const OLD_DATE = new Date('2025-01-01');
+
+function pvcVolume(overrides: Record<string, unknown> = {}) {
+  return {
+    VolumeId: 'vol-pvc-1',
+    Size: 20,
+    VolumeType: 'gp3',
+    State: 'available',
+    CreateTime: OLD_DATE,
+    Tags: [
+      { Key: 'kubernetes.io/created-for/pvc/name', Value: 'data-pvc' },
+      { Key: 'kubernetes.io/created-for/pvc/namespace', Value: 'app-ns' },
+    ],
+    ...overrides,
+  };
+}
+
+describe('AwsEksOrphanPvcScanner', () => {
+  it('exposes its resource kind', () => {
+    expect(scanner.kind).toBe('eks-orphan-pvc');
+  });
+
+  it('reports an unattached PVC volume with no recoverable cluster tag', async () => {
+    mockEc2Send.mockResolvedValueOnce({ Volumes: [pvcVolume()] });
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.map((v) => v.id)).toEqual(['vol-pvc-1']);
+    expect(result.value[0].costEstimate.monthlyCostUsd).toBeCloseTo(1.6, 2); // 20 GB * $0.08 gp3
+  });
+
+  it('reports an in-use volume whose owning cluster no longer exists', async () => {
+    mockEc2Send.mockResolvedValueOnce({
+      Volumes: [
+        pvcVolume({
+          State: 'in-use',
+          Tags: [
+            { Key: 'kubernetes.io/created-for/pvc/name', Value: 'data-pvc' },
+            { Key: 'kubernetes.io/created-for/pvc/namespace', Value: 'app-ns' },
+            { Key: 'kubernetes.io/cluster/gone-cluster', Value: 'owned' },
+          ],
+        }),
+      ],
+    });
+    mockEksSend.mockResolvedValueOnce({ clusters: ['other-cluster'] });
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.map((v) => v.id)).toEqual(['vol-pvc-1']);
+  });
+
+  it('does not report an in-use volume whose owning cluster still exists', async () => {
+    mockEc2Send.mockResolvedValueOnce({
+      Volumes: [
+        pvcVolume({
+          State: 'in-use',
+          Tags: [
+            { Key: 'kubernetes.io/created-for/pvc/name', Value: 'data-pvc' },
+            { Key: 'kubernetes.io/created-for/pvc/namespace', Value: 'app-ns' },
+            { Key: 'kubernetes.io/cluster/prod-cluster', Value: 'owned' },
+          ],
+        }),
+      ],
+    });
+    mockEksSend.mockResolvedValueOnce({ clusters: ['prod-cluster'] });
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toHaveLength(0);
+  });
+
+  it('does not report a just-created unattached volume within the grace period', async () => {
+    mockEc2Send.mockResolvedValueOnce({ Volumes: [pvcVolume({ CreateTime: new Date() })] });
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toHaveLength(0);
+  });
+
+  it('sends DescribeVolumesCommand filtered on the PVC tag key', async () => {
+    mockEc2Send.mockResolvedValueOnce({ Volumes: [] });
+
+    await scanner.scan(region);
+
+    expect(mockEc2Send).toHaveBeenCalledWith(expect.any(DescribeVolumesCommand));
+    const constructorArgs = (DescribeVolumesCommand as unknown as jest.Mock).mock.calls[0][0];
+    expect(constructorArgs.Filters).toEqual([
+      { Name: 'tag-key', Values: ['kubernetes.io/created-for/pvc/name'] },
+    ]);
+    expect(mockEksSend).toHaveBeenCalledWith(expect.any(ListClustersCommand));
+  });
+
+  it('handles missing optional fields with safe defaults', async () => {
+    mockEc2Send.mockResolvedValueOnce({
+      Volumes: [{ VolumeId: 'vol-bare', Size: 5, State: 'available', CreateTime: OLD_DATE }],
+    });
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const vol = result.value[0] as import('cloud-cost-domain').EksOrphanPvc;
+    expect(vol.volumeType).toBe('gp2');
+    expect(vol.pvcName).toBe('unknown');
+    expect(vol.pvcNamespace).toBe('unknown');
+    expect(vol.clusterName).toBeUndefined();
+  });
+
+  it('destroys both clients after a successful call and after a failure', async () => {
+    mockEc2Send.mockResolvedValueOnce({ Volumes: [] });
+    await scanner.scan(region);
+    expect(mockEc2Destroy).toHaveBeenCalledTimes(1);
+    expect(mockEksDestroy).toHaveBeenCalledTimes(1);
+
+    mockEc2Send.mockRejectedValueOnce(new Error('boom'));
+    await scanner.scan(region);
+    expect(mockEc2Destroy).toHaveBeenCalledTimes(2);
+    expect(mockEksDestroy).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns Result.fail wrapping AwsAdapterError on SDK error', async () => {
+    mockEc2Send.mockRejectedValueOnce(new Error('Network error'));
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBeInstanceOf(AwsAdapterError);
+      expect((result.error as AwsAdapterError).service).toBe('EBS');
+    }
+  });
+
+  it('follows NextToken across multiple volume pages and aggregates all volumes', async () => {
+    mockEc2Send
+      .mockResolvedValueOnce({ Volumes: [pvcVolume({ VolumeId: 'vol-page1' })], NextToken: 'cursor-2' })
+      .mockResolvedValueOnce({ Volumes: [pvcVolume({ VolumeId: 'vol-page2' })] });
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.map((v) => v.id)).toEqual(['vol-page1', 'vol-page2']);
+  });
+});
+
+// Ensures the mock pricing stays aligned with the real PricingPort.
+const _typecheck: PricingPort = mockPricing;
+void _typecheck;

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-eks-orphan-pvc.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-eks-orphan-pvc.scanner.ts
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: Apache-2.0
+import { EC2Client, DescribeVolumesCommand, type Volume } from '@aws-sdk/client-ec2';
+import { EKSClient, ListClustersCommand } from '@aws-sdk/client-eks';
+import { Result, createLogger } from 'shared-kernel';
+import type { AwsRegion, PricingPort, WasteScannerPort, WastedResource } from 'cloud-cost-domain';
+import { EksOrphanPvc, EksOrphanPvcPolicy } from 'cloud-cost-domain';
+import { AwsAdapterError } from '../errors/aws-adapter.error';
+import { paginate } from '../utils/paginate';
+import { createAwsClientConfig } from '../utils/client-config';
+
+const logger = createLogger('cloudrift:scanner');
+
+const PVC_NAME_TAG = 'kubernetes.io/created-for/pvc/name';
+const PVC_NAMESPACE_TAG = 'kubernetes.io/created-for/pvc/namespace';
+// Legacy in-tree provisioner convention — the only tag that recovers the
+// owning cluster's name from the volume itself (ADR-0066).
+const CLUSTER_TAG_PREFIX = 'kubernetes.io/cluster/';
+
+type VolumeWithIdAndSize = Volume & { VolumeId: string; Size: number };
+
+function clusterNameFromTags(tags: Record<string, string>): string | undefined {
+  const key = Object.keys(tags).find((k) => k.startsWith(CLUSTER_TAG_PREFIX));
+  return key ? key.slice(CLUSTER_TAG_PREFIX.length) : undefined;
+}
+
+/**
+ * Detects EBS volumes provisioned for an EKS PersistentVolumeClaim
+ * (identified via the CSI driver's `kubernetes.io/created-for/pvc/name` tag)
+ * that are either unattached, or still tagged for a cluster that no longer
+ * exists. AWS-API-only (ADR-0066): `ec2:DescribeVolumes` (prefiltered on the
+ * PVC tag) + `eks:ListClusters` for the cluster-existence cross-reference.
+ */
+export class AwsEksOrphanPvcScanner implements WasteScannerPort {
+  readonly kind = 'eks-orphan-pvc' as const;
+
+  constructor(
+    private readonly pricing: PricingPort,
+    private readonly accountId = 'unknown',
+    private readonly policy = new EksOrphanPvcPolicy(),
+  ) {}
+
+  async scan(region: AwsRegion): Promise<Result<WastedResource[]>> {
+    const ec2 = new EC2Client({ ...createAwsClientConfig(), region: region.code });
+    const eks = new EKSClient({ ...createAwsClientConfig(), region: region.code });
+    try {
+      const [rawVolumes, clusterNames] = await Promise.all([
+        paginate<Volume>(async (cursor) => {
+          const r = await ec2.send(
+            new DescribeVolumesCommand({
+              Filters: [{ Name: 'tag-key', Values: [PVC_NAME_TAG] }],
+              NextToken: cursor,
+            }),
+          );
+          return { items: r.Volumes ?? [], cursor: r.NextToken };
+        }),
+        paginate<string>(async (cursor) => {
+          const r = await eks.send(new ListClustersCommand({ nextToken: cursor }));
+          return { items: r.clusters ?? [], cursor: r.nextToken };
+        }),
+      ]);
+
+      const existingClusters = new Set(clusterNames);
+      const now = new Date();
+      const validVolumes = rawVolumes.filter(
+        (v): v is VolumeWithIdAndSize => !!v.VolumeId && v.Size !== undefined,
+      );
+      if (validVolumes.length !== rawVolumes.length) {
+        logger.debug(`${this.kind}: skipped ${rawVolumes.length - validVolumes.length} entries missing VolumeId/Size`);
+      }
+
+      const volumes = validVolumes
+        .map((v) => {
+          const tags = Object.fromEntries((v.Tags ?? []).map((t) => [t.Key ?? '', t.Value ?? '']));
+          const volumeType = v.VolumeType ?? 'gp2';
+          const pricePerGb =
+            this.pricing.getPrice(region, `ebs-${volumeType}`) || this.pricing.getPrice(region, 'ebs-gp3');
+          const clusterName = clusterNameFromTags(tags);
+          return new EksOrphanPvc({
+            volumeId: v.VolumeId,
+            region,
+            accountId: this.accountId,
+            pvcName: tags[PVC_NAME_TAG] ?? 'unknown',
+            pvcNamespace: tags[PVC_NAMESPACE_TAG] ?? 'unknown',
+            clusterName,
+            // No cluster tag recoverable from the volume: treat existence as
+            // "unknown", not "confirmed gone" (see class + entity docs).
+            clusterExists: clusterName === undefined || existingClusters.has(clusterName),
+            sizeGb: v.Size,
+            volumeType,
+            state: v.State ?? 'available',
+            createdTime: v.CreateTime ?? new Date(),
+            detectedAt: now,
+            tags,
+            monthlyCostUsd: +(pricePerGb * v.Size).toFixed(4),
+          });
+        })
+        .filter((volume) => this.policy.evaluate(volume, now).isWaste);
+
+      return Result.ok(volumes);
+    } catch (err) {
+      return Result.fail(new AwsAdapterError('EBS', err as Error));
+    } finally {
+      ec2.destroy();
+      eks.destroy();
+    }
+  }
+}

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/scanner-contract.spec.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/scanner-contract.spec.ts
@@ -51,6 +51,8 @@ import {
   SageMakerEndpointIdlePolicy,
   SageMakerTrainingOrphanedPolicy,
   EnvironmentGhostPolicy,
+  EksNodeOverprovisionedPolicy,
+  EksOrphanPvcPolicy,
 } from 'cloud-cost-domain';
 import type { ResourceKind, WasteScannerPort } from 'cloud-cost-domain';
 import { AwsEbsVolumeScanner } from './aws-ebs-volume.scanner';
@@ -89,6 +91,8 @@ import { AwsSageMakerNotebookIdleScanner } from './aws-sagemaker-notebook-idle.s
 import { AwsSageMakerEndpointIdleScanner } from './aws-sagemaker-endpoint-idle.scanner';
 import { AwsSageMakerTrainingOrphanedScanner } from './aws-sagemaker-training-orphaned.scanner';
 import { AwsEnvironmentGhostScanner } from './aws-environment-ghost.scanner';
+import { AwsEksNodeOverprovisionedScanner } from './aws-eks-node-overprovisioned.scanner';
+import { AwsEksOrphanPvcScanner } from './aws-eks-orphan-pvc.scanner';
 import { StaticPriceTableAdapter } from '../pricing/static-price-table.adapter';
 
 interface ContractFixture {
@@ -221,6 +225,9 @@ const scannerFactories: Record<ResourceKind, () => WasteScannerPort> = {
     new AwsSageMakerTrainingOrphanedScanner(pricing, ACCOUNT, new SageMakerTrainingOrphanedPolicy(po)),
   'environment-ghost': () =>
     new AwsEnvironmentGhostScanner(ACCOUNT, new EnvironmentGhostPolicy(po, 7), undefined, undefined, 7),
+  'eks-node-overprovisioned': () =>
+    new AwsEksNodeOverprovisionedScanner(livePrices, ACCOUNT, new EksNodeOverprovisionedPolicy(po, 30)),
+  'eks-orphan-pvc': () => new AwsEksOrphanPvcScanner(pricing, ACCOUNT, new EksOrphanPvcPolicy(po)),
 };
 
 const byId = (a: { id: string }, b: { id: string }) => a.id.localeCompare(b.id);

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/testing/contract-fixtures/eks-node-overprovisioned.json
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/testing/contract-fixtures/eks-node-overprovisioned.json
@@ -1,0 +1,61 @@
+{
+  "kind": "eks-node-overprovisioned",
+  "source": "transcribed from the AWS API reference (--live-pricing scanner, see ec2-underutilized.json), 2026-07-15 — expected cost = (10 - 3) * stub price 70",
+  "region": "us-east-1",
+  "accountId": "000000000000",
+  "pages": {
+    "ListClustersCommand": [
+      {
+        "clusters": ["prod-cluster"],
+        "$metadata": { "httpStatusCode": 200 }
+      }
+    ],
+    "ListNodegroupsCommand": [
+      {
+        "nodegroups": ["app-workers"],
+        "$metadata": { "httpStatusCode": 200 }
+      }
+    ],
+    "DescribeNodegroupCommand": [
+      {
+        "nodegroup": {
+          "nodegroupName": "app-workers",
+          "clusterName": "prod-cluster",
+          "status": "ACTIVE",
+          "instanceTypes": ["m5.xlarge"],
+          "scalingConfig": { "minSize": 3, "maxSize": 15, "desiredSize": 10 },
+          "createdAt": "2023-01-01T00:00:00.000Z",
+          "tags": {}
+        },
+        "$metadata": { "httpStatusCode": 200 }
+      }
+    ],
+    "GetMetricStatisticsCommand": [
+      {
+        "Label": "node_cpu_request",
+        "Datapoints": [{ "Average": 700 }],
+        "$metadata": { "httpStatusCode": 200 }
+      },
+      {
+        "Label": "node_cpu_limit",
+        "Datapoints": [{ "Average": 4000 }],
+        "$metadata": { "httpStatusCode": 200 }
+      },
+      {
+        "Label": "node_memory_request",
+        "Datapoints": [{ "Average": 2000000000 }],
+        "$metadata": { "httpStatusCode": 200 }
+      },
+      {
+        "Label": "node_memory_limit",
+        "Datapoints": [{ "Average": 8000000000 }],
+        "$metadata": { "httpStatusCode": 200 }
+      }
+    ]
+  },
+  "expected": {
+    "findings": [
+      { "id": "prod-cluster/app-workers", "monthlyCostUsd": 490 }
+    ]
+  }
+}

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/testing/contract-fixtures/eks-orphan-pvc.json
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/testing/contract-fixtures/eks-orphan-pvc.json
@@ -1,0 +1,37 @@
+{
+  "kind": "eks-orphan-pvc",
+  "source": "transcribed from the AWS API reference (static-pricing scanner, see ebs-volume.json), 2026-07-15 — expected cost = 50 GB * ebs-gp3 us-east-1 price 0.08",
+  "region": "us-east-1",
+  "accountId": "000000000000",
+  "pages": {
+    "DescribeVolumesCommand": [
+      {
+        "Volumes": [
+          {
+            "VolumeId": "vol-0pvc12345",
+            "Size": 50,
+            "VolumeType": "gp3",
+            "State": "available",
+            "CreateTime": "2023-01-01T00:00:00.000Z",
+            "Tags": [
+              { "Key": "kubernetes.io/created-for/pvc/name", "Value": "data-pvc" },
+              { "Key": "kubernetes.io/created-for/pvc/namespace", "Value": "app-ns" }
+            ]
+          }
+        ],
+        "$metadata": { "httpStatusCode": 200 }
+      }
+    ],
+    "ListClustersCommand": [
+      {
+        "clusters": ["prod-cluster"],
+        "$metadata": { "httpStatusCode": 200 }
+      }
+    ]
+  },
+  "expected": {
+    "findings": [
+      { "id": "vol-0pvc12345", "monthlyCostUsd": 4 }
+    ]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@aws-sdk/client-dynamodb": "^3.1073.0",
     "@aws-sdk/client-ec2": "^3.741.0",
     "@aws-sdk/client-efs": "^3.1073.0",
+    "@aws-sdk/client-eks": "^3.1075.0",
     "@aws-sdk/client-elastic-load-balancing-v2": "^3.741.0",
     "@aws-sdk/client-elasticache": "^3.1073.0",
     "@aws-sdk/client-fsx": "^3.1075.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@aws-sdk/client-efs':
         specifier: ^3.1073.0
         version: 3.1073.0
+      '@aws-sdk/client-eks':
+        specifier: ^3.1075.0
+        version: 3.1087.0
       '@aws-sdk/client-elastic-load-balancing-v2':
         specifier: ^3.741.0
         version: 3.1064.0
@@ -286,6 +289,10 @@ packages:
 
   '@aws-sdk/client-efs@3.1073.0':
     resolution: {integrity: sha512-iBkvNX1LK/p+auRBGGj8oXFD6S41EezyxnFDLzCaknbxfC5xoQvw+/2qcB3GOiNu7Mkq+tUN29EEaM7sWsUe2g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-eks@3.1087.0':
+    resolution: {integrity: sha512-vXF+/4FMhGi3+bK1tqz9ozawBwrtvGBvTdkaI17cbWySZ4Ik2ONluSOAYquSvfmySCJlhXP+xBBEbZ+kzTeRPw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/client-elastic-load-balancing-v2@3.1064.0':
@@ -4338,6 +4345,17 @@ snapshots:
       '@aws-sdk/core': 3.975.1
       '@aws-sdk/credential-provider-node': 3.972.67
       '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.3
+      '@smithy/fetch-http-handler': 5.6.5
+      '@smithy/node-http-handler': 4.9.5
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/client-eks@3.1087.0':
+    dependencies:
+      '@aws-sdk/core': 3.975.2
+      '@aws-sdk/credential-provider-node': 3.972.68
+      '@aws-sdk/types': 3.974.1
       '@smithy/core': 3.29.3
       '@smithy/fetch-http-handler': 5.6.5
       '@smithy/node-http-handler': 4.9.5


### PR DESCRIPTION
## Summary

Phase 6.5 — EKS Cost Visibility vertical (ADR-0065/ADR-0066), closing out Phase 6:

- **`eks-node-overprovisioned`** — EKS Node Groups whose CPU requested is far below allocatable, per CloudWatch Container Insights node-level aggregates. Gated on `--live-pricing`; suggests a rightsized node count. Falls back gracefully (no finding, warning only) when Container Insights isn't enabled.
- **`eks-orphan-pvc`** — EBS volumes provisioned for a Kubernetes PVC that are either unattached, or still tagged for an EKS cluster that no longer exists. Static EBS pricing, no `--live-pricing` needed.

Both are **AWS-API-only** — no kubeconfig, no cluster-internal connectivity (see ADR-0066 for the rationale and the accuracy tradeoff this implies).

This PR also closes out **Task 11 (final integration)** for the whole Phase 6 vertical-scanners plan, which had never been done for the 7 kinds shipped in 6.1–6.4:

- README (EN+IT): added the 9 missing "What it detects" rows for the entire Phase 6 (SQS DLQ, Lambda LogGroup orphaned, Aurora Serverless, SageMaker suite, Ghost Environments, both EKS scanners) + the missing IAM actions (`sqs:*`, `rds:DescribeDBClusters`, `tag:GetResources`, `eks:*`)
- New docs: [`docs/en/vertical-scanners.md`](docs/en/vertical-scanners.md) / [`docs/it/scanner-verticali-guida.md`](docs/it/scanner-verticali-guida.md) — per-vertical caveats, risks, and config reference
- `cloudrift.config.example.json`: added `auroraMinAcuUtilizationPercent` and an `environmentDetection` example block, both missing since their respective phases shipped

## Changes

- `libs/cloud-cost/domain`: `EksNodeOverprovisioned`/`EksOrphanPvc` entities, `EksNodeOverprovisionedPolicy`/`EksOrphanPvcPolicy`, `ResourceKind`/`RESOURCE_KIND_META`/`group-by-kind` wiring
- `libs/cloud-cost/infrastructure/aws-adapter`: `AwsEksNodeOverprovisionedScanner`, `AwsEksOrphanPvcScanner` (+ specs), contract fixtures, new `@aws-sdk/client-eks` dependency
- `apps/cli`: scanner registry wiring, CLI presenters, `eksNodeUtilizationPercent` config threshold
- `README.md`, `docs/en/vertical-scanners.md`, `docs/it/scanner-verticali-guida.md`, `cloudrift.config.example.json`

## Test plan

- [x] `pnpm nx run-many -t typecheck test lint` green across all 5 affected projects (domain, aws-adapter, application, cli, shared-kernel)
- [x] 384 aws-adapter tests (48 suites) / 208 domain tests / 70 CLI tests passing, including new scanner specs and contract fixtures
- [x] LocalStack e2e run — no regression on the other 16 scanner kinds (EKS untested there: LocalStack Community doesn't support `eks:*`, same limitation as RDS/ELB/EFS/FSx/SageMaker on the free tier)
- [x] Real-AWS verification (deferred — per the release backlog gate, done in one batched pass at the end of Phase 6 rather than per-PR)
