### PR TITLE
refactor(lint): enforce hexagonal layering via Nx depConstraints

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -40,6 +40,7 @@
     "access": "public"
   },
   "nx": {
+    "tags": ["scope:app"],
     "targets": {
       "test": {
         "executor": "@nx/jest:jest",

--- a/docs/adr/0075-nx-dep-constraints-layer-enforcement.md
+++ b/docs/adr/0075-nx-dep-constraints-layer-enforcement.md
@@ -1,0 +1,44 @@
+# ADR-0075: Nx `depConstraints` enforce the hexagonal layering at lint time
+
+- **Status:** Accepted (2026-07-22)
+
+## Context
+
+`eslint.config.mjs` already ran `@nx/enforce-module-boundaries`, but with `depConstraints: [{ sourceTag: '*', onlyDependOnLibsWithTags: ['*'] }]` — a wildcard that accepts any import from any project. No project had an `nx.tags` entry either. An external review (`docs/todo/code-review-2026-07-22.md`) flagged this as the boundary being real only by convention: nothing stopped `cloud-cost-domain` from importing `cloud-cost-infrastructure-aws-adapter` directly, which would silently defeat the entire hexagonal design ([ADR-0013](0013-ddd-hexagonal-plugin-model.md), [ADR-0016](0016-waste-rules-in-domain.md)) — a mistake would only be caught by a human noticing it in review, not by any tool.
+
+## Decision
+
+Tagged the five projects to match the hexagonal layers already documented in `docs/en/architecture.md`'s layer diagram:
+
+| Project | Tag |
+|---|---|
+| `shared-kernel` | `scope:shared` |
+| `cloud-cost-domain` | `scope:domain` |
+| `cloud-cost-application` | `scope:application` |
+| `cloud-cost-infrastructure-aws-adapter` | `scope:infrastructure` |
+| `cli` | `scope:app` |
+
+Tags live in each project's `package.json` under `nx.tags` (the same file already carrying each project's `nx.targets`), not a separate `project.json` — none of the libs had one, and adding a parallel config file per project just to hold one array wasn't worth it.
+
+Replaced the wildcard `depConstraints` with one rule per layer:
+
+```js
+depConstraints: [
+  { sourceTag: 'scope:shared', onlyDependOnLibsWithTags: ['scope:shared'] },
+  { sourceTag: 'scope:domain', onlyDependOnLibsWithTags: ['scope:shared', 'scope:domain'] },
+  { sourceTag: 'scope:application', onlyDependOnLibsWithTags: ['scope:shared', 'scope:domain', 'scope:application'] },
+  { sourceTag: 'scope:infrastructure', onlyDependOnLibsWithTags: ['scope:shared', 'scope:domain', 'scope:infrastructure'] },
+  { sourceTag: 'scope:app', onlyDependOnLibsWithTags: ['scope:shared', 'scope:domain', 'scope:application', 'scope:infrastructure', 'scope:app'] },
+],
+```
+
+`scope:infrastructure` is deliberately not allowed to depend on `scope:application` — adapters implement domain ports (`WasteScannerPort`, `PricingPort`) directly; the application layer only orchestrates them from the composition root, it is never itself a dependency of an adapter. This matches the dependency graph every `package.json` already declared (verified before writing the rule, not assumed).
+
+## Alternatives Considered
+
+- **Leave the wildcard, rely on review discipline.** Rejected: this is exactly the status quo the review flagged as the problem — a lint rule that exists but enforces nothing gives false confidence.
+- **A `project.json` per lib carrying the tag**, matching the Nx-generated default for new libs. Rejected: none of the five projects currently has one (tags and everything else already live in `package.json`); introducing the parallel file just for a one-line array adds a second place to look without a corresponding benefit.
+
+## Consequences
+
+Verified in three steps: (1) `pnpm nx run-many --target=lint --all` passed clean with the new rules — the real dependency graph already matched the intended layering exactly, so no existing import needed to change; (2) a throwaway illegal import (`cloud-cost-domain` importing from `cloud-cost-infrastructure-aws-adapter`) was added and confirmed to fail `@nx/enforce-module-boundaries` with a hard error, then reverted — proving the rule is live, not a no-op; (3) full `lint`/`test`/`build` across all five projects stayed green. Since `ci.yml`'s `lint` job runs on every push/PR to `main` and `build` depends on it, any future PR crossing a layer boundary the wrong way now fails CI, not just local review.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -65,6 +65,7 @@ Each entry follows: Context → Decision → Alternatives Considered → Consequ
 | [0062](0062-scan-concurrency-lowered-for-localstack-reliability.md) | Scan concurrency lowered from 12 to 3; CI e2e job retries | Superseded by [ADR-0063](0063-scan-concurrency-env-configurable-default-restored-to-12.md) |
 | [0063](0063-scan-concurrency-env-configurable-default-restored-to-12.md) | Scan concurrency default restored to 12, overridable via `CLOUDRIFT_SCAN_CONCURRENCY`; LocalStack e2e forces 1 | Accepted |
 | [0074](0074-waste-policies-one-file-per-policy.md) | Waste policies split into one file per policy | Accepted |
+| [0075](0075-nx-dep-constraints-layer-enforcement.md) | Nx `depConstraints` enforce the hexagonal layering at lint time | Accepted |
 
 ## Stack
 

--- a/docs/en/architecture.md
+++ b/docs/en/architecture.md
@@ -43,7 +43,7 @@ The sections below describe the waste-detection path in depth, since it's the la
 └─────────────────────────────────────────────────────────┘
 ```
 
-**Fundamental rule:** dependencies always point inward (towards the domain). The domain knows nothing about the AWS SDK, Commander.js or pdfkit.
+**Fundamental rule:** dependencies always point inward (towards the domain). The domain knows nothing about the AWS SDK, Commander.js or pdfkit. This is enforced by tooling, not just convention: each project is tagged (`scope:shared`/`scope:domain`/`scope:application`/`scope:infrastructure`/`scope:app`) and `@nx/enforce-module-boundaries`' `depConstraints` in `eslint.config.mjs` fails the lint on any import that crosses a layer the wrong way ([ADR-0075](../adr/0075-nx-dep-constraints-layer-enforcement.md)).
 
 ---
 

--- a/docs/it/architettura.md
+++ b/docs/it/architettura.md
@@ -42,7 +42,7 @@ Le sezioni sotto descrivono in dettaglio il percorso di waste-detection, essendo
 └─────────────────────────────────────────────────────────┘
 ```
 
-**Regola fondamentale:** le dipendenze puntano sempre verso l'interno (verso il domain). Il domain non sa nulla di AWS SDK, Commander.js o pdfkit.
+**Regola fondamentale:** le dipendenze puntano sempre verso l'interno (verso il domain). Il domain non sa nulla di AWS SDK, Commander.js o pdfkit. Questo è imposto dal tooling, non solo dalla convenzione: ogni progetto è taggato (`scope:shared`/`scope:domain`/`scope:application`/`scope:infrastructure`/`scope:app`) e `@nx/enforce-module-boundaries` (`depConstraints` in `eslint.config.mjs`) fa fallire il lint su qualsiasi import che attraversi un layer nella direzione sbagliata ([ADR-0075](../adr/0075-nx-dep-constraints-layer-enforcement.md)).
 
 ---
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -16,7 +16,24 @@ export default [
           enforceBuildableLibDependency: true,
           allow: ['^.*/eslint(\\.base)?\\.config\\.[cm]?[jt]s$'],
           depConstraints: [
-            { sourceTag: '*', onlyDependOnLibsWithTags: ['*'] },
+            // Hexagonal layering (ADR-0013): domain has zero infra knowledge,
+            // application only knows domain ports, infrastructure implements
+            // those ports directly (not via application), and the app is the
+            // only composition root allowed to see every layer.
+            { sourceTag: 'scope:shared', onlyDependOnLibsWithTags: ['scope:shared'] },
+            { sourceTag: 'scope:domain', onlyDependOnLibsWithTags: ['scope:shared', 'scope:domain'] },
+            {
+              sourceTag: 'scope:application',
+              onlyDependOnLibsWithTags: ['scope:shared', 'scope:domain', 'scope:application'],
+            },
+            {
+              sourceTag: 'scope:infrastructure',
+              onlyDependOnLibsWithTags: ['scope:shared', 'scope:domain', 'scope:infrastructure'],
+            },
+            {
+              sourceTag: 'scope:app',
+              onlyDependOnLibsWithTags: ['scope:shared', 'scope:domain', 'scope:application', 'scope:infrastructure', 'scope:app'],
+            },
           ],
         },
       ],

--- a/libs/cloud-cost/application/package.json
+++ b/libs/cloud-cost/application/package.json
@@ -16,6 +16,7 @@
     }
   },
   "nx": {
+    "tags": ["scope:application"],
     "targets": {
       "test": {
         "executor": "@nx/jest:jest",

--- a/libs/cloud-cost/domain/package.json
+++ b/libs/cloud-cost/domain/package.json
@@ -16,6 +16,7 @@
     }
   },
   "nx": {
+    "tags": ["scope:domain"],
     "targets": {
       "test": {
         "executor": "@nx/jest:jest",

--- a/libs/cloud-cost/infrastructure/aws-adapter/package.json
+++ b/libs/cloud-cost/infrastructure/aws-adapter/package.json
@@ -16,6 +16,7 @@
     }
   },
   "nx": {
+    "tags": ["scope:infrastructure"],
     "targets": {
       "test": {
         "executor": "@nx/jest:jest",

--- a/libs/shared/kernel/package.json
+++ b/libs/shared/kernel/package.json
@@ -16,6 +16,7 @@
     }
   },
   "nx": {
+    "tags": ["scope:shared"],
     "targets": {
       "test": {
         "executor": "@nx/jest:jest",


### PR DESCRIPTION
## Summary
- Tagged all 5 projects by hexagonal layer (`scope:shared`/`scope:domain`/`scope:application`/`scope:infrastructure`/`scope:app`) via `nx.tags` in each `package.json`
- Replaced the `@nx/enforce-module-boundaries` wildcard `depConstraints` in `eslint.config.mjs` with real per-layer rules — domain can only depend on shared, application on domain+shared, infrastructure on domain+shared (not application), app on everything
- Documented the decision in [ADR-0075](docs/adr/0075-nx-dep-constraints-layer-enforcement.md), linked from `docs/en/architecture.md` and `docs/it/architettura.md`

Addresses the "boundary enforced only by convention, not tooling" finding from `docs/todo/code-review-2026-07-22.md`.

## Test plan
- [x] `pnpm nx run-many --target=lint --all` — clean, zero violations (the real dependency graph already matched the intended layering, so no existing import needed to change)
- [x] Live negative test: added a throwaway illegal import (`cloud-cost-domain` → `cloud-cost-infrastructure-aws-adapter`), confirmed `@nx/enforce-module-boundaries` fails the lint with a hard error, then reverted it — proves the rule actually enforces, not a silent no-op
- [x] `pnpm nx run-many --target=test --all` and `--target=build --all` — all 5 projects green
