### PR TITLE
feat(resource-security): add 14 security-posture scanners (new parall…

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,37 @@ cloudrift dead-resources --scanners iam-user-inactive  # only one check
 
 ---
 
+### Security posture (`resource-security`)
+
+A third, separate domain: risky **configuration** on resources that are actively in use (unlike `dead-resources` above, which finds abandoned ones) — IAM/account hygiene, network exposure, public storage, encryption at rest, and visibility/audit. All 14 checks are read-only (`Describe*`/`Get*`/`List*` only). See [ADR-0081](https://github.com/elleVas/cloudrift/blob/main/docs/adr/0081-resource-security-parallel-domain.md).
+
+```sh
+cloudrift resource-security                                    # every check, us-east-1
+cloudrift resource-security -r us-east-1 eu-west-1              # multiple regions (regional checks only — see below)
+cloudrift resource-security --scanners iam-root-mfa-disabled    # only one check
+```
+
+| Check                       | Flags                              | Severity |
+| ---------------------------- | ----------------------------------- | -------- |
+| **Root Account (MFA disabled)** | `iam:GetAccountSummary` → `AccountMFAEnabled` | critical |
+| **IAM Users (MFA disabled)** | No MFA device registered | warning |
+| **IAM Access Keys (rotation overdue)** | Active key older than 90 days (CIS 1.14) | warning |
+| **Root Account (active access key)** | `AccountAccessKeysPresent` | critical |
+| **Account Password Policy (weak or missing)** | Short of the CIS baseline, or absent | warning |
+| **EC2 Security Groups (open ingress on sensitive ports)** | `0.0.0.0/0`/`::/0` on SSH/RDP/database ports | critical |
+| **EC2 Default Security Groups (permissive)** | Default VPC security group still has rules | warning |
+| **S3 Buckets (public)** | Public via ACL and/or bucket policy | critical |
+| **EC2 Snapshots (public)** | `createVolumePermission` granted to `all` | critical |
+| **EBS Volumes (unencrypted)** | Not encrypted at rest | warning |
+| **RDS Instances (unencrypted)** | Storage not encrypted at rest | warning |
+| **S3 Buckets (default encryption missing)** | No default server-side encryption | warning |
+| **RDS Instances (publicly accessible)** | Reachable from outside its VPC | critical |
+| **CloudTrail (no multi-region trail)** | No trail with multi-region logging | warning |
+
+**IAM, S3 (bucket listing), and CloudTrail are global for this command**: those eight checks run once per scan regardless of how many `--regions` you pass, never once per region — the other six checks are genuinely regional. `--format json`/`--pdf` for machine-readable/shareable output, no `--min-age-days` (a security misconfiguration is a risk from the moment it exists). See [docs/en/usage.md](https://github.com/elleVas/cloudrift/blob/main/docs/en/usage.md#resource-security--security-posture-scan) for the full flag reference.
+
+---
+
 ## Documentation
 
 The full reference — flags, config file, pricing sources, CI/CD, IAM permissions, contributing, architecture — lives in [`docs/`](https://github.com/elleVas/cloudrift/tree/main/docs/): English in [`docs/en/`](https://github.com/elleVas/cloudrift/tree/main/docs/en/), Italian in [`docs/it/`](https://github.com/elleVas/cloudrift/tree/main/docs/it/).

--- a/apps/cli/jest.config.cjs
+++ b/apps/cli/jest.config.cjs
@@ -32,6 +32,12 @@ module.exports = {
     '^dead-resources-application/(.*)$': '<rootDir>/../../libs/dead-resources/application/src/$1',
     '^dead-resources-infrastructure-aws-adapter$': '<rootDir>/../../libs/dead-resources/infrastructure/aws-adapter/src/index.ts',
     '^dead-resources-infrastructure-aws-adapter/(.*)$': '<rootDir>/../../libs/dead-resources/infrastructure/aws-adapter/src/$1',
+    '^resource-security-domain$': '<rootDir>/../../libs/resource-security/domain/src/index.ts',
+    '^resource-security-domain/(.*)$': '<rootDir>/../../libs/resource-security/domain/src/$1',
+    '^resource-security-application$': '<rootDir>/../../libs/resource-security/application/src/index.ts',
+    '^resource-security-application/(.*)$': '<rootDir>/../../libs/resource-security/application/src/$1',
+    '^resource-security-infrastructure-aws-adapter$': '<rootDir>/../../libs/resource-security/infrastructure/aws-adapter/src/index.ts',
+    '^resource-security-infrastructure-aws-adapter/(.*)$': '<rootDir>/../../libs/resource-security/infrastructure/aws-adapter/src/$1',
     '^(\\.{1,2}/.*)\\.js$': '$1',
   },
 };

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -158,6 +158,9 @@
     "dead-resources-domain": "workspace:*",
     "dead-resources-infrastructure-aws-adapter": "workspace:*",
     "pdfkit": "^0.15.2",
+    "resource-security-application": "workspace:*",
+    "resource-security-domain": "workspace:*",
+    "resource-security-infrastructure-aws-adapter": "workspace:*",
     "shared-kernel": "workspace:*",
     "zod": "^4.4.3"
   }

--- a/apps/cli/src/commands/resource-security.command.spec.ts
+++ b/apps/cli/src/commands/resource-security.command.spec.ts
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: Apache-2.0
+import { readFile, mkdtemp, rm } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { Result } from 'shared-kernel';
+import { IamRootMfaDisabled } from 'resource-security-domain';
+import type { ResourceSecuritySummary, FindResourceSecurityFindingsUseCasePort } from 'resource-security-domain';
+import { resourceSecurityCommand, type ResourceSecurityCommandOptions } from './resource-security.command';
+import type { ResourceSecurityDeps, ResourceSecurityAnalysisContext } from './resource-security.composition';
+
+function makeFinding(accountId: string): IamRootMfaDisabled {
+  return new IamRootMfaDisabled({ accountId, mfaEnabled: false, detectedAt: new Date('2026-07-23'), tags: {} });
+}
+
+function makeDeps(
+  opts: { summary?: ResourceSecuritySummary; onCreateAnalysis?: (ctx: ResourceSecurityAnalysisContext) => void } = {},
+): ResourceSecurityDeps {
+  const summary: ResourceSecuritySummary = opts.summary ?? {
+    findings: [],
+    countBySeverity: { info: 0, warning: 0, critical: 0 },
+    scanErrors: [],
+  };
+  const useCase: FindResourceSecurityFindingsUseCasePort = {
+    execute: async () => Result.ok(summary),
+  };
+  return {
+    resolveAccountId: async () => undefined,
+    createAnalysis: async (ctx) => {
+      opts.onCreateAnalysis?.(ctx);
+      return { useCase };
+    },
+  };
+}
+
+let stdout: string;
+let stderr: string;
+
+beforeEach(() => {
+  stdout = '';
+  stderr = '';
+  jest.spyOn(console, 'log').mockImplementation((...args) => {
+    stdout += args.join(' ') + '\n';
+  });
+  jest.spyOn(console, 'error').mockImplementation((...args) => {
+    stderr += args.join(' ') + '\n';
+  });
+  process.exitCode = undefined;
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+  process.exitCode = undefined;
+});
+
+function run(options: Partial<ResourceSecurityCommandOptions>, deps: ResourceSecurityDeps): Promise<void> {
+  return resourceSecurityCommand({ regions: ['us-east-1'], ...options }, deps);
+}
+
+describe('resourceSecurityCommand (CLI end-to-end)', () => {
+  it('rejects an invalid --format before doing any work (exit 1)', async () => {
+    await run({ format: 'xml' }, makeDeps());
+    expect(process.exitCode).toBe(1);
+    expect(stderr).toContain('--format must be one of');
+  });
+
+  it('rejects an invalid region', async () => {
+    await run({ regions: ['not-a-region'] }, makeDeps());
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('table format: renders "No security-posture risks found" when there are no findings', async () => {
+    await run({ format: 'table' }, makeDeps());
+    expect(stdout).toContain('No security-posture risks found');
+  });
+
+  it('table format: renders a finding with its severity', async () => {
+    await run(
+      { format: 'table' },
+      makeDeps({
+        summary: {
+          findings: [makeFinding('123456789012')],
+          countBySeverity: { info: 0, warning: 0, critical: 1 },
+          scanErrors: [],
+        },
+      }),
+    );
+    expect(stdout).toContain('123456789012');
+    expect(stdout).toContain('1 critical, 0 warning, 0 info');
+  });
+
+  it('json format: stdout is pure parseable JSON', async () => {
+    await run(
+      { format: 'json' },
+      makeDeps({
+        summary: {
+          findings: [makeFinding('123456789012')],
+          countBySeverity: { info: 0, warning: 0, critical: 1 },
+          scanErrors: [],
+        },
+      }),
+    );
+    const parsed = JSON.parse(stdout.trim());
+    expect(parsed.findings).toHaveLength(1);
+    expect(parsed.findings[0].kind).toBe('iam-root-mfa-disabled');
+    expect(parsed.countBySeverity).toEqual({ info: 0, warning: 0, critical: 1 });
+  });
+
+  it('--silent suppresses stdout entirely', async () => {
+    await run({ format: 'table', silent: true }, makeDeps());
+    expect(stdout).toBe('');
+  });
+
+  it('passes scannerKinds through to createAnalysis unchanged', async () => {
+    let received: ResourceSecurityAnalysisContext | undefined;
+    await run(
+      { scannerKinds: ['iam-root-mfa-disabled'] },
+      makeDeps({ onCreateAnalysis: (ctx) => (received = ctx) }),
+    );
+    expect(received?.scannerKinds).toEqual(['iam-root-mfa-disabled']);
+  });
+
+  it('rejects an unknown --scanners value', async () => {
+    await run({ scanners: ['not-a-real-check'] }, makeDeps());
+    expect(process.exitCode).toBe(1);
+    expect(stderr).toContain('unknown check');
+  });
+
+  it('resolves --scanners into scannerKinds, taking precedence over the programmatic field', async () => {
+    let received: ResourceSecurityAnalysisContext | undefined;
+    await run(
+      { scanners: ['s3-bucket-public'], scannerKinds: ['iam-root-mfa-disabled'] },
+      makeDeps({ onCreateAnalysis: (ctx) => (received = ctx) }),
+    );
+    expect(received?.scannerKinds).toEqual(['s3-bucket-public']);
+  });
+
+  it('writes a PDF artifact to disk with --pdf <file>', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'cloudrift-cli-'));
+    const file = join(dir, 'out.pdf');
+    try {
+      await run(
+        { format: 'table', pdf: file },
+        makeDeps({
+          summary: {
+            findings: [makeFinding('123456789012')],
+            countBySeverity: { info: 0, warning: 0, critical: 1 },
+            scanErrors: [],
+          },
+        }),
+      );
+      const written = await readFile(file);
+      expect(written.length).toBeGreaterThan(0);
+      expect(written.subarray(0, 5).toString('latin1')).toBe('%PDF-');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('--silent suppresses stdout while still writing the requested PDF artifact', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'cloudrift-cli-'));
+    const file = join(dir, 'out.pdf');
+    try {
+      await run({ format: 'table', pdf: file, silent: true }, makeDeps());
+      expect(stdout).toBe('');
+      const written = await readFile(file);
+      expect(written.subarray(0, 5).toString('latin1')).toBe('%PDF-');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('surfaces a scan failure', async () => {
+    const failingDeps: ResourceSecurityDeps = {
+      resolveAccountId: async () => undefined,
+      createAnalysis: async () => ({
+        useCase: { execute: async () => Result.fail(new Error('boom')) },
+      }),
+    };
+    await run({}, failingDeps);
+    expect(process.exitCode).toBe(1);
+    expect(stderr).toContain('boom');
+  });
+});

--- a/apps/cli/src/commands/resource-security.command.ts
+++ b/apps/cli/src/commands/resource-security.command.ts
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: Apache-2.0
+import chalk from 'chalk';
+import { dirname, resolve } from 'path';
+import { mkdir } from 'fs/promises';
+import { AwsRegion, RESOURCE_SECURITY_KINDS, DEFAULT_IGNORE_TAG } from 'resource-security-domain';
+import type { ResourceSecurityKind, ResourceSecurityPolicyOptions } from 'resource-security-domain';
+import { renderBrandMark } from '../brand-mark';
+import { formatResourceSecurityReportAsTable } from '../formatters/resource-security-report.table-formatter';
+import { formatResourceSecurityReportAsJson } from '../formatters/resource-security-report.json-formatter';
+import { generateResourceSecurityReportPdf } from '../formatters/resource-security-report.pdf-formatter';
+import { defaultResourceSecurityDeps, type ResourceSecurityDeps } from './resource-security.composition';
+
+export type { ResourceSecurityDeps };
+
+const OUTPUT_FORMATS = ['table', 'json'] as const;
+type OutputFormat = (typeof OUTPUT_FORMATS)[number];
+
+export interface ResourceSecurityCommandOptions {
+  regions: string[];
+  accountId?: string;
+  format?: string;
+  ignoreTag?: string;
+  silent?: boolean;
+  pdf?: string | boolean;
+  /** Raw `--scanners` CLI input, validated against `RESOURCE_SECURITY_KINDS` below. */
+  scanners?: string[];
+  /** Already-validated kind filter — how the wizard's multiselect passes its choice through. `--scanners` wins if both are set. */
+  scannerKinds?: ResourceSecurityKind[];
+}
+
+function fail(message: string): void {
+  console.error(chalk.red(`\n  Error: ${message}\n`));
+  process.exitCode = 1;
+}
+
+/** `--scanners`: Result-free validation against the known RESOURCE_SECURITY_KINDS. */
+function resolveExplicitScannerKinds(scanners: string[]): ResourceSecurityKind[] | { error: string } {
+  const valid = new Set<string>(RESOURCE_SECURITY_KINDS);
+  const unknown = scanners.filter((kind) => !valid.has(kind));
+  if (unknown.length > 0) {
+    return { error: `--scanners: unknown check(s) "${unknown.join(', ')}". Valid values: ${RESOURCE_SECURITY_KINDS.join(', ')}.` };
+  }
+  return scanners as ResourceSecurityKind[];
+}
+
+/**
+ * `resource-security`: read-only security-posture scan (IAM/account
+ * hygiene, network exposure, public storage, encryption at rest,
+ * visibility/audit). Its own top-level command, not a flag on `analyze` or
+ * `dead-resources` — a different domain with a different report shape
+ * (risk severity, not $/month or hygiene), same pattern as ADR-0078.
+ */
+export async function resourceSecurityCommand(
+  options: ResourceSecurityCommandOptions,
+  deps: ResourceSecurityDeps = defaultResourceSecurityDeps,
+): Promise<void> {
+  const format = (options.format ?? 'table') as OutputFormat;
+  if (!OUTPUT_FORMATS.includes(format)) {
+    return fail(`--format must be one of: ${OUTPUT_FORMATS.join(', ')}. Got "${options.format}".`);
+  }
+
+  let scannerKinds = options.scannerKinds;
+  if (options.scanners && options.scanners.length > 0) {
+    const resolved = resolveExplicitScannerKinds(options.scanners);
+    if ('error' in resolved) return fail(resolved.error);
+    scannerKinds = resolved;
+  }
+
+  const regions: AwsRegion[] = [];
+  for (const code of options.regions) {
+    const parsed = AwsRegion.parse(code);
+    if (!parsed.ok) return fail(parsed.error.message);
+    regions.push(parsed.value);
+  }
+
+  const silent = options.silent === true;
+  const quietStdout = format !== 'table' || silent;
+  const info = silent ? () => undefined : quietStdout ? (msg: string) => console.error(msg) : (msg: string) => console.log(msg);
+
+  if (!quietStdout) {
+    console.log(`\n${renderBrandMark()}\n`);
+  }
+
+  const accountId = options.accountId ?? (await deps.resolveAccountId()) ?? 'unknown';
+  if (accountId === 'unknown') {
+    info(chalk.dim('  Could not resolve the AWS account ID via STS — pass --account-id to set it explicitly.'));
+  }
+
+  if (!quietStdout) {
+    console.log(
+      chalk.bold.blue(`\n  Scanning ${regions.map((r) => r.code).join(', ')} (account ${accountId}) for security-posture risks...\n`),
+    );
+  }
+
+  const policyOptions: ResourceSecurityPolicyOptions = {
+    ignoreTag: options.ignoreTag ?? DEFAULT_IGNORE_TAG,
+  };
+
+  const { useCase } = await deps.createAnalysis({ regions, accountId, policyOptions, scannerKinds });
+
+  const result = await useCase.execute({ regions });
+  if (!result.ok) return fail(result.error.message);
+
+  const meta = { accountId, regions: regions.map((r) => r.code), generatedAt: new Date() };
+
+  if (!silent) {
+    const rendered =
+      format === 'json' ? formatResourceSecurityReportAsJson(result.value, meta) : formatResourceSecurityReportAsTable(result.value);
+    console.log(rendered);
+  }
+
+  if (options.pdf !== undefined && options.pdf !== false) {
+    const day = meta.generatedAt.toISOString().split('T')[0].replaceAll('-', '_');
+    const outputPath =
+      typeof options.pdf === 'string'
+        ? resolve(process.cwd(), options.pdf)
+        : resolve(process.cwd(), 'reports', `cloudrift-resource-security-${day}.pdf`);
+    await mkdir(dirname(outputPath), { recursive: true });
+    await generateResourceSecurityReportPdf(result.value, meta, outputPath);
+    info(chalk.green(`  PDF report saved to ${outputPath}`));
+  }
+}

--- a/apps/cli/src/commands/resource-security.composition.ts
+++ b/apps/cli/src/commands/resource-security.composition.ts
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: Apache-2.0
+import type {
+  AwsRegion,
+  ResourceSecurityKind,
+  ResourceSecurityPolicyOptions,
+  ResourceSecurityScannerPort,
+  FindResourceSecurityFindingsUseCasePort,
+} from 'resource-security-domain';
+import {
+  IamRootMfaDisabledPolicy,
+  IamUserMfaDisabledPolicy,
+  IamAccessKeyRotationOverduePolicy,
+  IamRootAccessKeyActivePolicy,
+  IamPasswordPolicyWeakPolicy,
+  Ec2SecurityGroupOpenIngressPolicy,
+  Ec2DefaultSecurityGroupPermissivePolicy,
+  S3BucketPublicPolicy,
+  Ec2SnapshotPublicPolicy,
+  Ec2VolumeUnencryptedPolicy,
+  RdsInstanceUnencryptedPolicy,
+  S3BucketEncryptionMissingPolicy,
+  RdsInstancePubliclyAccessiblePolicy,
+  CloudtrailNotMultiregionPolicy,
+} from 'resource-security-domain';
+import { FindResourceSecurityFindingsUseCase } from 'resource-security-application';
+import {
+  AwsIamRootMfaDisabledScanner,
+  AwsIamUserMfaDisabledScanner,
+  AwsIamAccessKeyRotationOverdueScanner,
+  AwsIamRootAccessKeyActiveScanner,
+  AwsIamPasswordPolicyWeakScanner,
+  AwsEc2SecurityGroupOpenIngressScanner,
+  AwsEc2DefaultSecurityGroupPermissiveScanner,
+  AwsS3BucketPublicScanner,
+  AwsEc2SnapshotPublicScanner,
+  AwsEc2VolumeUnencryptedScanner,
+  AwsRdsInstanceUnencryptedScanner,
+  AwsS3BucketEncryptionMissingScanner,
+  AwsRdsInstancePubliclyAccessibleScanner,
+  AwsCloudtrailNotMultiregionScanner,
+} from 'resource-security-infrastructure-aws-adapter';
+import { resolveAwsAccountId } from 'cloud-cost-infrastructure-aws-adapter';
+
+/** Everything a resource-security scanner factory may need to build its instance. */
+export interface ResourceSecurityScanContext {
+  accountId: string;
+  policyOptions: ResourceSecurityPolicyOptions;
+}
+
+/**
+ * Resolved context passed to `createAnalysis` to build the scanner list.
+ * Mirrors `DeadResourceAnalysisContext` (`dead-resources.composition.ts`).
+ */
+export interface ResourceSecurityAnalysisContext {
+  regions: AwsRegion[];
+  accountId: string;
+  policyOptions: ResourceSecurityPolicyOptions;
+  /** Restrict the scan to these kinds (from the wizard). Undefined runs every check. */
+  scannerKinds?: ResourceSecurityKind[];
+}
+
+export interface ResourceSecurityAnalysis {
+  useCase: FindResourceSecurityFindingsUseCasePort;
+}
+
+export interface ResourceSecurityDeps {
+  resolveAccountId(): Promise<string | undefined>;
+  createAnalysis(ctx: ResourceSecurityAnalysisContext): Promise<ResourceSecurityAnalysis>;
+}
+
+/** One entry per resource-security kind — same shape as `dead-resources.composition.ts`'s `buildScanners`, 14 entries doesn't warrant a registry split (ADR-0077's threshold was 43). */
+function buildScanners(ctx: ResourceSecurityScanContext): ResourceSecurityScannerPort[] {
+  return [
+    new AwsIamRootMfaDisabledScanner(ctx.accountId, new IamRootMfaDisabledPolicy(ctx.policyOptions)),
+    new AwsIamUserMfaDisabledScanner(ctx.accountId, new IamUserMfaDisabledPolicy(ctx.policyOptions)),
+    new AwsIamAccessKeyRotationOverdueScanner(ctx.accountId, new IamAccessKeyRotationOverduePolicy(ctx.policyOptions)),
+    new AwsIamRootAccessKeyActiveScanner(ctx.accountId, new IamRootAccessKeyActivePolicy(ctx.policyOptions)),
+    new AwsIamPasswordPolicyWeakScanner(ctx.accountId, new IamPasswordPolicyWeakPolicy(ctx.policyOptions)),
+    new AwsEc2SecurityGroupOpenIngressScanner(ctx.accountId, new Ec2SecurityGroupOpenIngressPolicy(ctx.policyOptions)),
+    new AwsEc2DefaultSecurityGroupPermissiveScanner(ctx.accountId, new Ec2DefaultSecurityGroupPermissivePolicy(ctx.policyOptions)),
+    new AwsS3BucketPublicScanner(ctx.accountId, new S3BucketPublicPolicy(ctx.policyOptions)),
+    new AwsEc2SnapshotPublicScanner(ctx.accountId, new Ec2SnapshotPublicPolicy(ctx.policyOptions)),
+    new AwsEc2VolumeUnencryptedScanner(ctx.accountId, new Ec2VolumeUnencryptedPolicy(ctx.policyOptions)),
+    new AwsRdsInstanceUnencryptedScanner(ctx.accountId, new RdsInstanceUnencryptedPolicy(ctx.policyOptions)),
+    new AwsS3BucketEncryptionMissingScanner(ctx.accountId, new S3BucketEncryptionMissingPolicy(ctx.policyOptions)),
+    new AwsRdsInstancePubliclyAccessibleScanner(ctx.accountId, new RdsInstancePubliclyAccessiblePolicy(ctx.policyOptions)),
+    new AwsCloudtrailNotMultiregionScanner(ctx.accountId, new CloudtrailNotMultiregionPolicy(ctx.policyOptions)),
+  ];
+}
+
+async function defaultCreateAnalysis(ctx: ResourceSecurityAnalysisContext): Promise<ResourceSecurityAnalysis> {
+  const scanners = buildScanners({ accountId: ctx.accountId, policyOptions: ctx.policyOptions });
+  const kindFilter = ctx.scannerKinds ? new Set(ctx.scannerKinds) : undefined;
+  const selected = kindFilter ? scanners.filter((scanner) => kindFilter.has(scanner.kind)) : scanners;
+  return { useCase: new FindResourceSecurityFindingsUseCase(selected) };
+}
+
+export const defaultResourceSecurityDeps: ResourceSecurityDeps = {
+  resolveAccountId: resolveAwsAccountId,
+  createAnalysis: defaultCreateAnalysis,
+};

--- a/apps/cli/src/formatters/resource-security-presenters.spec.ts
+++ b/apps/cli/src/formatters/resource-security-presenters.spec.ts
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: Apache-2.0
+import {
+  AwsRegion,
+  IamRootMfaDisabled,
+  IamUserMfaDisabled,
+  IamAccessKeyRotationOverdue,
+  IamRootAccessKeyActive,
+  IamPasswordPolicyWeak,
+  Ec2SecurityGroupOpenIngress,
+  Ec2DefaultSecurityGroupPermissive,
+  S3BucketPublic,
+  Ec2SnapshotPublic,
+  Ec2VolumeUnencrypted,
+  RdsInstanceUnencrypted,
+  S3BucketEncryptionMissing,
+  RdsInstancePubliclyAccessible,
+  CloudtrailNotMultiregion,
+} from 'resource-security-domain';
+import { rowFor, recommendFor, presenterFor } from './resource-security-presenters';
+
+const region = AwsRegion.create('us-east-1');
+const now = new Date('2026-07-23T10:00:00Z');
+
+const rootMfa = new IamRootMfaDisabled({ accountId: '123456789012', mfaEnabled: false, detectedAt: now, tags: {} });
+
+const userMfa = new IamUserMfaDisabled({
+  userName: 'alice',
+  arn: 'arn:aws:iam::123456789012:user/alice',
+  accountId: '123456789012',
+  createdAt: now,
+  detectedAt: now,
+  tags: {},
+});
+
+const keyRotation = new IamAccessKeyRotationOverdue({
+  accessKeyId: 'AKIA1',
+  userName: 'alice',
+  accountId: '123456789012',
+  createdAt: now,
+  detectedAt: now,
+  tags: {},
+});
+
+const rootKey = new IamRootAccessKeyActive({ accountId: '123456789012', accessKeysPresent: true, detectedAt: now, tags: {} });
+
+const passwordPolicy = new IamPasswordPolicyWeak({ accountId: '123456789012', exists: false, detectedAt: now, tags: {} });
+
+const openIngress = new Ec2SecurityGroupOpenIngress({
+  groupId: 'sg-1',
+  groupName: 'web',
+  region,
+  accountId: '123456789012',
+  matchedRules: ['22/tcp from 0.0.0.0/0'],
+  detectedAt: now,
+  tags: {},
+});
+
+const defaultSg = new Ec2DefaultSecurityGroupPermissive({
+  groupId: 'sg-default-1',
+  vpcId: 'vpc-1',
+  region,
+  accountId: '123456789012',
+  hasIngressRules: true,
+  hasEgressRules: true,
+  detectedAt: now,
+  tags: {},
+});
+
+const publicBucket = new S3BucketPublic({
+  bucketName: 'my-bucket',
+  accountId: '123456789012',
+  publicVia: ['bucket policy allows public access'],
+  detectedAt: now,
+  tags: {},
+});
+
+const publicSnapshot = new Ec2SnapshotPublic({
+  snapshotId: 'snap-1',
+  volumeId: 'vol-1',
+  region,
+  accountId: '123456789012',
+  detectedAt: now,
+  tags: {},
+});
+
+const unencryptedVolume = new Ec2VolumeUnencrypted({
+  volumeId: 'vol-2',
+  region,
+  accountId: '123456789012',
+  detectedAt: now,
+  tags: {},
+});
+
+const unencryptedRds = new RdsInstanceUnencrypted({
+  dbInstanceIdentifier: 'db-1',
+  region,
+  accountId: '123456789012',
+  detectedAt: now,
+  tags: {},
+});
+
+const missingEncryptionBucket = new S3BucketEncryptionMissing({ bucketName: 'my-bucket-2', accountId: '123456789012', detectedAt: now, tags: {} });
+
+const publicRds = new RdsInstancePubliclyAccessible({
+  dbInstanceIdentifier: 'db-2',
+  region,
+  accountId: '123456789012',
+  detectedAt: now,
+  tags: {},
+});
+
+const noMultiRegionTrail = new CloudtrailNotMultiregion({ accountId: '123456789012', hasMultiRegionTrail: false, detectedAt: now, tags: {} });
+
+describe('rowFor / recommendFor', () => {
+  it('dispatches an iam-root-mfa-disabled finding to the matching presenter (no Region column)', () => {
+    expect(rowFor(rootMfa)).toEqual(['123456789012']);
+    expect(recommendFor(rootMfa)).toContain('root account');
+  });
+
+  it('dispatches an iam-user-mfa-disabled finding to the matching presenter (no Region column)', () => {
+    expect(rowFor(userMfa)).toEqual(['alice', userMfa.arn, '2026-07-23']);
+    expect(recommendFor(userMfa)).toContain('alice');
+  });
+
+  it('dispatches an iam-access-key-rotation-overdue finding to the matching presenter (no Region column)', () => {
+    expect(rowFor(keyRotation)).toEqual(['AKIA1', 'alice', '2026-07-23']);
+    expect(recommendFor(keyRotation)).toContain('AKIA1');
+  });
+
+  it('dispatches an iam-root-access-key-active finding to the matching presenter (no Region column)', () => {
+    expect(rowFor(rootKey)).toEqual(['123456789012']);
+    expect(recommendFor(rootKey)).toContain('root account');
+  });
+
+  it('dispatches an iam-password-policy-weak finding to the matching presenter (no Region column)', () => {
+    expect(rowFor(passwordPolicy)).toEqual(['123456789012', passwordPolicy.riskReason]);
+    expect(recommendFor(passwordPolicy)).toContain('password policy');
+  });
+
+  it('dispatches an ec2-security-group-open-ingress finding to the matching presenter', () => {
+    expect(rowFor(openIngress)).toEqual(['sg-1', 'web', 'us-east-1', '22/tcp from 0.0.0.0/0']);
+    expect(recommendFor(openIngress)).toContain('web');
+  });
+
+  it('dispatches an ec2-default-security-group-permissive finding to the matching presenter', () => {
+    expect(rowFor(defaultSg)).toEqual(['sg-default-1', 'vpc-1', 'us-east-1']);
+    expect(recommendFor(defaultSg)).toContain('sg-default-1');
+  });
+
+  it('dispatches an s3-bucket-public finding to the matching presenter (no Region column)', () => {
+    expect(rowFor(publicBucket)).toEqual(['my-bucket', 'bucket policy allows public access']);
+    expect(recommendFor(publicBucket)).toContain('my-bucket');
+  });
+
+  it('dispatches an ec2-snapshot-public finding to the matching presenter', () => {
+    expect(rowFor(publicSnapshot)).toEqual(['snap-1', 'vol-1', 'us-east-1']);
+    expect(recommendFor(publicSnapshot)).toContain('snap-1');
+  });
+
+  it('dispatches an ec2-volume-unencrypted finding to the matching presenter', () => {
+    expect(rowFor(unencryptedVolume)).toEqual(['vol-2', 'us-east-1']);
+    expect(recommendFor(unencryptedVolume)).toContain('vol-2');
+  });
+
+  it('dispatches a rds-instance-unencrypted finding to the matching presenter', () => {
+    expect(rowFor(unencryptedRds)).toEqual(['db-1', 'us-east-1']);
+    expect(recommendFor(unencryptedRds)).toContain('db-1');
+  });
+
+  it('dispatches an s3-bucket-encryption-missing finding to the matching presenter (no Region column)', () => {
+    expect(rowFor(missingEncryptionBucket)).toEqual(['my-bucket-2']);
+    expect(recommendFor(missingEncryptionBucket)).toContain('my-bucket-2');
+  });
+
+  it('dispatches a rds-instance-publicly-accessible finding to the matching presenter', () => {
+    expect(rowFor(publicRds)).toEqual(['db-2', 'us-east-1']);
+    expect(recommendFor(publicRds)).toContain('db-2');
+  });
+
+  it('dispatches a cloudtrail-not-multiregion finding to the matching presenter (no Region column)', () => {
+    expect(rowFor(noMultiRegionTrail)).toEqual(['123456789012']);
+    expect(recommendFor(noMultiRegionTrail)).toContain('multi-region');
+  });
+
+  it('presenterFor exposes title and head without row/recommend', () => {
+    const presenter = presenterFor('s3-bucket-public');
+    expect(presenter.title).toContain('S3 Buckets');
+    expect(presenter.head).toEqual(['Bucket Name', 'Exposed Via']);
+  });
+});

--- a/apps/cli/src/formatters/resource-security-presenters.ts
+++ b/apps/cli/src/formatters/resource-security-presenters.ts
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: Apache-2.0
+import type { ResourceSecurityKind, ResourceSecurityKindMap, SecurityFinding } from 'resource-security-domain';
+
+/**
+ * Presentation per resource-security kind. Mirrors `dead-resource-
+ * presenters.ts`'s shape and exhaustive-switch dispatch (ADR-0059) — adding
+ * a new `ResourceSecurityKind` forces (via the compiler) adding the
+ * presenter here and a case in `rowFor`/`recommendFor` below.
+ */
+export interface ResourceSecurityPresenter<T extends SecurityFinding = SecurityFinding> {
+  title: string;
+  /** Column headers, severity excluded (added by the formatters as the last column). */
+  head: string[];
+  row(resource: T): string[];
+  recommend(resource: T): string;
+}
+
+function day(date: Date): string {
+  return date.toISOString().split('T')[0];
+}
+
+type PresenterMap = { [K in ResourceSecurityKind]: ResourceSecurityPresenter<ResourceSecurityKindMap[K]> };
+
+export const presenters: PresenterMap = {
+  // No Region column for account-wide/global-scope kinds (IAM, S3 bucket
+  // listing, CloudTrail) — `region` is unset on these entities.
+  'iam-root-mfa-disabled': {
+    title: 'Root Account — MFA Disabled',
+    head: ['Account ID'],
+    row: (f) => [f.accountId],
+    recommend: (f) => `Enable MFA on the root account (${f.accountId})`,
+  },
+  'iam-user-mfa-disabled': {
+    title: 'IAM Users — MFA Disabled',
+    head: ['User Name', 'ARN', 'Created'],
+    row: (u) => [u.userName, u.arn, day(u.createdAt)],
+    recommend: (u) => `Enable MFA for IAM user "${u.userName}" (${u.arn})`,
+  },
+  'iam-access-key-rotation-overdue': {
+    title: 'IAM Access Keys — Rotation Overdue',
+    head: ['Access Key ID', 'User Name', 'Created'],
+    row: (k) => [k.id, k.userName, day(k.createdAt)],
+    recommend: (k) => `Rotate access key ${k.id} for IAM user "${k.userName}" — ${k.riskReason}`,
+  },
+  'iam-root-access-key-active': {
+    title: 'Root Account — Active Access Key',
+    head: ['Account ID'],
+    row: (f) => [f.accountId],
+    recommend: (f) => `Delete the root account's access key(s) (${f.accountId}) — use IAM users/roles instead`,
+  },
+  'iam-password-policy-weak': {
+    title: 'Account Password Policy — Weak or Missing',
+    head: ['Account ID', 'Details'],
+    row: (f) => [f.accountId, f.riskReason],
+    recommend: (f) => `Tighten the account password policy — ${f.riskReason}`,
+  },
+  'ec2-security-group-open-ingress': {
+    title: 'EC2 Security Groups — Open Ingress',
+    head: ['Group ID', 'Group Name', 'Region', 'Matched Rules'],
+    row: (sg) => [sg.id, sg.groupName, sg.region.code, sg.matchedRules.join(', ')],
+    recommend: (sg) => `Restrict ingress on security group "${sg.groupName}" (${sg.id}) in ${sg.region.code} — ${sg.riskReason}`,
+  },
+  'ec2-default-security-group-permissive': {
+    title: 'EC2 Default Security Groups — Permissive',
+    head: ['Group ID', 'VPC ID', 'Region'],
+    row: (sg) => [sg.id, sg.vpcId, sg.region.code],
+    recommend: (sg) => `Empty the default security group (${sg.id}) in VPC ${sg.vpcId}, region ${sg.region.code} — ${sg.riskReason}`,
+  },
+  's3-bucket-public': {
+    title: 'S3 Buckets — Public',
+    head: ['Bucket Name', 'Exposed Via'],
+    row: (b) => [b.bucketName, b.publicVia.join('; ')],
+    recommend: (b) => `Remove public access from S3 bucket "${b.bucketName}" — ${b.riskReason}`,
+  },
+  'ec2-snapshot-public': {
+    title: 'EC2 Snapshots — Public',
+    head: ['Snapshot ID', 'Volume ID', 'Region'],
+    row: (s) => [s.id, s.volumeId, s.region.code],
+    recommend: (s) => `Remove public restore permissions from snapshot ${s.id} in ${s.region.code}`,
+  },
+  'ec2-volume-unencrypted': {
+    title: 'EBS Volumes — Unencrypted',
+    head: ['Volume ID', 'Region'],
+    row: (v) => [v.id, v.region.code],
+    recommend: (v) => `Migrate EBS volume ${v.id} in ${v.region.code} to an encrypted volume`,
+  },
+  'rds-instance-unencrypted': {
+    title: 'RDS Instances — Unencrypted',
+    head: ['DB Instance', 'Region'],
+    row: (i) => [i.id, i.region.code],
+    recommend: (i) => `Enable storage encryption for RDS instance "${i.id}" in ${i.region.code} (requires a snapshot/restore cycle)`,
+  },
+  's3-bucket-encryption-missing': {
+    title: 'S3 Buckets — Default Encryption Missing',
+    head: ['Bucket Name'],
+    row: (b) => [b.bucketName],
+    recommend: (b) => `Enable default encryption on S3 bucket "${b.bucketName}"`,
+  },
+  'rds-instance-publicly-accessible': {
+    title: 'RDS Instances — Publicly Accessible',
+    head: ['DB Instance', 'Region'],
+    row: (i) => [i.id, i.region.code],
+    recommend: (i) => `Disable public accessibility for RDS instance "${i.id}" in ${i.region.code}`,
+  },
+  'cloudtrail-not-multiregion': {
+    title: 'CloudTrail — No Multi-Region Trail',
+    head: ['Account ID'],
+    row: (f) => [f.accountId],
+    recommend: (f) => `Create or update a CloudTrail trail with multi-region logging enabled for account ${f.accountId}`,
+  },
+};
+
+export function presenterFor(kind: ResourceSecurityKind): Omit<ResourceSecurityPresenter, 'row' | 'recommend'> {
+  return presenters[kind];
+}
+
+/** Exhaustive switch on `finding.kind` (ADR-0059) — a missing case fails the build. */
+export function rowFor(finding: ResourceSecurityKindMap[ResourceSecurityKind]): string[] {
+  switch (finding.kind) {
+    case 'iam-root-mfa-disabled':
+      return presenters['iam-root-mfa-disabled'].row(finding);
+    case 'iam-user-mfa-disabled':
+      return presenters['iam-user-mfa-disabled'].row(finding);
+    case 'iam-access-key-rotation-overdue':
+      return presenters['iam-access-key-rotation-overdue'].row(finding);
+    case 'iam-root-access-key-active':
+      return presenters['iam-root-access-key-active'].row(finding);
+    case 'iam-password-policy-weak':
+      return presenters['iam-password-policy-weak'].row(finding);
+    case 'ec2-security-group-open-ingress':
+      return presenters['ec2-security-group-open-ingress'].row(finding);
+    case 'ec2-default-security-group-permissive':
+      return presenters['ec2-default-security-group-permissive'].row(finding);
+    case 's3-bucket-public':
+      return presenters['s3-bucket-public'].row(finding);
+    case 'ec2-snapshot-public':
+      return presenters['ec2-snapshot-public'].row(finding);
+    case 'ec2-volume-unencrypted':
+      return presenters['ec2-volume-unencrypted'].row(finding);
+    case 'rds-instance-unencrypted':
+      return presenters['rds-instance-unencrypted'].row(finding);
+    case 's3-bucket-encryption-missing':
+      return presenters['s3-bucket-encryption-missing'].row(finding);
+    case 'rds-instance-publicly-accessible':
+      return presenters['rds-instance-publicly-accessible'].row(finding);
+    case 'cloudtrail-not-multiregion':
+      return presenters['cloudtrail-not-multiregion'].row(finding);
+  }
+}
+
+export function recommendFor(finding: ResourceSecurityKindMap[ResourceSecurityKind]): string {
+  switch (finding.kind) {
+    case 'iam-root-mfa-disabled':
+      return presenters['iam-root-mfa-disabled'].recommend(finding);
+    case 'iam-user-mfa-disabled':
+      return presenters['iam-user-mfa-disabled'].recommend(finding);
+    case 'iam-access-key-rotation-overdue':
+      return presenters['iam-access-key-rotation-overdue'].recommend(finding);
+    case 'iam-root-access-key-active':
+      return presenters['iam-root-access-key-active'].recommend(finding);
+    case 'iam-password-policy-weak':
+      return presenters['iam-password-policy-weak'].recommend(finding);
+    case 'ec2-security-group-open-ingress':
+      return presenters['ec2-security-group-open-ingress'].recommend(finding);
+    case 'ec2-default-security-group-permissive':
+      return presenters['ec2-default-security-group-permissive'].recommend(finding);
+    case 's3-bucket-public':
+      return presenters['s3-bucket-public'].recommend(finding);
+    case 'ec2-snapshot-public':
+      return presenters['ec2-snapshot-public'].recommend(finding);
+    case 'ec2-volume-unencrypted':
+      return presenters['ec2-volume-unencrypted'].recommend(finding);
+    case 'rds-instance-unencrypted':
+      return presenters['rds-instance-unencrypted'].recommend(finding);
+    case 's3-bucket-encryption-missing':
+      return presenters['s3-bucket-encryption-missing'].recommend(finding);
+    case 'rds-instance-publicly-accessible':
+      return presenters['rds-instance-publicly-accessible'].recommend(finding);
+    case 'cloudtrail-not-multiregion':
+      return presenters['cloudtrail-not-multiregion'].recommend(finding);
+  }
+}

--- a/apps/cli/src/formatters/resource-security-report.json-formatter.ts
+++ b/apps/cli/src/formatters/resource-security-report.json-formatter.ts
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+import type { ResourceSecuritySummary } from 'resource-security-domain';
+
+export interface ResourceSecurityReportMeta {
+  accountId: string;
+  regions: string[];
+  generatedAt: Date;
+}
+
+/** No DTO builder yet (mirrors `dead-resources-report.json-formatter.ts`) — a single flat `findings[]` is enough for now. */
+export function formatResourceSecurityReportAsJson(summary: ResourceSecuritySummary, meta: ResourceSecurityReportMeta): string {
+  return JSON.stringify(
+    {
+      meta: {
+        accountId: meta.accountId,
+        regions: meta.regions,
+        generatedAt: meta.generatedAt.toISOString(),
+      },
+      countBySeverity: summary.countBySeverity,
+      findings: summary.findings.map((f) => ({
+        id: f.id,
+        kind: f.kind,
+        // undefined (account-wide/global-scope kinds — no region) becomes `null` in JSON, not an omitted key.
+        region: f.region?.code ?? null,
+        accountId: f.accountId,
+        detectedAt: f.detectedAt.toISOString(),
+        tags: f.tags,
+        riskReason: f.riskReason,
+        severity: f.severity,
+      })),
+      scanErrors: summary.scanErrors.map((e) => ({ kind: e.kind, region: e.region, error: e.error.message })),
+    },
+    null,
+    2,
+  );
+}

--- a/apps/cli/src/formatters/resource-security-report.pdf-formatter.spec.ts
+++ b/apps/cli/src/formatters/resource-security-report.pdf-formatter.spec.ts
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+import { mkdtemp, rm, readFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { IamRootMfaDisabled, S3BucketPublic } from 'resource-security-domain';
+import type { ResourceSecuritySummary } from 'resource-security-domain';
+import { generateResourceSecurityReportPdf, type ResourceSecurityReportPdfMeta } from './resource-security-report.pdf-formatter';
+
+const meta: ResourceSecurityReportPdfMeta = {
+  accountId: '123456789012',
+  regions: ['us-east-1'],
+  generatedAt: new Date('2026-07-23T12:00:00Z'),
+};
+
+function makeRootMfaFinding(): IamRootMfaDisabled {
+  return new IamRootMfaDisabled({ accountId: '123456789012', mfaEnabled: false, detectedAt: new Date('2026-07-23'), tags: {} });
+}
+
+function makePublicBucket(name: string): S3BucketPublic {
+  return new S3BucketPublic({
+    bucketName: name,
+    accountId: '123456789012',
+    publicVia: ['bucket policy allows public access'],
+    detectedAt: new Date('2026-07-23'),
+    tags: {},
+  });
+}
+
+describe('generateResourceSecurityReportPdf', () => {
+  it('completes without throwing for a realistic summary spanning multiple kinds', async () => {
+    const summary: ResourceSecuritySummary = {
+      findings: [makeRootMfaFinding(), makePublicBucket('bucket-1'), makePublicBucket('bucket-2')],
+      countBySeverity: { info: 0, warning: 0, critical: 3 },
+      scanErrors: [],
+    };
+    const dir = await mkdtemp(join(tmpdir(), 'cloudrift-pdf-'));
+    const file = join(dir, 'resource-security.pdf');
+    try {
+      await expect(generateResourceSecurityReportPdf(summary, meta, file)).resolves.toBeUndefined();
+      const written = await readFile(file);
+      expect(written.subarray(0, 5).toString('latin1')).toBe('%PDF-');
+      expect(written.length).toBeGreaterThan(1000);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('completes without throwing when there are no findings', async () => {
+    const empty: ResourceSecuritySummary = { findings: [], countBySeverity: { info: 0, warning: 0, critical: 0 }, scanErrors: [] };
+    const dir = await mkdtemp(join(tmpdir(), 'cloudrift-pdf-'));
+    const file = join(dir, 'empty.pdf');
+    try {
+      await expect(generateResourceSecurityReportPdf(empty, meta, file)).resolves.toBeUndefined();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('completes without throwing when there are scan warnings', async () => {
+    const withErrors: ResourceSecuritySummary = {
+      findings: [makeRootMfaFinding()],
+      countBySeverity: { info: 0, warning: 0, critical: 1 },
+      scanErrors: [{ kind: 'cloudtrail-not-multiregion', region: 'global', error: new Error('AccessDenied') }],
+    };
+    const dir = await mkdtemp(join(tmpdir(), 'cloudrift-pdf-'));
+    const file = join(dir, 'warnings.pdf');
+    try {
+      await expect(generateResourceSecurityReportPdf(withErrors, meta, file)).resolves.toBeUndefined();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/cli/src/formatters/resource-security-report.pdf-formatter.ts
+++ b/apps/cli/src/formatters/resource-security-report.pdf-formatter.ts
@@ -1,0 +1,239 @@
+// SPDX-License-Identifier: Apache-2.0
+import { createWriteStream } from 'fs';
+import { RESOURCE_SECURITY_KINDS, RESOURCE_SECURITY_KIND_META, groupByKind } from 'resource-security-domain';
+import type { ResourceSecuritySummary, ResourceSecuritySeverity } from 'resource-security-domain';
+import { RESOURCE_SECURITY_REPORT_DISCLAIMER } from 'resource-security-application';
+import { presenterFor, rowFor, recommendFor } from './resource-security-presenters';
+import {
+  C,
+  PAGE_H,
+  MARGIN,
+  CONTENT_W,
+  LINE_H,
+  drawMasthead,
+  ensureSpace,
+  measureDisclaimerHeight,
+  footerReservedHeight,
+  drawFooter,
+  drawMetricBox,
+  measureTableHeight,
+  drawTable,
+  computeColumnWidths,
+  wrapToLines,
+  rowHeightForLines,
+} from './pdf-shared';
+
+export interface ResourceSecurityReportPdfMeta {
+  accountId: string;
+  regions: string[];
+  generatedAt: Date;
+}
+
+const SEVERITY_RANK: Record<ResourceSecuritySeverity, number> = { critical: 0, warning: 1, info: 2 };
+const SEVERITY_COLOR: Record<ResourceSecuritySeverity, string> = { critical: C.danger, warning: C.warning, info: C.muted };
+
+export async function generateResourceSecurityReportPdf(
+  summary: ResourceSecuritySummary,
+  meta: ResourceSecurityReportPdfMeta,
+  outputPath: string,
+): Promise<void> {
+  const { default: PDFDocument } = await import('pdfkit');
+  return new Promise((resolve, reject) => {
+    const doc = new PDFDocument({ size: 'A4', margin: 0, autoFirstPage: false });
+    const stream = createWriteStream(outputPath);
+    doc.pipe(stream);
+    stream.on('finish', resolve);
+    stream.on('error', reject);
+
+    const disclaimerH = measureDisclaimerHeight(doc, RESOURCE_SECURITY_REPORT_DISCLAIMER);
+    const contentBottom = PAGE_H - MARGIN - footerReservedHeight(disclaimerH);
+    doc.on('pageAdded', () => drawFooter(doc, RESOURCE_SECURITY_REPORT_DISCLAIMER, disclaimerH));
+    doc.addPage();
+
+    drawSummaryPage(doc, summary, meta, contentBottom);
+    drawDetailPages(doc, summary, contentBottom);
+
+    doc.end();
+  });
+}
+
+// ─── Summary page ────────────────────────────────────────────────────────────
+
+function drawSummaryPage(
+  doc: PDFKit.PDFDocument,
+  summary: ResourceSecuritySummary,
+  meta: ResourceSecurityReportPdfMeta,
+  contentBottom: number,
+): void {
+  const bandH = drawMasthead(doc, 'cloudrift', 'AWS Resource Security Report');
+  let y = bandH + 24;
+
+  const metaParts: string[] = [`Generated: ${meta.generatedAt.toISOString().split('T')[0]}`];
+  if (meta.accountId !== 'unknown') metaParts.push(`Account: ${meta.accountId}`);
+  metaParts.push(`Regions: ${meta.regions.join(', ')}`);
+  doc.font('Helvetica').fontSize(8.5).fillColor(C.muted)
+    .text(metaParts.join('   ·   '), MARGIN, y, { lineBreak: false });
+
+  y += 18;
+  doc.moveTo(MARGIN, y).lineTo(MARGIN + CONTENT_W, y).lineWidth(0.5).strokeColor(C.border).stroke();
+  y += 14;
+
+  const { info, warning, critical } = summary.countBySeverity;
+  y = ensureSpace(doc, y, 90, contentBottom);
+  drawMetricBox(doc, MARGIN, y, 108, 'TOTAL FINDINGS', String(summary.findings.length), C.text);
+  drawMetricBox(doc, MARGIN + 118, y, 108, 'CRITICAL', String(critical), C.danger);
+  drawMetricBox(doc, MARGIN + 236, y, 108, 'WARNING', String(warning), C.warning);
+  drawMetricBox(doc, MARGIN + 354, y, 123, 'INFO', String(info), C.muted);
+  y += 90;
+
+  doc.font('Helvetica-Bold').fontSize(10.5).fillColor(C.text)
+    .text('Breakdown by check', MARGIN, y, { lineBreak: false });
+  y += 16;
+  const breakdownRows = buildBreakdownRows(summary);
+  const breakdownHeaders = ['Check', 'Found'];
+  const breakdownColWidths = computeColumnWidths(doc, breakdownHeaders, breakdownRows, CONTENT_W);
+  y = ensureSpace(doc, y, measureTableHeight(doc, breakdownHeaders, breakdownRows, breakdownColWidths), contentBottom);
+  y = drawTable(doc, breakdownHeaders, breakdownRows, breakdownColWidths, y, contentBottom);
+
+  const topFindings = buildTopFindings(summary);
+  if (topFindings.length > 0) {
+    y += 20;
+    y = ensureSpace(doc, y, 16 + measureRecommendationsHeight(doc, topFindings), contentBottom);
+    doc.font('Helvetica-Bold').fontSize(10.5).fillColor(C.text)
+      .text('Top findings — most severe first', MARGIN, y, { lineBreak: false });
+    y += 16;
+    y = drawRecommendations(doc, topFindings, y, contentBottom);
+  }
+
+  if (summary.scanErrors.length > 0) {
+    y += 16;
+    y = ensureSpace(doc, y, 14, contentBottom);
+    doc.font('Helvetica-Bold').fontSize(9).fillColor(C.warning)
+      .text('Scan warnings — partial results:', MARGIN, y, { lineBreak: false });
+    y += 14;
+    for (const { kind, region, error } of summary.scanErrors) {
+      const text = `• ${kind} in ${region}: ${error.message}`;
+      doc.font('Helvetica').fontSize(8.5);
+      const lineH = doc.heightOfString(text, { width: CONTENT_W - 8 });
+      y = ensureSpace(doc, y, lineH + 4, contentBottom);
+      doc.fillColor(C.warning).text(text, MARGIN + 8, y, { width: CONTENT_W - 8 });
+      y += lineH + 4;
+    }
+  }
+}
+
+// ─── Detail pages ─────────────────────────────────────────────────────────────
+
+function drawDetailPages(doc: PDFKit.PDFDocument, summary: ResourceSecuritySummary, contentBottom: number): void {
+  const grouped = groupByKind(summary.findings);
+
+  for (const kind of RESOURCE_SECURITY_KINDS) {
+    const findings = grouped[kind];
+    if (findings.length === 0) continue;
+
+    const presenter = presenterFor(kind);
+    doc.addPage();
+    const y = sectionHeader(doc, presenter.title);
+    const rows = findings.map((finding) => [...rowFor(finding), finding.severity]);
+    const headers = [...presenter.head, 'Severity'];
+    const colWidths = computeColumnWidths(doc, headers, rows, CONTENT_W);
+    drawTable(doc, headers, rows, colWidths, y, contentBottom);
+  }
+}
+
+function sectionHeader(doc: PDFKit.PDFDocument, title: string): number {
+  doc.font('Helvetica-Bold').fontSize(13).fillColor(C.primary)
+    .text(title, MARGIN, MARGIN, { lineBreak: false });
+  return MARGIN + 26;
+}
+
+// ─── Top findings (severity-ranked, capped) ────────────────────────────────────
+
+interface TopFinding {
+  label: string;
+  severity: ResourceSecuritySeverity;
+}
+
+function buildTopFindings(summary: ResourceSecuritySummary): TopFinding[] {
+  // Routed through groupByKind (not summary.findings directly) so `finding`
+  // keeps the kind↔entity correlation recommendFor's switch relies on.
+  const grouped = groupByKind(summary.findings);
+  const findings: TopFinding[] = [];
+  for (const kind of RESOURCE_SECURITY_KINDS) {
+    for (const finding of grouped[kind]) {
+      findings.push({ label: recommendFor(finding), severity: finding.severity });
+    }
+  }
+  return findings.sort((a, b) => SEVERITY_RANK[a.severity] - SEVERITY_RANK[b.severity]).slice(0, 8);
+}
+
+function measureRecommendationsHeight(doc: PDFKit.PDFDocument, findings: TopFinding[]): number {
+  doc.font('Helvetica').fontSize(8.5);
+  const labelW = CONTENT_W - 90;
+  return findings.reduce(
+    (total, { label }) => total + rowHeightForLines(wrapToLines(doc, label, labelW).length),
+    0,
+  );
+}
+
+function drawRecommendations(
+  doc: PDFKit.PDFDocument,
+  findings: TopFinding[],
+  startY: number,
+  contentBottom: number,
+): number {
+  let y = startY;
+  let segmentStartY = startY;
+  let segmentH = 0;
+  const labelW = CONTENT_W - 90;
+
+  const strokeSegmentBorder = () => {
+    if (segmentH === 0) return;
+    doc.rect(MARGIN, segmentStartY, CONTENT_W, segmentH).lineWidth(0.5).strokeColor(C.border).stroke();
+  };
+
+  for (let i = 0; i < findings.length; i++) {
+    doc.font('Helvetica').fontSize(8.5);
+    const labelLines = wrapToLines(doc, findings[i].label, labelW);
+    const h = rowHeightForLines(labelLines.length);
+
+    if (y + h > contentBottom) {
+      strokeSegmentBorder();
+      doc.addPage();
+      y = MARGIN;
+      segmentStartY = y;
+      segmentH = 0;
+    }
+
+    const bg = i % 2 === 0 ? '#ffffff' : C.rowAlt;
+    doc.rect(MARGIN, y, CONTENT_W, h).fill(bg);
+
+    doc.font('Helvetica-Bold').fontSize(8.5).fillColor(C.muted)
+      .text(`${i + 1}.`, MARGIN + 4, y + 6, { width: 16, lineBreak: false });
+
+    doc.font('Helvetica').fontSize(8.5).fillColor(C.text);
+    labelLines.forEach((line, li) => {
+      doc.text(line, MARGIN + 22, y + 6 + li * LINE_H, { width: labelW, lineBreak: false });
+    });
+
+    doc.font('Helvetica-Bold').fontSize(8).fillColor(SEVERITY_COLOR[findings[i].severity])
+      .text(findings[i].severity, MARGIN + 22 + labelW + 4, y + 6, { width: 64, align: 'right', lineBreak: false });
+
+    y += h;
+    segmentH += h;
+  }
+
+  strokeSegmentBorder();
+  return y;
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function buildBreakdownRows(summary: ResourceSecuritySummary): string[][] {
+  const grouped = groupByKind(summary.findings);
+
+  return RESOURCE_SECURITY_KINDS.filter((kind) => grouped[kind].length > 0).map((kind) => [
+    RESOURCE_SECURITY_KIND_META[kind].label,
+    String(grouped[kind].length),
+  ]);
+}

--- a/apps/cli/src/formatters/resource-security-report.table-formatter.ts
+++ b/apps/cli/src/formatters/resource-security-report.table-formatter.ts
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+import Table from 'cli-table3';
+import chalk from 'chalk';
+import { RESOURCE_SECURITY_KINDS, groupByKind } from 'resource-security-domain';
+import type { ResourceSecuritySummary, ResourceSecuritySeverity } from 'resource-security-domain';
+import { REPORT_CONTACT } from 'cloud-cost-application';
+import { presenterFor, rowFor } from './resource-security-presenters';
+
+const SEVERITY_COLOR: Record<ResourceSecuritySeverity, (text: string) => string> = {
+  info: chalk.dim,
+  warning: chalk.yellow,
+  critical: chalk.red,
+};
+
+export function formatResourceSecurityReportAsTable(summary: ResourceSecuritySummary): string {
+  const lines: string[] = [];
+  const grouped = groupByKind(summary.findings);
+
+  let rendered = false;
+  for (const kind of RESOURCE_SECURITY_KINDS) {
+    const findings = grouped[kind];
+    if (findings.length === 0) continue;
+    rendered = true;
+
+    const presenter = presenterFor(kind);
+    lines.push(chalk.bold.yellow(`\n  ${presenter.title}`));
+    const table = new Table({ head: [...presenter.head, 'Severity'], style: { head: ['cyan'] } });
+    for (const finding of findings) {
+      table.push([...rowFor(finding), SEVERITY_COLOR[finding.severity](finding.severity)]);
+    }
+    lines.push(table.toString());
+  }
+
+  if (!rendered && summary.scanErrors.length === 0) {
+    lines.push(chalk.green('\n  No security-posture risks found.'));
+  }
+
+  if (summary.scanErrors.length > 0) {
+    lines.push(chalk.bold.yellow('\n  Scan warnings — partial results (some scans could not complete):'));
+    for (const { kind, region, error } of summary.scanErrors) {
+      lines.push(chalk.yellow(`    • ${kind} in ${region}: ${error.message}`));
+    }
+  }
+
+  const incomplete = summary.scanErrors.length > 0 ? chalk.yellow(' (incomplete — see warnings above)') : '';
+  const { info, warning, critical } = summary.countBySeverity;
+  lines.push(
+    chalk.bold(
+      `\n  Total: ${summary.findings.length} finding(s)${incomplete} — ` +
+        `${critical} critical, ${warning} warning, ${info} info`,
+    ),
+  );
+  lines.push(chalk.dim(`  Contact: ${REPORT_CONTACT.email} · ${REPORT_CONTACT.github} · ${REPORT_CONTACT.linkedin}\n`));
+
+  return lines.join('\n');
+}

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -5,6 +5,7 @@ import { analyzeWasteCommand } from './commands/analyze-waste.command';
 import { costCommand } from './commands/cost.command';
 import { trendCommand } from './commands/trend.command';
 import { deadResourcesCommand } from './commands/dead-resources.command';
+import { resourceSecurityCommand } from './commands/resource-security.command';
 import { runEntryWizard } from './wizard/entry.wizard';
 import { isInteractiveTty } from './wizard/tty';
 
@@ -143,6 +144,31 @@ program
   )
   .option('--silent', 'suppress all stdout output (banner, report). Errors still surface.')
   .action((options) => deadResourcesCommand(options));
+
+program
+  .command('resource-security')
+  .description('Scan AWS account for security-posture risks (IAM/account hygiene, network exposure, public storage, encryption, audit)')
+  .option(
+    '-r, --regions <regions...>',
+    'AWS regions to scan',
+    ['us-east-1'],
+  )
+  .option('--account-id <id>', 'AWS account ID override (auto-detected via STS when omitted)')
+  .option(
+    '--ignore-tag <tag>',
+    'resources carrying this tag are excluded from the report (default cloudrift:ignore)',
+  )
+  .option(
+    '--scanners <kinds...>',
+    'only run these checks (space-separated, e.g. iam-root-mfa-disabled s3-bucket-public)',
+  )
+  .option('--format <format>', 'stdout output format: table (default) or json', 'table')
+  .option(
+    '--pdf [filename]',
+    'Also write a PDF report to disk (optional filename, defaults to reports/cloudrift-resource-security-YYYY_MM_DD.pdf)',
+  )
+  .option('--silent', 'suppress all stdout output (banner, report). Errors still surface.')
+  .action((options) => resourceSecurityCommand(options));
 
 // No subcommand at all, in a real terminal: hand off to the interactive
 // wizard instead of commander's default (print help, exit 1). Any flags or

--- a/apps/cli/src/wizard/entry.wizard.ts
+++ b/apps/cli/src/wizard/entry.wizard.ts
@@ -3,12 +3,14 @@ import { analyzeWasteCommand } from '../commands/analyze-waste.command';
 import { costCommand } from '../commands/cost.command';
 import { trendCommand } from '../commands/trend.command';
 import { deadResourcesCommand } from '../commands/dead-resources.command';
+import { resourceSecurityCommand } from '../commands/resource-security.command';
 import { renderBrandMark } from '../brand-mark';
 import { promptMode } from './mode-picker.wizard';
 import { promptRegions } from './region-input.wizard';
 import { promptScannerSelection } from './scanner-selection.wizard';
 import { promptDeadResourceSelection } from './dead-resource-selection.wizard';
-import { promptWasteOutput, promptDeadResourcesOutput, promptSimpleOutput } from './output-format.wizard';
+import { promptResourceSecuritySelection } from './resource-security-selection.wizard';
+import { promptWasteOutput, promptDeadResourcesOutput, promptResourceSecurityOutput, promptSimpleOutput } from './output-format.wizard';
 
 /**
  * The interactive entry point: shown when `cloudrift` is run with no
@@ -60,6 +62,26 @@ export async function runEntryWizard(): Promise<void> {
 
     outro('Starting scan...');
     await deadResourcesCommand({
+      regions,
+      scannerKinds,
+      format: output.format,
+      pdf: output.savePdf ? true : undefined,
+    });
+    return;
+  }
+
+  if (mode === 'resource-security') {
+    const regions = await promptRegions();
+    if (regions === undefined) return;
+
+    const scannerKinds = await promptResourceSecuritySelection();
+    if (scannerKinds === undefined) return;
+
+    const output = await promptResourceSecurityOutput();
+    if (output === undefined) return;
+
+    outro('Starting scan...');
+    await resourceSecurityCommand({
       regions,
       scannerKinds,
       format: output.format,

--- a/apps/cli/src/wizard/mode-picker.wizard.ts
+++ b/apps/cli/src/wizard/mode-picker.wizard.ts
@@ -1,12 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
-export type WizardMode = 'waste' | 'cost' | 'trend' | 'dead-resources';
+export type WizardMode = 'waste' | 'cost' | 'trend' | 'dead-resources' | 'resource-security';
 
 /**
  * Top-level "what do you want to do" choice — the entry point for the
  * wizard shown when `cloudrift` is run with no subcommand. Explicit
- * subcommands (`cloudrift analyze`/`cost`/`trend`/`dead-resources`, with
- * flags) are unaffected and keep working exactly as before for CI/scripts.
+ * subcommands (`cloudrift analyze`/`cost`/`trend`/`dead-resources`/
+ * `resource-security`, with flags) are unaffected and keep working exactly
+ * as before for CI/scripts.
  *
  * Returns `undefined` if the user cancels (Ctrl+C).
  */
@@ -31,6 +32,11 @@ export async function promptMode(): Promise<WizardMode | undefined> {
         value: 'dead-resources',
         label: 'Find dead/unused resources',
         hint: 'free — hygiene, no $/month (e.g. unused key pairs)',
+      },
+      {
+        value: 'resource-security',
+        label: 'Scan for security-posture risks',
+        hint: 'free — IAM/MFA, open ingress, public storage, encryption, audit',
       },
     ],
   });

--- a/apps/cli/src/wizard/output-format.wizard.ts
+++ b/apps/cli/src/wizard/output-format.wizard.ts
@@ -55,6 +55,13 @@ export async function promptDeadResourcesOutput(): Promise<DeadResourcesOutputCh
   return { format, savePdf };
 }
 
+export type ResourceSecurityOutputChoice = DeadResourcesOutputChoice;
+
+/** Output format + optional PDF for the resource-security wizard flow — table/json only, no markdown, same shape as dead-resources. */
+export async function promptResourceSecurityOutput(): Promise<ResourceSecurityOutputChoice | undefined> {
+  return promptDeadResourcesOutput();
+}
+
 /** Output format for the cost/trend wizard flow — no file artifacts yet, see PDF backlog item. */
 export async function promptSimpleOutput(): Promise<'table' | 'json' | undefined> {
   const { select, cancel, isCancel } = await import('@clack/prompts');

--- a/apps/cli/src/wizard/resource-security-selection.wizard.ts
+++ b/apps/cli/src/wizard/resource-security-selection.wizard.ts
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+import type { Option } from '@clack/prompts';
+import { RESOURCE_SECURITY_KINDS, RESOURCE_SECURITY_KIND_META, type ResourceSecurityKind } from 'resource-security-domain';
+
+/**
+ * Multi-select prompt for the `resource-security` wizard flow. Mirrors
+ * `dead-resource-selection.wizard.ts`'s shape exactly (flat list, no forced
+ * category grouping) over a different kind union.
+ *
+ * Returns `undefined` if the user cancels (Ctrl+C).
+ */
+export async function promptResourceSecuritySelection(): Promise<ResourceSecurityKind[] | undefined> {
+  const { cancel, intro, isCancel, multiselect } = await import('@clack/prompts');
+  intro('Select the security-posture checks to run (space to toggle, enter to confirm)');
+  const options = RESOURCE_SECURITY_KINDS.map((kind) => ({
+    value: kind,
+    label: RESOURCE_SECURITY_KIND_META[kind].label,
+  })) as Option<ResourceSecurityKind>[];
+  const selected = await multiselect<ResourceSecurityKind>({
+    message: 'Checks to run',
+    options,
+    initialValues: [...RESOURCE_SECURITY_KINDS],
+    required: true,
+  });
+
+  if (isCancel(selected)) {
+    cancel('Cancelled — no scan was run.');
+    return undefined;
+  }
+
+  return selected;
+}

--- a/apps/cli/tsconfig.app.json
+++ b/apps/cli/tsconfig.app.json
@@ -38,6 +38,15 @@
     },
     {
       "path": "../../libs/cost-analytics/application/tsconfig.lib.json"
+    },
+    {
+      "path": "../../libs/resource-security/infrastructure/aws-adapter/tsconfig.lib.json"
+    },
+    {
+      "path": "../../libs/resource-security/domain/tsconfig.lib.json"
+    },
+    {
+      "path": "../../libs/resource-security/application/tsconfig.lib.json"
     }
   ]
 }

--- a/docs/adr/0081-resource-security-parallel-domain.md
+++ b/docs/adr/0081-resource-security-parallel-domain.md
@@ -1,0 +1,76 @@
+# ADR-0081: `resource-security` as a new parallel domain
+
+- **Status:** Accepted (2026-07-23)
+
+## Context
+
+`dead-resources` ([ADR-0078](0078-dead-resources-parallel-domain.md)/[ADR-0079](0079-dead-resources-global-scope-scanners.md)) widened cloudrift's scope from "cost waste" to "anything dead/unused in the account," but explicitly drew a line around security-posture checks: "root senza MFA" and similar findings are configuration-of-security-posture checks, not abandoned/unused objects, and were deliberately left out of that domain (see the "Nota — non estende automaticamente allo scope 'security'" note added to the `dead-resources` scope decision).
+
+A follow-up scoping pass (2026-07-23) confirmed and expanded this: 14 read-only security-posture checks across five categories — IAM/account-level (root MFA, user MFA, access-key rotation, root access keys, password policy), network exposure (open ingress, permissive default security groups), public storage (S3 buckets, EBS snapshots), encryption at rest (EBS, RDS, S3), and visibility/audit (RDS public accessibility, CloudTrail multi-region coverage). All read-only (`Describe*`/`Get*`/`List*` IAM actions only), consistent with the project's "never deletes/modifies/stops" disclaimer.
+
+## Decision
+
+**Three new Nx libraries**, mirroring `dead-resources-{domain,application,infrastructure/aws-adapter}`'s exact layout and hexagonal layering ([ADR-0013](0013-ddd-hexagonal-plugin-model.md), [ADR-0078](0078-dead-resources-parallel-domain.md)):
+
+- `resource-security-domain` (`libs/resource-security/domain`, `scope:domain`)
+- `resource-security-application` (`libs/resource-security/application`, `scope:application`)
+- `resource-security-infrastructure-aws-adapter` (`libs/resource-security/infrastructure/aws-adapter`, `scope:infrastructure`)
+
+**New domain model**, deliberately not reusing `dead-resources-domain`'s types — these findings describe risky configuration on actively-used resources, not abandoned ones:
+
+```ts
+export type ResourceSecuritySeverity = 'info' | 'warning' | 'critical';
+export interface SecurityFinding {
+  readonly id: string;
+  readonly kind: ResourceSecurityKind;
+  readonly region?: AwsRegion; // optional: account-wide/global-scope kinds have none
+  readonly accountId: string;
+  readonly detectedAt: Date;
+  readonly tags: Record<string, string>;
+  readonly riskReason: string; // instead of hygieneReason
+  readonly severity: ResourceSecuritySeverity;
+}
+```
+
+`ResourceSecurityScannerPort`, `FindResourceSecurityFindingsUseCasePort`/`FindResourceSecurityFindingsUseCase`, and the `scope: 'regional' | 'global'` job-splitting coordinator all mirror their `dead-resources-*` counterparts verbatim in shape and behavior (8 of the 14 kinds are global-scope: the 5 IAM/account-level checks, both S3 checks, and CloudTrail — S3's `ListBuckets` and IAM/CloudTrail's account-wide view have no meaningful per-region split).
+
+**`ResourceSecurityPolicy<T>` deliberately omits `DeadResourcePolicy`'s grace-period/`minAgeDays` machinery.** A hygiene finding ("this key pair hasn't been touched in N days") legitimately needs a settling-in period; a security misconfiguration (open ingress, no MFA, an unencrypted volume) is a risk from the moment it exists, so gating findings behind an age threshold would misrepresent the risk. Only the tag-exclusion logic (`ignoreTag`/`excludeTagValues`) carries over. The one kind that does need an age threshold (`iam-access-key-rotation-overdue`, CIS AWS Foundations 1.14: rotate every 90 days) computes it in its own `judge()` using the `now` parameter, rather than adding grace-period fields every other kind would have to ignore.
+
+**All 14 kinds implemented in one pass** (unlike `dead-resources`' incremental single-kind-first rollout in ADR-0078): the scope was already fully enumerated and confirmed before implementation started, so there was no discovery risk to de-risk against.
+
+| Category | Kind | Scope |
+|---|---|---|
+| IAM/account | `iam-root-mfa-disabled` | global |
+| IAM/account | `iam-user-mfa-disabled` | global |
+| IAM/account | `iam-access-key-rotation-overdue` | global |
+| IAM/account | `iam-root-access-key-active` | global |
+| IAM/account | `iam-password-policy-weak` | global |
+| Network | `ec2-security-group-open-ingress` | regional |
+| Network | `ec2-default-security-group-permissive` | regional |
+| Public storage | `s3-bucket-public` | global |
+| Public storage | `ec2-snapshot-public` | regional |
+| Encryption | `ec2-volume-unencrypted` | regional |
+| Encryption | `rds-instance-unencrypted` | regional |
+| Encryption | `s3-bucket-encryption-missing` | global |
+| Visibility/audit | `rds-instance-publicly-accessible` | regional |
+| Visibility/audit | `cloudtrail-not-multiregion` | global |
+
+**CLI**: a new top-level `cloudrift resource-security` command (`--regions`, `--account-id`, `--ignore-tag`, `--scanners`, `--format table|json`, `--pdf`, `--silent`) — no `--min-age-days` (no grace-period concept, see above). Its own composition root (`resource-security.composition.ts`) and presenter/formatter set (`resource-security-presenters.ts`, table/json/PDF formatters, all reusing `pdf-shared.ts` per [ADR-0072](0072-pdf-shared-layout-module.md)) following the exhaustive-switch dispatch pattern ([ADR-0059](0059-presenter-dispatch-exhaustive-switch.md)). Wired into the wizard as a fifth `WizardMode` (`mode-picker.wizard.ts`), with its own flat, non-categorized multi-select (`resource-security-selection.wizard.ts`) — same shape and same "don't force a category taxonomy" reasoning as `dead-resource-selection.wizard.ts`.
+
+## Alternatives Considered
+
+- **Fold into `dead-resources`.** Rejected per the "Nota" already recorded against that domain's scope: these are security-posture checks on in-use resources, not abandoned ones — reusing `hygieneReason`/`DeadResourceSeverity` would misdescribe every finding.
+- **Fold into `analyze` via a flag.** Rejected for the same reason ADR-0078 rejected this for `dead-resources`: conflates domains with different report semantics in one output.
+- **Sub-module inside `dead-resources-domain`.** Rejected: would blur that domain's own "sole inbound boundary" invariant and force sharing grace-period machinery this domain deliberately doesn't want.
+
+## Consequences
+
+**Known, deliberate duplication**, same tradeoff ADR-0078 already accepted: `paginate()`, `mapWithConcurrency()`, `createAwsClientConfig()`, and `AwsAdapterError` are copied verbatim into `resource-security-infrastructure-aws-adapter` rather than imported from `dead-resources-infrastructure-aws-adapter`. Revisit (move to `shared-kernel`) only if a fourth AWS-touching infrastructure lib needs the same utilities.
+
+**New IAM permission, `cloudtrail:DescribeTrails`, plus five more from services already granted for other domains** (`iam:GetAccountSummary`, `iam:ListMFADevices`, `iam:GetAccountPasswordPolicy`, four `s3:Get*` actions, `ec2:DescribeSnapshotAttribute`) — see [iam-permissions.md](../en/iam-permissions.md). `@aws-sdk/client-cloudtrail` is a new root dependency; every other AWS SDK client this domain uses (`client-iam`, `client-ec2`, `client-s3`, `client-rds`) was already a dependency.
+
+**No LocalStack e2e coverage yet** — same gap `dead-resources` has (ADR-0079's rationale applies unchanged): several checks here (root MFA, password policy, CloudTrail multi-region) describe account-wide state LocalStack Community doesn't model faithfully. Verified instead via unit tests (47 domain + 7 application + 70 infrastructure-adapter tests, all with mocked AWS SDK clients) and manual review; no contract-fixture harness was added for this domain (unlike `dead-resources-contract.spec.ts`) since the per-scanner unit specs already exercise realistic response shapes end-to-end through scan → policy.
+
+**No new god-file risk.** `resource-security.composition.ts`'s `buildScanners()` is a plain 14-entry array, same shape as `dead-resources.composition.ts`'s pre-split array — well under the 43-entry threshold that justified splitting the cost-waste registry ([ADR-0077](0077-scanner-registry-split-on-pricing-seam.md)).
+
+Verified via `pnpm nx run-many --target={lint,test,build} --all`: all projects green, 47 new `resource-security-domain` tests, 7 new `resource-security-application` tests, 70 new `resource-security-infrastructure-aws-adapter` tests, 30 new CLI tests (`resource-security.command.spec.ts`, `resource-security-presenters.spec.ts`, `resource-security-report.pdf-formatter.spec.ts`) — zero regressions in the existing suite.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -22,6 +22,7 @@ Each entry follows: Context → Decision → Alternatives Considered → Consequ
 | [0065](0065-vertical-premium-scanners-phase-6-strategy.md) | Vertical premium scanners — Phase 6 strategy | Accepted |
 | [0078](0078-dead-resources-parallel-domain.md) | `dead-resources` as a new parallel domain, not a `WastedResource` extension | Accepted, kind list extended by [ADR-0079](0079-dead-resources-global-scope-scanners.md) |
 | [0079](0079-dead-resources-global-scope-scanners.md) | Global-scope scanners (IAM) in the `dead-resources` coordinator | Accepted |
+| [0081](0081-resource-security-parallel-domain.md) | `resource-security` as a new parallel domain (14 security-posture checks) | Accepted |
 
 ## Cost analytics (`cost` / `trend`)
 

--- a/docs/en/iam-permissions.md
+++ b/docs/en/iam-permissions.md
@@ -102,3 +102,25 @@ The `dead-resources` command (dead/unused resource hygiene checks, see [ADR-0078
 ```
 
 `ec2:DescribeInstances`/`ec2:DescribeNetworkInterfaces` (already in the main policy above) are reused to cross-reference key pairs against running/stopped instances and security groups against network interfaces, respectively. None of these actions are needed for `analyze` — only for `dead-resources`. `s3:ListBucket` (a bucket-level, not account-level, action) is what backs each `s3-bucket-empty` check's `ListObjectsV2` call — a bucket policy that denies it to this principal makes that one bucket unreadable, not the whole scan (see `aws-s3-bucket-empty.scanner.ts`'s per-bucket skip-on-error behavior). `ec2:DescribeRegions` and the reused `ec2:DescribeInstances` are what back `iam-instance-profile-unattached`'s account-wide, all-region cross-reference (see `aws-iam-instance-profile-unattached.scanner.ts`'s doc comment for why this one check deliberately ignores `--regions`) — a region this principal can't `DescribeInstances` in is skipped for that check, not treated as a scan failure.
+
+The `resource-security` command (security-posture checks — IAM/account hygiene, network exposure, public storage, encryption at rest, visibility/audit; see [ADR-0081](../adr/0081-resource-security-parallel-domain.md), full flag reference in [usage.md](usage.md#resource-security--security-posture-scan)) additionally requires:
+
+```json
+{
+  "Effect": "Allow",
+  "Action": [
+    "iam:GetAccountSummary",
+    "iam:ListMFADevices",
+    "iam:GetAccountPasswordPolicy",
+    "s3:GetBucketAcl",
+    "s3:GetBucketPolicyStatus",
+    "s3:GetPublicAccessBlock",
+    "s3:GetBucketEncryption",
+    "ec2:DescribeSnapshotAttribute",
+    "cloudtrail:DescribeTrails"
+  ],
+  "Resource": "*"
+}
+```
+
+`iam:ListUsers`, `iam:ListAccessKeys`, `ec2:DescribeSecurityGroups`, `ec2:DescribeVolumes`, `ec2:DescribeSnapshots`, `s3:ListAllMyBuckets`, and `rds:DescribeDBInstances` (all already in the main policy or the `dead-resources` block above) are reused — this command adds no new hygiene/inventory calls, only the read-only checks (`Get*`/`DescribeSnapshotAttribute`/`DescribeTrails`) needed to evaluate each resource's security configuration. `cloudtrail:DescribeTrails` is the one action from a service not otherwise used by cloudrift. None of these actions are needed for `analyze` or `dead-resources` — only for `resource-security`.

--- a/docs/en/usage.md
+++ b/docs/en/usage.md
@@ -2,9 +2,9 @@
 
 > 🇮🇹 [Versione italiana](../it/utilizzo.md)
 
-Flags, examples, the PDF report, partial-failure handling, and per-region pricing for `cloudrift analyze`, plus the `cost`/`trend`/`dead-resources` commands and the interactive wizard.
+Flags, examples, the PDF report, partial-failure handling, and per-region pricing for `cloudrift analyze`, plus the `cost`/`trend`/`dead-resources`/`resource-security` commands and the interactive wizard.
 
-**Interactive wizard:** running `cloudrift` with **no subcommand** in a real terminal (outside CI) launches a mode-picker wizard — choose "Find wasted resources" / "Compare spend vs. last month" / "View monthly spend trend" / "Find dead/unused resources", then answer a few prompts (regions, which scanners, output format). It calls the exact same `analyze`/`cost`/`trend`/`dead-resources` code the flags below drive, so it's never out of sync with them. Any explicit subcommand, any flag, CI, or non-interactive stdout skips the wizard entirely — scripts and pipelines are unaffected. See [ADR-0071](../adr/0071-unified-entry-wizard-bare-invocation.md).
+**Interactive wizard:** running `cloudrift` with **no subcommand** in a real terminal (outside CI) launches a mode-picker wizard — choose "Find wasted resources" / "Compare spend vs. last month" / "View monthly spend trend" / "Find dead/unused resources" / "Scan for security-posture risks", then answer a few prompts (regions, which scanners, output format). It calls the exact same `analyze`/`cost`/`trend`/`dead-resources`/`resource-security` code the flags below drive, so it's never out of sync with them. Any explicit subcommand, any flag, CI, or non-interactive stdout skips the wizard entirely — scripts and pipelines are unaffected. See [ADR-0071](../adr/0071-unified-entry-wizard-bare-invocation.md).
 
 ## `analyze` — find wasted resources
 
@@ -219,3 +219,66 @@ node apps/cli/dist/main.js dead-resources --pdf ./hygiene.pdf --silent
 ```
 
 **IAM permissions:** this command needs `ec2:DescribeKeyPairs`, `ec2:DescribeReservedInstances`, `ec2:DescribeSecurityGroups`, `iam:ListUsers`, `iam:ListAccessKeys`, `iam:GetAccessKeyLastUsed`, `iam:ListPolicies`, `iam:ListRoles`, `logs:DescribeLogGroups`, `acm:ListCertificates`, `route53:ListHostedZones`, `cloudformation:DescribeStacks`, `s3:ListAllMyBuckets`, `s3:ListBucket`, `cloudwatch:DescribeAlarms` in addition to `analyze`'s policy — see [docs/en/iam-permissions.md](iam-permissions.md).
+
+---
+
+## `resource-security` — security-posture scan
+
+A separate domain from both `analyze`'s cost-waste model and `dead-resources`' hygiene model — see [ADR-0081](../adr/0081-resource-security-parallel-domain.md). Finds risky **configuration** on resources that are actively in use (unlike `dead-resources`, which finds abandoned ones): disabled root/user MFA, overdue access-key rotation, active root access keys, a weak or missing account password policy, security groups with ingress open to the internet on sensitive ports, permissive default security groups, public S3 buckets and EBS snapshots, unencrypted EBS volumes and RDS instances, S3 buckets with no default encryption, publicly accessible RDS instances, and accounts with no multi-region CloudTrail trail — 14 checks in total, all backed by read-only `Describe*`/`Get*`/`List*` API calls. Findings carry a `severity` (`info` / `warning` / `critical`), same shape as `dead-resources`; there is no `--min-age-days` grace period — a security misconfiguration is a risk from the moment it exists, not after it ages.
+
+```sh
+node apps/cli/dist/main.js resource-security [options]
+```
+
+| Option                       | Description                                                                                                    | Default            |
+| ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ |
+| `-r, --regions <regions...>` | AWS regions to scan (ignored by the global-scope checks — see below)                                           | `us-east-1`        |
+| `--account-id <id>`          | AWS account ID override (auto-detected via `sts:GetCallerIdentity` when omitted)                               | auto-detected      |
+| `--ignore-tag <tag>`         | Resources carrying this tag are excluded from the report                                                       | `cloudrift:ignore` |
+| `--scanners <kinds...>`      | Only run these checks (space-separated, e.g. `iam-root-mfa-disabled s3-bucket-public`)                         | all checks          |
+| `--format <format>`          | stdout output format: `table` or `json`                                                                        | `table`            |
+| `--pdf [filename]`           | Also write a PDF report to disk (defaults to `reports/cloudrift-resource-security-YYYY_MM_DD.pdf`)             | —                  |
+| `--silent`                   | Suppress all stdout output (banner, report). Errors still surface.                                              | off                |
+| `-h, --help`                 | Show help                                                                                                       | —                  |
+
+**Checks:**
+
+| Kind | Scope | What's flagged | Severity |
+| --- | --- | --- | --- |
+| `iam-root-mfa-disabled` | global | Root account has no MFA device enabled | `critical` |
+| `iam-user-mfa-disabled` | global | IAM user with no MFA device registered | `warning` |
+| `iam-access-key-rotation-overdue` | global | Active access key older than 90 days (CIS AWS Foundations 1.14) | `warning` |
+| `iam-root-access-key-active` | global | Root account has at least one active access key | `critical` |
+| `iam-password-policy-weak` | global | Account password policy missing, or short of the CIS baseline (14-char minimum, all character classes, ≤90-day max age, 24-password reuse prevention) | `warning` |
+| `ec2-security-group-open-ingress` | regional | Security group with ingress open to `0.0.0.0/0`/`::/0` on a sensitive port (SSH, RDP, common database ports) | `critical` |
+| `ec2-default-security-group-permissive` | regional | A VPC's `default` security group still carries ingress and/or egress rules | `warning` |
+| `s3-bucket-public` | global | Bucket reachable by the internet via its ACL and/or bucket policy | `critical` |
+| `ec2-snapshot-public` | regional | EBS snapshot with `createVolumePermission` granted to the `all` group | `critical` |
+| `ec2-volume-unencrypted` | regional | EBS volume not encrypted at rest | `warning` |
+| `rds-instance-unencrypted` | regional | RDS instance storage not encrypted at rest | `warning` |
+| `s3-bucket-encryption-missing` | global | Bucket with no default server-side encryption configured | `warning` |
+| `rds-instance-publicly-accessible` | regional | RDS instance reachable from outside its VPC | `critical` |
+| `cloudtrail-not-multiregion` | global | No CloudTrail trail configured with multi-region logging | `warning` |
+
+> **IAM, S3 (bucket listing), and CloudTrail are treated as global for this command.** The eight `global` checks above run **once per scan**, never once per requested region — unlike the six `regional` checks. See [ADR-0081](../adr/0081-resource-security-parallel-domain.md).
+
+**Examples:**
+
+```sh
+# Every check, default region
+node apps/cli/dist/main.js resource-security
+
+# Multiple regions — only affects the regional checks, not the global ones
+node apps/cli/dist/main.js resource-security -r us-east-1 eu-west-1
+
+# Only the IAM checks
+node apps/cli/dist/main.js resource-security --scanners iam-root-mfa-disabled iam-user-mfa-disabled
+
+# Machine-readable output
+node apps/cli/dist/main.js resource-security --format json | jq '.findings[] | select(.severity=="critical")'
+
+# PDF report, nothing printed to the terminal
+node apps/cli/dist/main.js resource-security --pdf ./security.pdf --silent
+```
+
+**IAM permissions:** this command needs `iam:GetAccountSummary`, `iam:ListMFADevices`, `iam:GetAccountPasswordPolicy`, `s3:GetBucketAcl`, `s3:GetBucketPolicyStatus`, `s3:GetPublicAccessBlock`, `s3:GetBucketEncryption`, `ec2:DescribeSnapshotAttribute`, `cloudtrail:DescribeTrails` in addition to `analyze`'s policy (several other checks reuse actions already granted for `analyze`/`dead-resources`) — see [docs/en/iam-permissions.md](iam-permissions.md).

--- a/docs/it/permessi-iam.md
+++ b/docs/it/permessi-iam.md
@@ -102,3 +102,25 @@ Il comando `dead-resources` (check di hygiene per risorse morte/inutilizzate, ve
 ```
 
 `ec2:DescribeInstances`/`ec2:DescribeNetworkInterfaces` (già nella policy principale sopra) vengono riusate rispettivamente per incrociare le key pair con le istanze in esecuzione/ferme e i security group con le network interface. Nessuna di queste action serve per `analyze` — solo per `dead-resources`. `s3:ListBucket` (action a livello di singolo bucket, non a livello account) è quella dietro la chiamata `ListObjectsV2` di ogni check `s3-bucket-empty` — una bucket policy che la nega a questo principal rende illeggibile solo quel bucket, non l'intera scansione (vedi il comportamento di skip-per-errore in `aws-s3-bucket-empty.scanner.ts`). `ec2:DescribeRegions` e la riusata `ec2:DescribeInstances` sono ciò che sta dietro l'incrocio account-wide, su tutte le regioni, di `iam-instance-profile-unattached` (vedi il commento in `aws-iam-instance-profile-unattached.scanner.ts` sul perché questo check ignora deliberatamente `--regions`) — una regione in cui questo principal non può fare `DescribeInstances` viene saltata per quel check, non trattata come un fallimento della scansione.
+
+Il comando `resource-security` (check di postura di sicurezza — hygiene IAM/account, esposizione di rete, storage pubblico, crittografia a riposo, visibilità/audit; vedi [ADR-0081](../adr/0081-resource-security-parallel-domain.md), riferimento completo dei flag in [utilizzo.md](utilizzo.md#resource-security--scansione-della-postura-di-sicurezza)) richiede in più:
+
+```json
+{
+  "Effect": "Allow",
+  "Action": [
+    "iam:GetAccountSummary",
+    "iam:ListMFADevices",
+    "iam:GetAccountPasswordPolicy",
+    "s3:GetBucketAcl",
+    "s3:GetBucketPolicyStatus",
+    "s3:GetPublicAccessBlock",
+    "s3:GetBucketEncryption",
+    "ec2:DescribeSnapshotAttribute",
+    "cloudtrail:DescribeTrails"
+  ],
+  "Resource": "*"
+}
+```
+
+`iam:ListUsers`, `iam:ListAccessKeys`, `ec2:DescribeSecurityGroups`, `ec2:DescribeVolumes`, `ec2:DescribeSnapshots`, `s3:ListAllMyBuckets` e `rds:DescribeDBInstances` (già presenti nella policy principale o nel blocco `dead-resources` sopra) vengono riusate — questo comando non aggiunge nuove chiamate di hygiene/inventario, solo le verifiche read-only (`Get*`/`DescribeSnapshotAttribute`/`DescribeTrails`) necessarie per valutare la configurazione di sicurezza di ogni risorsa. `cloudtrail:DescribeTrails` è l'unica action di un servizio non altrimenti usato da cloudrift. Nessuna di queste action serve per `analyze` o `dead-resources` — solo per `resource-security`.

--- a/docs/it/utilizzo.md
+++ b/docs/it/utilizzo.md
@@ -2,9 +2,9 @@
 
 > 🇬🇧 [English version](../en/usage.md)
 
-Flag, esempi, report PDF, gestione errori parziali, e prezzi per regione per `cloudrift analyze`, più i comandi `cost`/`trend`/`dead-resources` e il wizard interattivo.
+Flag, esempi, report PDF, gestione errori parziali, e prezzi per regione per `cloudrift analyze`, più i comandi `cost`/`trend`/`dead-resources`/`resource-security` e il wizard interattivo.
 
-**Wizard interattivo:** lanciando `cloudrift` senza **nessun sottocomando** in un vero terminale (fuori da CI) parte un wizard che ti fa scegliere cosa fare — "Trova risorse sprecate" / "Confronta la spesa col mese scorso" / "Vedi il trend mensile di spesa" / "Trova risorse morte/inutilizzate" — e poi pochi prompt (regioni, quali scanner, formato di output). Richiama esattamente lo stesso codice di `analyze`/`cost`/`trend`/`dead-resources` guidato dai flag qui sotto, quindi non va mai fuori sincrono con loro. Qualunque sottocomando esplicito, qualunque flag, CI, o stdout non interattivo saltano del tutto il wizard — script e pipeline non ne sono toccati. Vedi [ADR-0071](../adr/0071-unified-entry-wizard-bare-invocation.md).
+**Wizard interattivo:** lanciando `cloudrift` senza **nessun sottocomando** in un vero terminale (fuori da CI) parte un wizard che ti fa scegliere cosa fare — "Trova risorse sprecate" / "Confronta la spesa col mese scorso" / "Vedi il trend mensile di spesa" / "Trova risorse morte/inutilizzate" / "Scansiona rischi di postura di sicurezza" — e poi pochi prompt (regioni, quali scanner, formato di output). Richiama esattamente lo stesso codice di `analyze`/`cost`/`trend`/`dead-resources`/`resource-security` guidato dai flag qui sotto, quindi non va mai fuori sincrono con loro. Qualunque sottocomando esplicito, qualunque flag, CI, o stdout non interattivo saltano del tutto il wizard — script e pipeline non ne sono toccati. Vedi [ADR-0071](../adr/0071-unified-entry-wizard-bare-invocation.md).
 
 ## `analyze` — trova risorse sprecate
 
@@ -234,3 +234,66 @@ node apps/cli/dist/main.js dead-resources --pdf ./hygiene.pdf --silent
 ```
 
 **Permessi IAM:** questo comando richiede `ec2:DescribeKeyPairs`, `ec2:DescribeReservedInstances`, `ec2:DescribeSecurityGroups`, `iam:ListUsers`, `iam:ListAccessKeys`, `iam:GetAccessKeyLastUsed`, `iam:ListPolicies`, `iam:ListRoles`, `logs:DescribeLogGroups`, `acm:ListCertificates`, `route53:ListHostedZones`, `cloudformation:DescribeStacks`, `s3:ListAllMyBuckets`, `s3:ListBucket`, `cloudwatch:DescribeAlarms` in aggiunta alla policy di `analyze` — vedi [docs/it/permessi-iam.md](permessi-iam.md).
+
+---
+
+## `resource-security` — scansione della postura di sicurezza
+
+Un dominio separato sia dal modello cost-waste di `analyze` sia dal modello hygiene di `dead-resources` — vedi [ADR-0081](../adr/0081-resource-security-parallel-domain.md). Trova **configurazioni** rischiose su risorse effettivamente in uso (a differenza di `dead-resources`, che trova risorse abbandonate): MFA disabilitata su root/utenti, rotazione delle access key in ritardo, access key attive sull'account root, password policy debole o assente, security group con ingress aperto su internet su porte sensibili, security group di default permissivi, bucket S3 ed EBS snapshot pubblici, volumi EBS e istanze RDS non cifrati, bucket S3 senza cifratura di default, istanze RDS pubblicamente accessibili, e account senza un trail CloudTrail multi-regione — 14 check in totale, tutti basati su chiamate API di sola lettura (`Describe*`/`Get*`/`List*`). I finding portano una `severity` (`info` / `warning` / `critical`), stessa forma di `dead-resources`; non c'è un grace period `--min-age-days` — una configurazione di sicurezza errata è un rischio dal momento in cui esiste, non dopo che invecchia.
+
+```sh
+node apps/cli/dist/main.js resource-security [opzioni]
+```
+
+| Opzione                       | Descrizione                                                                                                    | Default            |
+| ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ |
+| `-r, --regions <regions...>` | Regioni AWS da scansionare (ignorato dai check a scope globale — vedi sotto)                                   | `us-east-1`        |
+| `--account-id <id>`          | Override dell'account ID AWS (auto-rilevato via `sts:GetCallerIdentity` se omesso)                             | auto-rilevato      |
+| `--ignore-tag <tag>`         | Le risorse con questo tag sono escluse dal report                                                              | `cloudrift:ignore` |
+| `--scanners <kinds...>`      | Esegue solo questi check (separati da spazio, es. `iam-root-mfa-disabled s3-bucket-public`)                    | tutti i check       |
+| `--format <format>`          | Formato di output su stdout: `table` o `json`                                                                  | `table`            |
+| `--pdf [filename]`           | Scrive anche un report PDF su disco (default `reports/cloudrift-resource-security-YYYY_MM_DD.pdf`)             | —                  |
+| `--silent`                   | Sopprime tutto l'output stdout (banner, report). Gli errori restano visibili.                                   | off                |
+| `-h, --help`                 | Mostra l'help                                                                                                   | —                  |
+
+**Check:**
+
+| Kind | Scope | Cosa viene segnalato | Severity |
+| --- | --- | --- | --- |
+| `iam-root-mfa-disabled` | globale | Account root senza alcun dispositivo MFA abilitato | `critical` |
+| `iam-user-mfa-disabled` | globale | Utente IAM senza alcun dispositivo MFA registrato | `warning` |
+| `iam-access-key-rotation-overdue` | globale | Access key attiva più vecchia di 90 giorni (CIS 1.14) | `warning` |
+| `iam-root-access-key-active` | globale | L'account root ha almeno una access key attiva | `critical` |
+| `iam-password-policy-weak` | globale | Password policy dell'account assente, o sotto la baseline CIS | `warning` |
+| `ec2-security-group-open-ingress` | regionale | Security group con ingress aperto a `0.0.0.0/0`/`::/0` su una porta sensibile (SSH, RDP, porte database comuni) | `critical` |
+| `ec2-default-security-group-permissive` | regionale | Il security group `default` di una VPC ha ancora regole | `warning` |
+| `s3-bucket-public` | globale | Bucket raggiungibile da internet via ACL e/o bucket policy | `critical` |
+| `ec2-snapshot-public` | regionale | Snapshot EBS con `createVolumePermission` concesso al gruppo `all` | `critical` |
+| `ec2-volume-unencrypted` | regionale | Volume EBS non cifrato a riposo | `warning` |
+| `rds-instance-unencrypted` | regionale | Storage dell'istanza RDS non cifrato a riposo | `warning` |
+| `s3-bucket-encryption-missing` | globale | Bucket senza cifratura lato server di default configurata | `warning` |
+| `rds-instance-publicly-accessible` | regionale | Istanza RDS raggiungibile dall'esterno della sua VPC | `critical` |
+| `cloudtrail-not-multiregion` | globale | Nessun trail CloudTrail configurato con logging multi-regione | `warning` |
+
+> **IAM, S3 (elenco bucket) e CloudTrail sono trattati come globali per questo comando.** Gli otto check `globale` sopra girano **una sola volta per scansione**, mai una volta per regione richiesta — a differenza dei sei check `regionale`. Vedi [ADR-0081](../adr/0081-resource-security-parallel-domain.md).
+
+**Esempi:**
+
+```sh
+# Ogni check, regione di default
+node apps/cli/dist/main.js resource-security
+
+# Più regioni — impatta solo i check regionali, non quelli globali
+node apps/cli/dist/main.js resource-security -r us-east-1 eu-west-1
+
+# Solo i check IAM
+node apps/cli/dist/main.js resource-security --scanners iam-root-mfa-disabled iam-user-mfa-disabled
+
+# Output leggibile da macchina
+node apps/cli/dist/main.js resource-security --format json | jq '.findings[] | select(.severity=="critical")'
+
+# Report PDF, niente stampato a terminale
+node apps/cli/dist/main.js resource-security --pdf ./sicurezza.pdf --silent
+```
+
+**Permessi IAM:** questo comando richiede `iam:GetAccountSummary`, `iam:ListMFADevices`, `iam:GetAccountPasswordPolicy`, `s3:GetBucketAcl`, `s3:GetBucketPolicyStatus`, `s3:GetPublicAccessBlock`, `s3:GetBucketEncryption`, `ec2:DescribeSnapshotAttribute`, `cloudtrail:DescribeTrails` in aggiunta alla policy di `analyze` (altri check riusano action già concesse per `analyze`/`dead-resources`) — vedi [docs/it/permessi-iam.md](permessi-iam.md).

--- a/libs/resource-security/application/eslint.config.mjs
+++ b/libs/resource-security/application/eslint.config.mjs
@@ -1,0 +1,10 @@
+import baseConfig from '../../../eslint.config.mjs';
+
+export default [
+  ...baseConfig,
+  {
+    files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
+    // Override or add rules here
+    rules: {},
+  },
+];

--- a/libs/resource-security/application/jest.config.cjs
+++ b/libs/resource-security/application/jest.config.cjs
@@ -1,0 +1,23 @@
+/** @type {import('@jest/types').Config.InitialOptions} */
+module.exports = {
+  displayName: 'resource-security-application',
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      { tsconfig: '<rootDir>/tsconfig.spec.json', diagnostics: false },
+    ],
+  },
+  moduleFileExtensions: ['ts', 'js', 'json'],
+  testMatch: ['<rootDir>/src/**/*.spec.ts'],
+  moduleNameMapper: {
+    '^shared-kernel$': '<rootDir>/../../shared/kernel/src/index.ts',
+    '^shared-kernel/(.*)$': '<rootDir>/../../shared/kernel/src/$1',
+    '^cloud-cost-domain$': '<rootDir>/../../cloud-cost/domain/src/index.ts',
+    '^cloud-cost-domain/(.*)$': '<rootDir>/../../cloud-cost/domain/src/$1',
+    '^resource-security-domain$': '<rootDir>/../domain/src/index.ts',
+    '^resource-security-domain/(.*)$': '<rootDir>/../domain/src/$1',
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
+};

--- a/libs/resource-security/application/package.json
+++ b/libs/resource-security/application/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "resource-security-application",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "@cloudrift/source": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "nx": {
+    "tags": [
+      "scope:application"
+    ],
+    "targets": {
+      "test": {
+        "executor": "@nx/jest:jest",
+        "outputs": [
+          "{workspaceRoot}/coverage/{projectRoot}"
+        ],
+        "options": {
+          "jestConfig": "libs/resource-security/application/jest.config.cjs",
+          "passWithNoTests": true
+        }
+      }
+    }
+  },
+  "dependencies": {
+    "resource-security-domain": "workspace:*",
+    "shared-kernel": "workspace:*",
+    "tslib": "^2.8.1"
+  }
+}

--- a/libs/resource-security/application/src/constants/report-disclaimer.ts
+++ b/libs/resource-security/application/src/constants/report-disclaimer.ts
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0
+// Deliberately separate text from `dead-resources-application`'s
+// `DEAD_RESOURCES_REPORT_DISCLAIMER`: this domain reports security-posture
+// risk findings, not hygiene/cost findings.
+export const RESOURCE_SECURITY_REPORT_DISCLAIMER =
+  'cloudrift is a read-only analysis tool: it reports security-posture findings and recommendations ' +
+  'only — it never deletes, modifies, or stops any AWS resource, and does not perform any exploitation ' +
+  'or active testing. All findings should be validated by your infrastructure/security team before ' +
+  'taking action. The maintainers assume no liability for actions taken based on this report.';

--- a/libs/resource-security/application/src/index.ts
+++ b/libs/resource-security/application/src/index.ts
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: Apache-2.0
+export { FindResourceSecurityFindingsUseCase } from './use-cases/find-resource-security-findings.use-case';
+export { RESOURCE_SECURITY_REPORT_DISCLAIMER } from './constants/report-disclaimer';

--- a/libs/resource-security/application/src/use-cases/find-resource-security-findings.use-case.spec.ts
+++ b/libs/resource-security/application/src/use-cases/find-resource-security-findings.use-case.spec.ts
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: Apache-2.0
+import { FindResourceSecurityFindingsUseCase } from './find-resource-security-findings.use-case';
+import { AwsRegion, Ec2VolumeUnencrypted } from 'resource-security-domain';
+import type { ResourceSecurityKind, SecurityFinding, ResourceSecurityScannerPort } from 'resource-security-domain';
+import { Result } from 'shared-kernel';
+
+const usEast = AwsRegion.create('us-east-1');
+const euWest = AwsRegion.create('eu-west-1');
+
+function makeVolume(id: string): Ec2VolumeUnencrypted {
+  return new Ec2VolumeUnencrypted({
+    volumeId: id,
+    region: usEast,
+    accountId: '123456789012',
+    detectedAt: new Date('2026-07-23'),
+    tags: {},
+  });
+}
+
+/** Fake scanner: one response per region, in call order. */
+function makeScanner(kind: ResourceSecurityKind, responses: Array<Result<SecurityFinding[]>>): ResourceSecurityScannerPort {
+  let call = 0;
+  return {
+    kind,
+    scan: async () => responses[Math.min(call++, responses.length - 1)],
+  };
+}
+
+describe('FindResourceSecurityFindingsUseCase', () => {
+  it('returns an empty summary when all scanners find nothing', async () => {
+    const useCase = new FindResourceSecurityFindingsUseCase([makeScanner('ec2-volume-unencrypted', [Result.ok([])])]);
+
+    const result = await useCase.execute({ regions: [usEast] });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.findings).toHaveLength(0);
+    expect(result.value.countBySeverity).toEqual({ info: 0, warning: 0, critical: 0 });
+    expect(result.value.scanErrors).toHaveLength(0);
+  });
+
+  it('aggregates findings from all scanners and counts by severity', async () => {
+    const useCase = new FindResourceSecurityFindingsUseCase([
+      makeScanner('ec2-volume-unencrypted', [Result.ok([makeVolume('vol-1'), makeVolume('vol-2')])]),
+    ]);
+
+    const result = await useCase.execute({ regions: [usEast] });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.findings).toHaveLength(2);
+    expect(result.value.countBySeverity).toEqual({ info: 0, warning: 2, critical: 0 });
+  });
+
+  it('records a scanError with kind and region when a scanner fails, preserving other results', async () => {
+    const err = new Error('EC2 failed');
+    const useCase = new FindResourceSecurityFindingsUseCase([makeScanner('ec2-volume-unencrypted', [Result.fail(err)])]);
+
+    const result = await useCase.execute({ regions: [usEast] });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.findings).toHaveLength(0);
+    expect(result.value.scanErrors).toEqual([{ kind: 'ec2-volume-unencrypted', region: 'us-east-1', error: err }]);
+  });
+
+  it('calls a global-scope scanner exactly once, regardless of how many regions were requested', async () => {
+    const calls: string[] = [];
+    const globalScanner: ResourceSecurityScannerPort = {
+      kind: 'iam-root-mfa-disabled',
+      scope: 'global',
+      scan: async (region) => {
+        calls.push(region.code);
+        return Result.ok([]);
+      },
+    };
+
+    const useCase = new FindResourceSecurityFindingsUseCase([globalScanner]);
+    await useCase.execute({ regions: [usEast, euWest] });
+
+    expect(calls).toHaveLength(1);
+  });
+
+  it('still calls a regional scanner once per region alongside a global one', async () => {
+    const regionalCalls: string[] = [];
+    let globalCalls = 0;
+    const scanners: ResourceSecurityScannerPort[] = [
+      {
+        kind: 'ec2-volume-unencrypted',
+        scan: async (region) => {
+          regionalCalls.push(region.code);
+          return Result.ok([]);
+        },
+      },
+      {
+        kind: 'iam-root-mfa-disabled',
+        scope: 'global',
+        scan: async () => {
+          globalCalls++;
+          return Result.ok([]);
+        },
+      },
+    ];
+
+    const useCase = new FindResourceSecurityFindingsUseCase(scanners);
+    await useCase.execute({ regions: [usEast, euWest] });
+
+    expect(regionalCalls.sort()).toEqual(['eu-west-1', 'us-east-1']);
+    expect(globalCalls).toBe(1);
+  });
+
+  it('labels a global scanner scanError as "global", not a real region', async () => {
+    const err = new Error('AccessDenied');
+    const globalScanner: ResourceSecurityScannerPort = {
+      kind: 'iam-root-mfa-disabled',
+      scope: 'global',
+      scan: async () => Result.fail(err),
+    };
+
+    const useCase = new FindResourceSecurityFindingsUseCase([globalScanner]);
+    const result = await useCase.execute({ regions: [usEast, euWest] });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.scanErrors).toEqual([{ kind: 'iam-root-mfa-disabled', region: 'global', error: err }]);
+  });
+
+  it('bounds in-flight scans to the configured concurrency, across any scanner×region mix', async () => {
+    let inFlight = 0;
+    let peak = 0;
+    const slowScanner = (kind: ResourceSecurityKind): ResourceSecurityScannerPort => ({
+      kind,
+      scan: async () => {
+        inFlight++;
+        peak = Math.max(peak, inFlight);
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        inFlight--;
+        return Result.ok([]);
+      },
+    });
+
+    const useCase = new FindResourceSecurityFindingsUseCase([slowScanner('ec2-volume-unencrypted')], 1);
+    await useCase.execute({ regions: [usEast, euWest] });
+
+    expect(peak).toBe(1);
+  });
+});

--- a/libs/resource-security/application/src/use-cases/find-resource-security-findings.use-case.ts
+++ b/libs/resource-security/application/src/use-cases/find-resource-security-findings.use-case.ts
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+import { Result, createLogger } from 'shared-kernel';
+import type {
+  FindResourceSecurityFindingsRequest,
+  FindResourceSecurityFindingsUseCasePort,
+  ResourceSecuritySummary,
+  SecurityFinding,
+  ResourceSecurityScannerPort,
+  ResourceSecurityScanError,
+  ResourceSecuritySeverity,
+} from 'resource-security-domain';
+
+const logger = createLogger('cloudrift:scanner');
+
+/** Same bound as `FindDeadResourcesUseCase`/`AnalyzeCloudWasteUseCase` — see ADR-0064/ADR-0063. */
+const DEFAULT_SCAN_CONCURRENCY = 12;
+
+/**
+ * Generic coordinator: every (scanner, region) pair becomes one job in a
+ * FIFO queue consumed by a small worker pool with a single global bound.
+ * Deliberately mirrors `FindDeadResourcesUseCase`'s shape rather than being
+ * shared with it — the two coordinators operate on disjoint finding types.
+ */
+export class FindResourceSecurityFindingsUseCase implements FindResourceSecurityFindingsUseCasePort {
+  constructor(
+    private readonly scanners: readonly ResourceSecurityScannerPort[],
+    private readonly scanConcurrency = DEFAULT_SCAN_CONCURRENCY,
+  ) {}
+
+  async execute(request: FindResourceSecurityFindingsRequest): Promise<Result<ResourceSecuritySummary>> {
+    const findings: SecurityFinding[] = [];
+    const scanErrors: ResourceSecurityScanError[] = [];
+
+    // Global-scope scanners (IAM, S3 bucket listing, CloudTrail) get exactly
+    // one job, not one per region — the region passed to that one job is
+    // arbitrary (the first requested) and the scanner implementation must
+    // ignore it. Callers always pass at least one region (CLI default,
+    // wizard requires a selection).
+    const jobs = this.scanners.flatMap((scanner) =>
+      scanner.scope === 'global' ? [{ scanner, region: request.regions[0] }] : request.regions.map((region) => ({ scanner, region })),
+    );
+
+    let nextJob = 0;
+    const worker = async (): Promise<void> => {
+      while (nextJob < jobs.length) {
+        const { scanner, region } = jobs[nextJob++];
+        const regionLabel = scanner.scope === 'global' ? 'global' : region.code;
+        const startedAt = Date.now();
+        const result = await scanner.scan(region);
+        const durationMs = Date.now() - startedAt;
+        if (result.ok) {
+          logger.debug(`${scanner.kind} scan ok`, { region: regionLabel, durationMs, findings: result.value.length });
+          findings.push(...result.value);
+        } else {
+          logger.debug(`${scanner.kind} scan failed`, { region: regionLabel, durationMs, error: result.error.message });
+          scanErrors.push({ kind: scanner.kind, region: regionLabel, error: result.error });
+        }
+      }
+    };
+
+    const workerCount = Math.max(1, Math.min(this.scanConcurrency, jobs.length));
+    await Promise.all(Array.from({ length: workerCount }, () => worker()));
+
+    const countBySeverity: Record<ResourceSecuritySeverity, number> = { info: 0, warning: 0, critical: 0 };
+    for (const finding of findings) {
+      countBySeverity[finding.severity]++;
+    }
+
+    return Result.ok({ findings, countBySeverity, scanErrors });
+  }
+}

--- a/libs/resource-security/application/tsconfig.json
+++ b/libs/resource-security/application/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/libs/resource-security/application/tsconfig.lib.json
+++ b/libs/resource-security/application/tsconfig.lib.json
@@ -1,0 +1,21 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "dist/tsconfig.lib.tsbuildinfo",
+    "emitDeclarationOnly": false,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"],
+  "references": [
+    {
+      "path": "../domain/tsconfig.lib.json"
+    },
+    {
+      "path": "../../shared/kernel/tsconfig.lib.json"
+    }
+  ]
+}

--- a/libs/resource-security/application/tsconfig.spec.json
+++ b/libs/resource-security/application/tsconfig.spec.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "outDir": "./dist/test",
+    "types": ["jest", "node"],
+    "strict": true,
+    "esModuleInterop": true
+  },
+  "include": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/libs/resource-security/domain/eslint.config.mjs
+++ b/libs/resource-security/domain/eslint.config.mjs
@@ -1,0 +1,10 @@
+import baseConfig from '../../../eslint.config.mjs';
+
+export default [
+  ...baseConfig,
+  {
+    files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
+    // Override or add rules here
+    rules: {},
+  },
+];

--- a/libs/resource-security/domain/jest.config.cjs
+++ b/libs/resource-security/domain/jest.config.cjs
@@ -1,0 +1,21 @@
+/** @type {import('@jest/types').Config.InitialOptions} */
+module.exports = {
+  displayName: 'resource-security-domain',
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      { tsconfig: '<rootDir>/tsconfig.spec.json', diagnostics: false },
+    ],
+  },
+  moduleFileExtensions: ['ts', 'js', 'json'],
+  testMatch: ['<rootDir>/src/**/*.spec.ts'],
+  moduleNameMapper: {
+    '^shared-kernel$': '<rootDir>/../../shared/kernel/src/index.ts',
+    '^shared-kernel/(.*)$': '<rootDir>/../../shared/kernel/src/$1',
+    '^cloud-cost-domain$': '<rootDir>/../../cloud-cost/domain/src/index.ts',
+    '^cloud-cost-domain/(.*)$': '<rootDir>/../../cloud-cost/domain/src/$1',
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
+};

--- a/libs/resource-security/domain/package.json
+++ b/libs/resource-security/domain/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "resource-security-domain",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "@cloudrift/source": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "nx": {
+    "tags": [
+      "scope:domain"
+    ],
+    "targets": {
+      "test": {
+        "executor": "@nx/jest:jest",
+        "outputs": [
+          "{workspaceRoot}/coverage/{projectRoot}"
+        ],
+        "options": {
+          "jestConfig": "libs/resource-security/domain/jest.config.cjs",
+          "passWithNoTests": true
+        }
+      }
+    }
+  },
+  "dependencies": {
+    "cloud-cost-domain": "workspace:*",
+    "shared-kernel": "workspace:*",
+    "tslib": "^2.8.1"
+  }
+}

--- a/libs/resource-security/domain/src/entities/cloudtrail-not-multiregion.entity.spec.ts
+++ b/libs/resource-security/domain/src/entities/cloudtrail-not-multiregion.entity.spec.ts
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+import { CloudtrailNotMultiregion } from './cloudtrail-not-multiregion.entity';
+import type { CloudtrailNotMultiregionProps } from './cloudtrail-not-multiregion.entity';
+
+function makeFinding(overrides: Partial<CloudtrailNotMultiregionProps> = {}): CloudtrailNotMultiregion {
+  return new CloudtrailNotMultiregion({
+    accountId: '123456789012',
+    hasMultiRegionTrail: false,
+    detectedAt: new Date('2026-07-23'),
+    tags: {},
+    ...overrides,
+  });
+}
+
+describe('CloudtrailNotMultiregion', () => {
+  it('exposes id, kind and severity', () => {
+    const finding = makeFinding();
+    expect(finding.id).toBe('123456789012');
+    expect(finding.kind).toBe('cloudtrail-not-multiregion');
+    expect(finding.severity).toBe('warning');
+  });
+});

--- a/libs/resource-security/domain/src/entities/cloudtrail-not-multiregion.entity.ts
+++ b/libs/resource-security/domain/src/entities/cloudtrail-not-multiregion.entity.ts
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+import { Entity } from 'shared-kernel';
+import type { SecurityFinding, ResourceSecuritySeverity } from '../resource-security';
+
+export interface CloudtrailNotMultiregionProps {
+  accountId: string;
+  hasMultiRegionTrail: boolean;
+  detectedAt: Date;
+  tags: Record<string, string>;
+}
+
+/**
+ * Account-wide finding: no CloudTrail trail is configured with
+ * `IsMultiRegionTrail: true`. CIS AWS Foundations 3.1 — without one,
+ * activity in regions with no dedicated trail goes unlogged.
+ */
+export class CloudtrailNotMultiregion extends Entity<string> implements SecurityFinding {
+  private readonly props: Readonly<CloudtrailNotMultiregionProps>;
+
+  constructor(props: CloudtrailNotMultiregionProps) {
+    super(props.accountId);
+    this.props = this.deepFreeze({ ...props });
+  }
+
+  get accountId(): string {
+    return this.props.accountId;
+  }
+
+  get hasMultiRegionTrail(): boolean {
+    return this.props.hasMultiRegionTrail;
+  }
+
+  get detectedAt(): Date {
+    return this.props.detectedAt;
+  }
+
+  get tags(): Record<string, string> {
+    return this.props.tags;
+  }
+
+  get kind(): 'cloudtrail-not-multiregion' {
+    return 'cloudtrail-not-multiregion';
+  }
+
+  get riskReason(): string {
+    return 'no CloudTrail trail is configured for multi-region logging';
+  }
+
+  get severity(): ResourceSecuritySeverity {
+    return 'warning';
+  }
+}

--- a/libs/resource-security/domain/src/entities/ec2-default-security-group-permissive.entity.spec.ts
+++ b/libs/resource-security/domain/src/entities/ec2-default-security-group-permissive.entity.spec.ts
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+import { AwsRegion } from 'cloud-cost-domain';
+import { Ec2DefaultSecurityGroupPermissive } from './ec2-default-security-group-permissive.entity';
+import type { Ec2DefaultSecurityGroupPermissiveProps } from './ec2-default-security-group-permissive.entity';
+
+function makeFinding(overrides: Partial<Ec2DefaultSecurityGroupPermissiveProps> = {}): Ec2DefaultSecurityGroupPermissive {
+  return new Ec2DefaultSecurityGroupPermissive({
+    groupId: 'sg-default-1',
+    vpcId: 'vpc-1',
+    region: AwsRegion.create('us-east-1'),
+    accountId: '123456789012',
+    hasIngressRules: true,
+    hasEgressRules: true,
+    detectedAt: new Date('2026-07-23'),
+    tags: {},
+    ...overrides,
+  });
+}
+
+describe('Ec2DefaultSecurityGroupPermissive', () => {
+  it('exposes id, kind and severity', () => {
+    const finding = makeFinding();
+    expect(finding.id).toBe('sg-default-1');
+    expect(finding.kind).toBe('ec2-default-security-group-permissive');
+    expect(finding.severity).toBe('warning');
+  });
+
+  it('riskReason reports which rule types are present', () => {
+    expect(makeFinding({ hasIngressRules: true, hasEgressRules: false }).riskReason).toContain('ingress rules present');
+  });
+});

--- a/libs/resource-security/domain/src/entities/ec2-default-security-group-permissive.entity.ts
+++ b/libs/resource-security/domain/src/entities/ec2-default-security-group-permissive.entity.ts
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+import { Entity } from 'shared-kernel';
+import type { AwsRegion } from 'cloud-cost-domain';
+import type { SecurityFinding, ResourceSecuritySeverity } from '../resource-security';
+
+export interface Ec2DefaultSecurityGroupPermissiveProps {
+  groupId: string;
+  vpcId: string;
+  region: AwsRegion;
+  accountId: string;
+  hasIngressRules: boolean;
+  hasEgressRules: boolean;
+  detectedAt: Date;
+  tags: Record<string, string>;
+}
+
+/**
+ * A VPC's auto-created `default` security group still carries ingress
+ * and/or egress rules. CIS AWS Foundations 5.3 recommends the default
+ * security group of every VPC restrict all traffic — it can't be deleted,
+ * only emptied, and is silently attached to any resource launched without
+ * an explicit security group.
+ */
+export class Ec2DefaultSecurityGroupPermissive extends Entity<string> implements SecurityFinding {
+  private readonly props: Readonly<Ec2DefaultSecurityGroupPermissiveProps>;
+
+  constructor(props: Ec2DefaultSecurityGroupPermissiveProps) {
+    super(props.groupId);
+    this.props = this.deepFreeze({ ...props });
+  }
+
+  get vpcId(): string {
+    return this.props.vpcId;
+  }
+
+  get region(): AwsRegion {
+    return this.props.region;
+  }
+
+  get accountId(): string {
+    return this.props.accountId;
+  }
+
+  get hasIngressRules(): boolean {
+    return this.props.hasIngressRules;
+  }
+
+  get hasEgressRules(): boolean {
+    return this.props.hasEgressRules;
+  }
+
+  get detectedAt(): Date {
+    return this.props.detectedAt;
+  }
+
+  get tags(): Record<string, string> {
+    return this.props.tags;
+  }
+
+  get kind(): 'ec2-default-security-group-permissive' {
+    return 'ec2-default-security-group-permissive';
+  }
+
+  get riskReason(): string {
+    const parts: string[] = [];
+    if (this.hasIngressRules) parts.push('ingress rules present');
+    if (this.hasEgressRules) parts.push('egress rules present');
+    return `default security group should restrict all traffic (${parts.join(', ')})`;
+  }
+
+  get severity(): ResourceSecuritySeverity {
+    return 'warning';
+  }
+}

--- a/libs/resource-security/domain/src/entities/ec2-security-group-open-ingress.entity.spec.ts
+++ b/libs/resource-security/domain/src/entities/ec2-security-group-open-ingress.entity.spec.ts
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+import { AwsRegion } from 'cloud-cost-domain';
+import { Ec2SecurityGroupOpenIngress } from './ec2-security-group-open-ingress.entity';
+import type { Ec2SecurityGroupOpenIngressProps } from './ec2-security-group-open-ingress.entity';
+
+function makeFinding(overrides: Partial<Ec2SecurityGroupOpenIngressProps> = {}): Ec2SecurityGroupOpenIngress {
+  return new Ec2SecurityGroupOpenIngress({
+    groupId: 'sg-1',
+    groupName: 'web',
+    region: AwsRegion.create('us-east-1'),
+    accountId: '123456789012',
+    matchedRules: ['22/tcp from 0.0.0.0/0'],
+    detectedAt: new Date('2026-07-23'),
+    tags: {},
+    ...overrides,
+  });
+}
+
+describe('Ec2SecurityGroupOpenIngress', () => {
+  it('exposes id, kind and severity', () => {
+    const finding = makeFinding();
+    expect(finding.id).toBe('sg-1');
+    expect(finding.kind).toBe('ec2-security-group-open-ingress');
+    expect(finding.severity).toBe('critical');
+  });
+
+  it('riskReason lists the matched rules', () => {
+    expect(makeFinding().riskReason).toContain('22/tcp from 0.0.0.0/0');
+  });
+});

--- a/libs/resource-security/domain/src/entities/ec2-security-group-open-ingress.entity.ts
+++ b/libs/resource-security/domain/src/entities/ec2-security-group-open-ingress.entity.ts
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+import { Entity } from 'shared-kernel';
+import type { AwsRegion } from 'cloud-cost-domain';
+import type { SecurityFinding, ResourceSecuritySeverity } from '../resource-security';
+
+export interface Ec2SecurityGroupOpenIngressProps {
+  groupId: string;
+  groupName: string;
+  region: AwsRegion;
+  accountId: string;
+  /** e.g. ["22/tcp from 0.0.0.0/0", "3389/tcp from ::/0"] — one per matched sensitive-port rule. */
+  matchedRules: string[];
+  detectedAt: Date;
+  tags: Record<string, string>;
+}
+
+/** EC2 security group with an ingress rule open to the internet (0.0.0.0/0 or ::/0) on a commonly-attacked port (SSH, RDP, database ports). */
+export class Ec2SecurityGroupOpenIngress extends Entity<string> implements SecurityFinding {
+  private readonly props: Readonly<Ec2SecurityGroupOpenIngressProps>;
+
+  constructor(props: Ec2SecurityGroupOpenIngressProps) {
+    super(props.groupId);
+    this.props = this.deepFreeze({ ...props });
+  }
+
+  get groupName(): string {
+    return this.props.groupName;
+  }
+
+  get region(): AwsRegion {
+    return this.props.region;
+  }
+
+  get accountId(): string {
+    return this.props.accountId;
+  }
+
+  get matchedRules(): string[] {
+    return this.props.matchedRules;
+  }
+
+  get detectedAt(): Date {
+    return this.props.detectedAt;
+  }
+
+  get tags(): Record<string, string> {
+    return this.props.tags;
+  }
+
+  get kind(): 'ec2-security-group-open-ingress' {
+    return 'ec2-security-group-open-ingress';
+  }
+
+  get riskReason(): string {
+    return `open ingress on sensitive port(s): ${this.matchedRules.join(', ')}`;
+  }
+
+  get severity(): ResourceSecuritySeverity {
+    return 'critical';
+  }
+}

--- a/libs/resource-security/domain/src/entities/ec2-snapshot-public.entity.spec.ts
+++ b/libs/resource-security/domain/src/entities/ec2-snapshot-public.entity.spec.ts
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+import { AwsRegion } from 'cloud-cost-domain';
+import { Ec2SnapshotPublic } from './ec2-snapshot-public.entity';
+import type { Ec2SnapshotPublicProps } from './ec2-snapshot-public.entity';
+
+function makeFinding(overrides: Partial<Ec2SnapshotPublicProps> = {}): Ec2SnapshotPublic {
+  return new Ec2SnapshotPublic({
+    snapshotId: 'snap-1',
+    volumeId: 'vol-1',
+    region: AwsRegion.create('us-east-1'),
+    accountId: '123456789012',
+    detectedAt: new Date('2026-07-23'),
+    tags: {},
+    ...overrides,
+  });
+}
+
+describe('Ec2SnapshotPublic', () => {
+  it('exposes id, kind and severity', () => {
+    const finding = makeFinding();
+    expect(finding.id).toBe('snap-1');
+    expect(finding.kind).toBe('ec2-snapshot-public');
+    expect(finding.severity).toBe('critical');
+  });
+
+  it('riskReason mentions the public restore permission', () => {
+    expect(makeFinding().riskReason).toContain('createVolumePermission: all');
+  });
+});

--- a/libs/resource-security/domain/src/entities/ec2-snapshot-public.entity.ts
+++ b/libs/resource-security/domain/src/entities/ec2-snapshot-public.entity.ts
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+import { Entity } from 'shared-kernel';
+import type { AwsRegion } from 'cloud-cost-domain';
+import type { SecurityFinding, ResourceSecuritySeverity } from '../resource-security';
+
+export interface Ec2SnapshotPublicProps {
+  snapshotId: string;
+  volumeId: string;
+  region: AwsRegion;
+  accountId: string;
+  detectedAt: Date;
+  tags: Record<string, string>;
+}
+
+/** EBS snapshot with `createVolumePermission` granted to the `all` group — anyone can create a volume from it, exposing its data. */
+export class Ec2SnapshotPublic extends Entity<string> implements SecurityFinding {
+  private readonly props: Readonly<Ec2SnapshotPublicProps>;
+
+  constructor(props: Ec2SnapshotPublicProps) {
+    super(props.snapshotId);
+    this.props = this.deepFreeze({ ...props });
+  }
+
+  get volumeId(): string {
+    return this.props.volumeId;
+  }
+
+  get region(): AwsRegion {
+    return this.props.region;
+  }
+
+  get accountId(): string {
+    return this.props.accountId;
+  }
+
+  get detectedAt(): Date {
+    return this.props.detectedAt;
+  }
+
+  get tags(): Record<string, string> {
+    return this.props.tags;
+  }
+
+  get kind(): 'ec2-snapshot-public' {
+    return 'ec2-snapshot-public';
+  }
+
+  get riskReason(): string {
+    return 'snapshot has public restore permissions (createVolumePermission: all)';
+  }
+
+  get severity(): ResourceSecuritySeverity {
+    return 'critical';
+  }
+}

--- a/libs/resource-security/domain/src/entities/ec2-volume-unencrypted.entity.spec.ts
+++ b/libs/resource-security/domain/src/entities/ec2-volume-unencrypted.entity.spec.ts
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+import { AwsRegion } from 'cloud-cost-domain';
+import { Ec2VolumeUnencrypted } from './ec2-volume-unencrypted.entity';
+import type { Ec2VolumeUnencryptedProps } from './ec2-volume-unencrypted.entity';
+
+function makeFinding(overrides: Partial<Ec2VolumeUnencryptedProps> = {}): Ec2VolumeUnencrypted {
+  return new Ec2VolumeUnencrypted({
+    volumeId: 'vol-1',
+    region: AwsRegion.create('us-east-1'),
+    accountId: '123456789012',
+    detectedAt: new Date('2026-07-23'),
+    tags: {},
+    ...overrides,
+  });
+}
+
+describe('Ec2VolumeUnencrypted', () => {
+  it('exposes id, kind and severity', () => {
+    const finding = makeFinding();
+    expect(finding.id).toBe('vol-1');
+    expect(finding.kind).toBe('ec2-volume-unencrypted');
+    expect(finding.severity).toBe('warning');
+  });
+});

--- a/libs/resource-security/domain/src/entities/ec2-volume-unencrypted.entity.ts
+++ b/libs/resource-security/domain/src/entities/ec2-volume-unencrypted.entity.ts
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+import { Entity } from 'shared-kernel';
+import type { AwsRegion } from 'cloud-cost-domain';
+import type { SecurityFinding, ResourceSecuritySeverity } from '../resource-security';
+
+export interface Ec2VolumeUnencryptedProps {
+  volumeId: string;
+  region: AwsRegion;
+  accountId: string;
+  detectedAt: Date;
+  tags: Record<string, string>;
+}
+
+/** EBS volume not encrypted at rest (`DescribeVolumes`'s `Encrypted: false`). */
+export class Ec2VolumeUnencrypted extends Entity<string> implements SecurityFinding {
+  private readonly props: Readonly<Ec2VolumeUnencryptedProps>;
+
+  constructor(props: Ec2VolumeUnencryptedProps) {
+    super(props.volumeId);
+    this.props = this.deepFreeze({ ...props });
+  }
+
+  get region(): AwsRegion {
+    return this.props.region;
+  }
+
+  get accountId(): string {
+    return this.props.accountId;
+  }
+
+  get detectedAt(): Date {
+    return this.props.detectedAt;
+  }
+
+  get tags(): Record<string, string> {
+    return this.props.tags;
+  }
+
+  get kind(): 'ec2-volume-unencrypted' {
+    return 'ec2-volume-unencrypted';
+  }
+
+  get riskReason(): string {
+    return 'EBS volume is not encrypted at rest';
+  }
+
+  get severity(): ResourceSecuritySeverity {
+    return 'warning';
+  }
+}

--- a/libs/resource-security/domain/src/entities/iam-access-key-rotation-overdue.entity.spec.ts
+++ b/libs/resource-security/domain/src/entities/iam-access-key-rotation-overdue.entity.spec.ts
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+import { IamAccessKeyRotationOverdue } from './iam-access-key-rotation-overdue.entity';
+import type { IamAccessKeyRotationOverdueProps } from './iam-access-key-rotation-overdue.entity';
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+function makeFinding(overrides: Partial<IamAccessKeyRotationOverdueProps> = {}): IamAccessKeyRotationOverdue {
+  return new IamAccessKeyRotationOverdue({
+    accessKeyId: 'AKIA1',
+    userName: 'alice',
+    accountId: '123456789012',
+    createdAt: new Date(Date.now() - 200 * MS_PER_DAY),
+    detectedAt: new Date(),
+    tags: {},
+    ...overrides,
+  });
+}
+
+describe('IamAccessKeyRotationOverdue', () => {
+  it('exposes id, kind and severity', () => {
+    const finding = makeFinding();
+    expect(finding.id).toBe('AKIA1');
+    expect(finding.kind).toBe('iam-access-key-rotation-overdue');
+    expect(finding.severity).toBe('warning');
+  });
+
+  it('riskReason reports the key age', () => {
+    expect(makeFinding().riskReason).toContain('200d');
+  });
+});

--- a/libs/resource-security/domain/src/entities/iam-access-key-rotation-overdue.entity.ts
+++ b/libs/resource-security/domain/src/entities/iam-access-key-rotation-overdue.entity.ts
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+import { Entity } from 'shared-kernel';
+import type { SecurityFinding, ResourceSecuritySeverity } from '../resource-security';
+
+export interface IamAccessKeyRotationOverdueProps {
+  accessKeyId: string;
+  userName: string;
+  accountId: string;
+  createdAt: Date;
+  detectedAt: Date;
+  tags: Record<string, string>;
+}
+
+/**
+ * Active IAM access key older than the policy's rotation window. Distinct
+ * from `dead-resources-domain`'s `iam-access-key-stale` (an age-based
+ * hygiene heuristic): this is framed as a security-policy violation (CIS AWS
+ * Foundations 1.14: rotate access keys every 90 days), same underlying
+ * `iam:ListAccessKeys` data, different lens.
+ */
+export class IamAccessKeyRotationOverdue extends Entity<string> implements SecurityFinding {
+  private readonly props: Readonly<IamAccessKeyRotationOverdueProps>;
+
+  constructor(props: IamAccessKeyRotationOverdueProps) {
+    super(props.accessKeyId);
+    this.props = this.deepFreeze({ ...props });
+  }
+
+  get accessKeyId(): string {
+    return this.props.accessKeyId;
+  }
+
+  get userName(): string {
+    return this.props.userName;
+  }
+
+  get accountId(): string {
+    return this.props.accountId;
+  }
+
+  get createdAt(): Date {
+    return this.props.createdAt;
+  }
+
+  get detectedAt(): Date {
+    return this.props.detectedAt;
+  }
+
+  get tags(): Record<string, string> {
+    return this.props.tags;
+  }
+
+  get kind(): 'iam-access-key-rotation-overdue' {
+    return 'iam-access-key-rotation-overdue';
+  }
+
+  get riskReason(): string {
+    const ageDays = Math.floor((this.detectedAt.getTime() - this.createdAt.getTime()) / (24 * 60 * 60 * 1000));
+    return `active for ${ageDays}d, exceeds the rotation policy`;
+  }
+
+  get severity(): ResourceSecuritySeverity {
+    return 'warning';
+  }
+}

--- a/libs/resource-security/domain/src/entities/iam-password-policy-weak.entity.spec.ts
+++ b/libs/resource-security/domain/src/entities/iam-password-policy-weak.entity.spec.ts
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+import { IamPasswordPolicyWeak } from './iam-password-policy-weak.entity';
+import type { IamPasswordPolicyWeakProps } from './iam-password-policy-weak.entity';
+
+function makeFinding(overrides: Partial<IamPasswordPolicyWeakProps> = {}): IamPasswordPolicyWeak {
+  return new IamPasswordPolicyWeak({
+    accountId: '123456789012',
+    exists: false,
+    detectedAt: new Date('2026-07-23'),
+    tags: {},
+    ...overrides,
+  });
+}
+
+describe('IamPasswordPolicyWeak', () => {
+  it('is weak when no policy exists', () => {
+    const finding = makeFinding({ exists: false });
+    expect(finding.isWeak).toBe(true);
+    expect(finding.riskReason).toContain('no account password policy');
+  });
+
+  it('is weak when the baseline is not met', () => {
+    const finding = makeFinding({
+      exists: true,
+      minimumPasswordLength: 8,
+      requireSymbols: false,
+      requireNumbers: true,
+      requireUppercaseCharacters: true,
+      requireLowercaseCharacters: true,
+      maxPasswordAge: 90,
+      passwordReusePrevention: 24,
+    });
+    expect(finding.isWeak).toBe(true);
+    expect(finding.riskReason).toContain('minimum length below 14');
+    expect(finding.riskReason).toContain('symbols not required');
+  });
+
+  it('is not weak when the CIS baseline is met', () => {
+    const finding = makeFinding({
+      exists: true,
+      minimumPasswordLength: 14,
+      requireSymbols: true,
+      requireNumbers: true,
+      requireUppercaseCharacters: true,
+      requireLowercaseCharacters: true,
+      maxPasswordAge: 90,
+      passwordReusePrevention: 24,
+    });
+    expect(finding.isWeak).toBe(false);
+  });
+
+  it('exposes kind and severity', () => {
+    expect(makeFinding().kind).toBe('iam-password-policy-weak');
+    expect(makeFinding().severity).toBe('warning');
+  });
+});

--- a/libs/resource-security/domain/src/entities/iam-password-policy-weak.entity.ts
+++ b/libs/resource-security/domain/src/entities/iam-password-policy-weak.entity.ts
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: Apache-2.0
+import { Entity } from 'shared-kernel';
+import type { SecurityFinding, ResourceSecuritySeverity } from '../resource-security';
+
+export interface IamPasswordPolicyWeakProps {
+  accountId: string;
+  /** False when `iam:GetAccountPasswordPolicy` returns `NoSuchEntityException` — no policy configured at all. */
+  exists: boolean;
+  minimumPasswordLength?: number;
+  requireSymbols?: boolean;
+  requireNumbers?: boolean;
+  requireUppercaseCharacters?: boolean;
+  requireLowercaseCharacters?: boolean;
+  /** 0/undefined means "no maximum" — passwords never expire. */
+  maxPasswordAge?: number;
+  passwordReusePrevention?: number;
+  detectedAt: Date;
+  tags: Record<string, string>;
+}
+
+const MIN_LENGTH_BASELINE = 14;
+const MAX_AGE_BASELINE_DAYS = 90;
+const REUSE_PREVENTION_BASELINE = 24;
+
+/**
+ * Account-wide finding: the account password policy is missing, or falls
+ * short of the CIS AWS Foundations Benchmark baseline (1.8/1.9: minimum
+ * length 14, all four character classes required, max age <= 90 days,
+ * reuse prevention >= 24).
+ */
+export class IamPasswordPolicyWeak extends Entity<string> implements SecurityFinding {
+  private readonly props: Readonly<IamPasswordPolicyWeakProps>;
+
+  constructor(props: IamPasswordPolicyWeakProps) {
+    super(props.accountId);
+    this.props = this.deepFreeze({ ...props });
+  }
+
+  get accountId(): string {
+    return this.props.accountId;
+  }
+
+  get exists(): boolean {
+    return this.props.exists;
+  }
+
+  get detectedAt(): Date {
+    return this.props.detectedAt;
+  }
+
+  get tags(): Record<string, string> {
+    return this.props.tags;
+  }
+
+  get kind(): 'iam-password-policy-weak' {
+    return 'iam-password-policy-weak';
+  }
+
+  private get weaknesses(): string[] {
+    if (!this.props.exists) return [];
+    const reasons: string[] = [];
+    if ((this.props.minimumPasswordLength ?? 0) < MIN_LENGTH_BASELINE) reasons.push(`minimum length below ${MIN_LENGTH_BASELINE}`);
+    if (!this.props.requireSymbols) reasons.push('symbols not required');
+    if (!this.props.requireNumbers) reasons.push('numbers not required');
+    if (!this.props.requireUppercaseCharacters) reasons.push('uppercase characters not required');
+    if (!this.props.requireLowercaseCharacters) reasons.push('lowercase characters not required');
+    if (!this.props.maxPasswordAge || this.props.maxPasswordAge > MAX_AGE_BASELINE_DAYS) {
+      reasons.push(`max password age not set to <= ${MAX_AGE_BASELINE_DAYS} days`);
+    }
+    if ((this.props.passwordReusePrevention ?? 0) < REUSE_PREVENTION_BASELINE) {
+      reasons.push(`password reuse prevention below ${REUSE_PREVENTION_BASELINE}`);
+    }
+    return reasons;
+  }
+
+  get isWeak(): boolean {
+    return !this.props.exists || this.weaknesses.length > 0;
+  }
+
+  get riskReason(): string {
+    if (!this.props.exists) return 'no account password policy configured';
+    return this.weaknesses.length > 0 ? `weak password policy: ${this.weaknesses.join(', ')}` : 'password policy meets CIS baseline';
+  }
+
+  get severity(): ResourceSecuritySeverity {
+    return 'warning';
+  }
+}

--- a/libs/resource-security/domain/src/entities/iam-root-access-key-active.entity.spec.ts
+++ b/libs/resource-security/domain/src/entities/iam-root-access-key-active.entity.spec.ts
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+import { IamRootAccessKeyActive } from './iam-root-access-key-active.entity';
+import type { IamRootAccessKeyActiveProps } from './iam-root-access-key-active.entity';
+
+function makeFinding(overrides: Partial<IamRootAccessKeyActiveProps> = {}): IamRootAccessKeyActive {
+  return new IamRootAccessKeyActive({
+    accountId: '123456789012',
+    accessKeysPresent: true,
+    detectedAt: new Date('2026-07-23'),
+    tags: {},
+    ...overrides,
+  });
+}
+
+describe('IamRootAccessKeyActive', () => {
+  it('exposes id, kind and severity', () => {
+    const finding = makeFinding();
+    expect(finding.id).toBe('123456789012');
+    expect(finding.kind).toBe('iam-root-access-key-active');
+    expect(finding.severity).toBe('critical');
+  });
+
+  it('riskReason mentions the active access key', () => {
+    expect(makeFinding().riskReason).toContain('active access key');
+  });
+});

--- a/libs/resource-security/domain/src/entities/iam-root-access-key-active.entity.ts
+++ b/libs/resource-security/domain/src/entities/iam-root-access-key-active.entity.ts
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+import { Entity } from 'shared-kernel';
+import type { SecurityFinding, ResourceSecuritySeverity } from '../resource-security';
+
+export interface IamRootAccessKeyActiveProps {
+  accountId: string;
+  accessKeysPresent: boolean;
+  detectedAt: Date;
+  tags: Record<string, string>;
+}
+
+/**
+ * Account-wide finding: the root user has at least one active access key.
+ * From `iam:GetAccountSummary`'s `AccountAccessKeysPresent` field — CIS AWS
+ * Foundations 1.4 recommends the root user have no access keys at all.
+ */
+export class IamRootAccessKeyActive extends Entity<string> implements SecurityFinding {
+  private readonly props: Readonly<IamRootAccessKeyActiveProps>;
+
+  constructor(props: IamRootAccessKeyActiveProps) {
+    super(props.accountId);
+    this.props = this.deepFreeze({ ...props });
+  }
+
+  get accountId(): string {
+    return this.props.accountId;
+  }
+
+  get accessKeysPresent(): boolean {
+    return this.props.accessKeysPresent;
+  }
+
+  get detectedAt(): Date {
+    return this.props.detectedAt;
+  }
+
+  get tags(): Record<string, string> {
+    return this.props.tags;
+  }
+
+  get kind(): 'iam-root-access-key-active' {
+    return 'iam-root-access-key-active';
+  }
+
+  get riskReason(): string {
+    return 'root account has at least one active access key';
+  }
+
+  get severity(): ResourceSecuritySeverity {
+    return 'critical';
+  }
+}

--- a/libs/resource-security/domain/src/entities/iam-root-mfa-disabled.entity.spec.ts
+++ b/libs/resource-security/domain/src/entities/iam-root-mfa-disabled.entity.spec.ts
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+import { IamRootMfaDisabled } from './iam-root-mfa-disabled.entity';
+import type { IamRootMfaDisabledProps } from './iam-root-mfa-disabled.entity';
+
+function makeFinding(overrides: Partial<IamRootMfaDisabledProps> = {}): IamRootMfaDisabled {
+  return new IamRootMfaDisabled({
+    accountId: '123456789012',
+    mfaEnabled: false,
+    detectedAt: new Date('2026-07-23'),
+    tags: {},
+    ...overrides,
+  });
+}
+
+describe('IamRootMfaDisabled', () => {
+  it('exposes id, kind and severity', () => {
+    const finding = makeFinding();
+    expect(finding.id).toBe('123456789012');
+    expect(finding.kind).toBe('iam-root-mfa-disabled');
+    expect(finding.severity).toBe('critical');
+  });
+
+  it('riskReason explains the missing MFA device', () => {
+    expect(makeFinding().riskReason).toContain('no MFA device');
+  });
+});

--- a/libs/resource-security/domain/src/entities/iam-root-mfa-disabled.entity.ts
+++ b/libs/resource-security/domain/src/entities/iam-root-mfa-disabled.entity.ts
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+import { Entity } from 'shared-kernel';
+import type { SecurityFinding, ResourceSecuritySeverity } from '../resource-security';
+
+export interface IamRootMfaDisabledProps {
+  accountId: string;
+  mfaEnabled: boolean;
+  detectedAt: Date;
+  tags: Record<string, string>;
+}
+
+/**
+ * Account-wide finding (at most one per account): the root user has no MFA
+ * device enrolled. From `iam:GetAccountSummary`'s `AccountMFAEnabled` field
+ * — no per-resource identity to key on, so `id` is the account id.
+ */
+export class IamRootMfaDisabled extends Entity<string> implements SecurityFinding {
+  private readonly props: Readonly<IamRootMfaDisabledProps>;
+
+  constructor(props: IamRootMfaDisabledProps) {
+    super(props.accountId);
+    this.props = this.deepFreeze({ ...props });
+  }
+
+  get accountId(): string {
+    return this.props.accountId;
+  }
+
+  get mfaEnabled(): boolean {
+    return this.props.mfaEnabled;
+  }
+
+  get detectedAt(): Date {
+    return this.props.detectedAt;
+  }
+
+  get tags(): Record<string, string> {
+    return this.props.tags;
+  }
+
+  get kind(): 'iam-root-mfa-disabled' {
+    return 'iam-root-mfa-disabled';
+  }
+
+  get riskReason(): string {
+    return 'root account has no MFA device enabled';
+  }
+
+  get severity(): ResourceSecuritySeverity {
+    return 'critical';
+  }
+}

--- a/libs/resource-security/domain/src/entities/iam-user-mfa-disabled.entity.spec.ts
+++ b/libs/resource-security/domain/src/entities/iam-user-mfa-disabled.entity.spec.ts
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+import { IamUserMfaDisabled } from './iam-user-mfa-disabled.entity';
+import type { IamUserMfaDisabledProps } from './iam-user-mfa-disabled.entity';
+
+function makeFinding(overrides: Partial<IamUserMfaDisabledProps> = {}): IamUserMfaDisabled {
+  return new IamUserMfaDisabled({
+    userName: 'alice',
+    arn: 'arn:aws:iam::123456789012:user/alice',
+    accountId: '123456789012',
+    createdAt: new Date('2024-01-01'),
+    detectedAt: new Date('2026-07-23'),
+    tags: {},
+    ...overrides,
+  });
+}
+
+describe('IamUserMfaDisabled', () => {
+  it('exposes id, kind and severity', () => {
+    const finding = makeFinding();
+    expect(finding.id).toBe('arn:aws:iam::123456789012:user/alice');
+    expect(finding.kind).toBe('iam-user-mfa-disabled');
+    expect(finding.severity).toBe('warning');
+  });
+
+  it('riskReason mentions the missing MFA device', () => {
+    expect(makeFinding().riskReason).toContain('no MFA device');
+  });
+});

--- a/libs/resource-security/domain/src/entities/iam-user-mfa-disabled.entity.ts
+++ b/libs/resource-security/domain/src/entities/iam-user-mfa-disabled.entity.ts
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+import { Entity } from 'shared-kernel';
+import type { SecurityFinding, ResourceSecuritySeverity } from '../resource-security';
+
+export interface IamUserMfaDisabledProps {
+  userName: string;
+  arn: string;
+  accountId: string;
+  createdAt: Date;
+  detectedAt: Date;
+  tags: Record<string, string>;
+}
+
+/** IAM user with no MFA device registered (`iam:ListMFADevices` returns empty). IAM is a global AWS service — no `region`. */
+export class IamUserMfaDisabled extends Entity<string> implements SecurityFinding {
+  private readonly props: Readonly<IamUserMfaDisabledProps>;
+
+  constructor(props: IamUserMfaDisabledProps) {
+    super(props.arn);
+    this.props = this.deepFreeze({ ...props });
+  }
+
+  get userName(): string {
+    return this.props.userName;
+  }
+
+  get arn(): string {
+    return this.props.arn;
+  }
+
+  get accountId(): string {
+    return this.props.accountId;
+  }
+
+  get createdAt(): Date {
+    return this.props.createdAt;
+  }
+
+  get detectedAt(): Date {
+    return this.props.detectedAt;
+  }
+
+  get tags(): Record<string, string> {
+    return this.props.tags;
+  }
+
+  get kind(): 'iam-user-mfa-disabled' {
+    return 'iam-user-mfa-disabled';
+  }
+
+  get riskReason(): string {
+    return 'no MFA device registered';
+  }
+
+  get severity(): ResourceSecuritySeverity {
+    return 'warning';
+  }
+}

--- a/libs/resource-security/domain/src/entities/rds-instance-publicly-accessible.entity.spec.ts
+++ b/libs/resource-security/domain/src/entities/rds-instance-publicly-accessible.entity.spec.ts
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+import { AwsRegion } from 'cloud-cost-domain';
+import { RdsInstancePubliclyAccessible } from './rds-instance-publicly-accessible.entity';
+import type { RdsInstancePubliclyAccessibleProps } from './rds-instance-publicly-accessible.entity';
+
+function makeFinding(overrides: Partial<RdsInstancePubliclyAccessibleProps> = {}): RdsInstancePubliclyAccessible {
+  return new RdsInstancePubliclyAccessible({
+    dbInstanceIdentifier: 'db-1',
+    region: AwsRegion.create('us-east-1'),
+    accountId: '123456789012',
+    detectedAt: new Date('2026-07-23'),
+    tags: {},
+    ...overrides,
+  });
+}
+
+describe('RdsInstancePubliclyAccessible', () => {
+  it('exposes id, kind and severity', () => {
+    const finding = makeFinding();
+    expect(finding.id).toBe('db-1');
+    expect(finding.kind).toBe('rds-instance-publicly-accessible');
+    expect(finding.severity).toBe('critical');
+  });
+});

--- a/libs/resource-security/domain/src/entities/rds-instance-publicly-accessible.entity.ts
+++ b/libs/resource-security/domain/src/entities/rds-instance-publicly-accessible.entity.ts
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+import { Entity } from 'shared-kernel';
+import type { AwsRegion } from 'cloud-cost-domain';
+import type { SecurityFinding, ResourceSecuritySeverity } from '../resource-security';
+
+export interface RdsInstancePubliclyAccessibleProps {
+  dbInstanceIdentifier: string;
+  region: AwsRegion;
+  accountId: string;
+  detectedAt: Date;
+  tags: Record<string, string>;
+}
+
+/** RDS instance reachable from outside its VPC (`DescribeDBInstances`'s `PubliclyAccessible: true`). */
+export class RdsInstancePubliclyAccessible extends Entity<string> implements SecurityFinding {
+  private readonly props: Readonly<RdsInstancePubliclyAccessibleProps>;
+
+  constructor(props: RdsInstancePubliclyAccessibleProps) {
+    super(props.dbInstanceIdentifier);
+    this.props = this.deepFreeze({ ...props });
+  }
+
+  get dbInstanceIdentifier(): string {
+    return this.props.dbInstanceIdentifier;
+  }
+
+  get region(): AwsRegion {
+    return this.props.region;
+  }
+
+  get accountId(): string {
+    return this.props.accountId;
+  }
+
+  get detectedAt(): Date {
+    return this.props.detectedAt;
+  }
+
+  get tags(): Record<string, string> {
+    return this.props.tags;
+  }
+
+  get kind(): 'rds-instance-publicly-accessible' {
+    return 'rds-instance-publicly-accessible';
+  }
+
+  get riskReason(): string {
+    return 'RDS instance is publicly accessible';
+  }
+
+  get severity(): ResourceSecuritySeverity {
+    return 'critical';
+  }
+}

--- a/libs/resource-security/domain/src/entities/rds-instance-unencrypted.entity.spec.ts
+++ b/libs/resource-security/domain/src/entities/rds-instance-unencrypted.entity.spec.ts
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+import { AwsRegion } from 'cloud-cost-domain';
+import { RdsInstanceUnencrypted } from './rds-instance-unencrypted.entity';
+import type { RdsInstanceUnencryptedProps } from './rds-instance-unencrypted.entity';
+
+function makeFinding(overrides: Partial<RdsInstanceUnencryptedProps> = {}): RdsInstanceUnencrypted {
+  return new RdsInstanceUnencrypted({
+    dbInstanceIdentifier: 'db-1',
+    region: AwsRegion.create('us-east-1'),
+    accountId: '123456789012',
+    detectedAt: new Date('2026-07-23'),
+    tags: {},
+    ...overrides,
+  });
+}
+
+describe('RdsInstanceUnencrypted', () => {
+  it('exposes id, kind and severity', () => {
+    const finding = makeFinding();
+    expect(finding.id).toBe('db-1');
+    expect(finding.kind).toBe('rds-instance-unencrypted');
+    expect(finding.severity).toBe('warning');
+  });
+});

--- a/libs/resource-security/domain/src/entities/rds-instance-unencrypted.entity.ts
+++ b/libs/resource-security/domain/src/entities/rds-instance-unencrypted.entity.ts
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+import { Entity } from 'shared-kernel';
+import type { AwsRegion } from 'cloud-cost-domain';
+import type { SecurityFinding, ResourceSecuritySeverity } from '../resource-security';
+
+export interface RdsInstanceUnencryptedProps {
+  dbInstanceIdentifier: string;
+  region: AwsRegion;
+  accountId: string;
+  detectedAt: Date;
+  tags: Record<string, string>;
+}
+
+/** RDS instance storage not encrypted at rest (`DescribeDBInstances`'s `StorageEncrypted: false`). */
+export class RdsInstanceUnencrypted extends Entity<string> implements SecurityFinding {
+  private readonly props: Readonly<RdsInstanceUnencryptedProps>;
+
+  constructor(props: RdsInstanceUnencryptedProps) {
+    super(props.dbInstanceIdentifier);
+    this.props = this.deepFreeze({ ...props });
+  }
+
+  get dbInstanceIdentifier(): string {
+    return this.props.dbInstanceIdentifier;
+  }
+
+  get region(): AwsRegion {
+    return this.props.region;
+  }
+
+  get accountId(): string {
+    return this.props.accountId;
+  }
+
+  get detectedAt(): Date {
+    return this.props.detectedAt;
+  }
+
+  get tags(): Record<string, string> {
+    return this.props.tags;
+  }
+
+  get kind(): 'rds-instance-unencrypted' {
+    return 'rds-instance-unencrypted';
+  }
+
+  get riskReason(): string {
+    return 'RDS instance storage is not encrypted at rest';
+  }
+
+  get severity(): ResourceSecuritySeverity {
+    return 'warning';
+  }
+}

--- a/libs/resource-security/domain/src/entities/s3-bucket-encryption-missing.entity.spec.ts
+++ b/libs/resource-security/domain/src/entities/s3-bucket-encryption-missing.entity.spec.ts
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+import { S3BucketEncryptionMissing } from './s3-bucket-encryption-missing.entity';
+import type { S3BucketEncryptionMissingProps } from './s3-bucket-encryption-missing.entity';
+
+function makeFinding(overrides: Partial<S3BucketEncryptionMissingProps> = {}): S3BucketEncryptionMissing {
+  return new S3BucketEncryptionMissing({
+    bucketName: 'my-bucket',
+    accountId: '123456789012',
+    detectedAt: new Date('2026-07-23'),
+    tags: {},
+    ...overrides,
+  });
+}
+
+describe('S3BucketEncryptionMissing', () => {
+  it('exposes id, kind and severity', () => {
+    const finding = makeFinding();
+    expect(finding.id).toBe('my-bucket');
+    expect(finding.kind).toBe('s3-bucket-encryption-missing');
+    expect(finding.severity).toBe('warning');
+  });
+});

--- a/libs/resource-security/domain/src/entities/s3-bucket-encryption-missing.entity.ts
+++ b/libs/resource-security/domain/src/entities/s3-bucket-encryption-missing.entity.ts
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+import { Entity } from 'shared-kernel';
+import type { SecurityFinding, ResourceSecuritySeverity } from '../resource-security';
+
+export interface S3BucketEncryptionMissingProps {
+  bucketName: string;
+  accountId: string;
+  detectedAt: Date;
+  tags: Record<string, string>;
+}
+
+/** S3 bucket with no default server-side encryption configured (`GetBucketEncryption` returns `ServerSideEncryptionConfigurationNotFoundError`). */
+export class S3BucketEncryptionMissing extends Entity<string> implements SecurityFinding {
+  private readonly props: Readonly<S3BucketEncryptionMissingProps>;
+
+  constructor(props: S3BucketEncryptionMissingProps) {
+    super(props.bucketName);
+    this.props = this.deepFreeze({ ...props });
+  }
+
+  get bucketName(): string {
+    return this.props.bucketName;
+  }
+
+  get accountId(): string {
+    return this.props.accountId;
+  }
+
+  get detectedAt(): Date {
+    return this.props.detectedAt;
+  }
+
+  get tags(): Record<string, string> {
+    return this.props.tags;
+  }
+
+  get kind(): 's3-bucket-encryption-missing' {
+    return 's3-bucket-encryption-missing';
+  }
+
+  get riskReason(): string {
+    return 'bucket has no default server-side encryption configured';
+  }
+
+  get severity(): ResourceSecuritySeverity {
+    return 'warning';
+  }
+}

--- a/libs/resource-security/domain/src/entities/s3-bucket-public.entity.spec.ts
+++ b/libs/resource-security/domain/src/entities/s3-bucket-public.entity.spec.ts
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+import { S3BucketPublic } from './s3-bucket-public.entity';
+import type { S3BucketPublicProps } from './s3-bucket-public.entity';
+
+function makeFinding(overrides: Partial<S3BucketPublicProps> = {}): S3BucketPublic {
+  return new S3BucketPublic({
+    bucketName: 'my-bucket',
+    accountId: '123456789012',
+    publicVia: ['bucket policy allows public access'],
+    detectedAt: new Date('2026-07-23'),
+    tags: {},
+    ...overrides,
+  });
+}
+
+describe('S3BucketPublic', () => {
+  it('exposes id, kind and severity', () => {
+    const finding = makeFinding();
+    expect(finding.id).toBe('my-bucket');
+    expect(finding.kind).toBe('s3-bucket-public');
+    expect(finding.severity).toBe('critical');
+  });
+
+  it('riskReason joins all public-exposure reasons', () => {
+    const finding = makeFinding({ publicVia: ['bucket policy allows public access', 'bucket ACL grants public access'] });
+    expect(finding.riskReason).toBe('bucket policy allows public access; bucket ACL grants public access');
+  });
+});

--- a/libs/resource-security/domain/src/entities/s3-bucket-public.entity.ts
+++ b/libs/resource-security/domain/src/entities/s3-bucket-public.entity.ts
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+import { Entity } from 'shared-kernel';
+import type { SecurityFinding, ResourceSecuritySeverity } from '../resource-security';
+
+export interface S3BucketPublicProps {
+  bucketName: string;
+  accountId: string;
+  /** e.g. ["bucket policy allows public access", "bucket ACL grants public access"]. */
+  publicVia: string[];
+  detectedAt: Date;
+  tags: Record<string, string>;
+}
+
+/** S3 bucket reachable by the internet, via its ACL and/or bucket policy. S3 bucket names are account-wide (not per-region), so no `region`. */
+export class S3BucketPublic extends Entity<string> implements SecurityFinding {
+  private readonly props: Readonly<S3BucketPublicProps>;
+
+  constructor(props: S3BucketPublicProps) {
+    super(props.bucketName);
+    this.props = this.deepFreeze({ ...props });
+  }
+
+  get bucketName(): string {
+    return this.props.bucketName;
+  }
+
+  get accountId(): string {
+    return this.props.accountId;
+  }
+
+  get publicVia(): string[] {
+    return this.props.publicVia;
+  }
+
+  get detectedAt(): Date {
+    return this.props.detectedAt;
+  }
+
+  get tags(): Record<string, string> {
+    return this.props.tags;
+  }
+
+  get kind(): 's3-bucket-public' {
+    return 's3-bucket-public';
+  }
+
+  get riskReason(): string {
+    return this.publicVia.join('; ');
+  }
+
+  get severity(): ResourceSecuritySeverity {
+    return 'critical';
+  }
+}

--- a/libs/resource-security/domain/src/group-by-kind.ts
+++ b/libs/resource-security/domain/src/group-by-kind.ts
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+import { RESOURCE_SECURITY_KINDS, type ResourceSecurityKind, type SecurityFinding } from './resource-security';
+import type { IamRootMfaDisabled } from './entities/iam-root-mfa-disabled.entity';
+import type { IamUserMfaDisabled } from './entities/iam-user-mfa-disabled.entity';
+import type { IamAccessKeyRotationOverdue } from './entities/iam-access-key-rotation-overdue.entity';
+import type { IamRootAccessKeyActive } from './entities/iam-root-access-key-active.entity';
+import type { IamPasswordPolicyWeak } from './entities/iam-password-policy-weak.entity';
+import type { Ec2SecurityGroupOpenIngress } from './entities/ec2-security-group-open-ingress.entity';
+import type { Ec2DefaultSecurityGroupPermissive } from './entities/ec2-default-security-group-permissive.entity';
+import type { S3BucketPublic } from './entities/s3-bucket-public.entity';
+import type { Ec2SnapshotPublic } from './entities/ec2-snapshot-public.entity';
+import type { Ec2VolumeUnencrypted } from './entities/ec2-volume-unencrypted.entity';
+import type { RdsInstanceUnencrypted } from './entities/rds-instance-unencrypted.entity';
+import type { S3BucketEncryptionMissing } from './entities/s3-bucket-encryption-missing.entity';
+import type { RdsInstancePubliclyAccessible } from './entities/rds-instance-publicly-accessible.entity';
+import type { CloudtrailNotMultiregion } from './entities/cloudtrail-not-multiregion.entity';
+
+/**
+ * Map kind → concrete entity. Allows consumers (formatters) to retrieve the
+ * specific type from the kind without manual casts.
+ */
+export interface ResourceSecurityKindMap {
+  'iam-root-mfa-disabled': IamRootMfaDisabled;
+  'iam-user-mfa-disabled': IamUserMfaDisabled;
+  'iam-access-key-rotation-overdue': IamAccessKeyRotationOverdue;
+  'iam-root-access-key-active': IamRootAccessKeyActive;
+  'iam-password-policy-weak': IamPasswordPolicyWeak;
+  'ec2-security-group-open-ingress': Ec2SecurityGroupOpenIngress;
+  'ec2-default-security-group-permissive': Ec2DefaultSecurityGroupPermissive;
+  's3-bucket-public': S3BucketPublic;
+  'ec2-snapshot-public': Ec2SnapshotPublic;
+  'ec2-volume-unencrypted': Ec2VolumeUnencrypted;
+  'rds-instance-unencrypted': RdsInstanceUnencrypted;
+  's3-bucket-encryption-missing': S3BucketEncryptionMissing;
+  'rds-instance-publicly-accessible': RdsInstancePubliclyAccessible;
+  'cloudtrail-not-multiregion': CloudtrailNotMultiregion;
+}
+
+export type SecurityFindingsByKind = {
+  [K in ResourceSecurityKind]: ResourceSecurityKindMap[K][];
+};
+
+export function groupByKind(findings: readonly SecurityFinding[]): SecurityFindingsByKind {
+  const grouped = Object.fromEntries(
+    RESOURCE_SECURITY_KINDS.map((kind) => [kind, []]),
+  ) as unknown as SecurityFindingsByKind;
+
+  for (const finding of findings) {
+    (grouped[finding.kind] as SecurityFinding[]).push(finding);
+  }
+
+  return grouped;
+}

--- a/libs/resource-security/domain/src/index.ts
+++ b/libs/resource-security/domain/src/index.ts
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: Apache-2.0
+// Re-exported from cloud-cost-domain: a generic AWS value object this domain
+// needs too, not duplicated here to avoid two region-code lists drifting
+// out of sync (mirrors dead-resources-domain, ADR-0078).
+export { AwsRegion } from 'cloud-cost-domain';
+
+// Resource security model
+export { RESOURCE_SECURITY_KINDS, RESOURCE_SECURITY_KIND_META } from './resource-security';
+export type {
+  ResourceSecurityKind,
+  ResourceSecuritySeverity,
+  ResourceSecurityScope,
+  ResourceSecurityKindMeta,
+  SecurityFinding,
+} from './resource-security';
+export { groupByKind } from './group-by-kind';
+export type { ResourceSecurityKindMap, SecurityFindingsByKind } from './group-by-kind';
+
+// Entities
+export { IamRootMfaDisabled } from './entities/iam-root-mfa-disabled.entity';
+export type { IamRootMfaDisabledProps } from './entities/iam-root-mfa-disabled.entity';
+export { IamUserMfaDisabled } from './entities/iam-user-mfa-disabled.entity';
+export type { IamUserMfaDisabledProps } from './entities/iam-user-mfa-disabled.entity';
+export { IamAccessKeyRotationOverdue } from './entities/iam-access-key-rotation-overdue.entity';
+export type { IamAccessKeyRotationOverdueProps } from './entities/iam-access-key-rotation-overdue.entity';
+export { IamRootAccessKeyActive } from './entities/iam-root-access-key-active.entity';
+export type { IamRootAccessKeyActiveProps } from './entities/iam-root-access-key-active.entity';
+export { IamPasswordPolicyWeak } from './entities/iam-password-policy-weak.entity';
+export type { IamPasswordPolicyWeakProps } from './entities/iam-password-policy-weak.entity';
+export { Ec2SecurityGroupOpenIngress } from './entities/ec2-security-group-open-ingress.entity';
+export type { Ec2SecurityGroupOpenIngressProps } from './entities/ec2-security-group-open-ingress.entity';
+export { Ec2DefaultSecurityGroupPermissive } from './entities/ec2-default-security-group-permissive.entity';
+export type { Ec2DefaultSecurityGroupPermissiveProps } from './entities/ec2-default-security-group-permissive.entity';
+export { S3BucketPublic } from './entities/s3-bucket-public.entity';
+export type { S3BucketPublicProps } from './entities/s3-bucket-public.entity';
+export { Ec2SnapshotPublic } from './entities/ec2-snapshot-public.entity';
+export type { Ec2SnapshotPublicProps } from './entities/ec2-snapshot-public.entity';
+export { Ec2VolumeUnencrypted } from './entities/ec2-volume-unencrypted.entity';
+export type { Ec2VolumeUnencryptedProps } from './entities/ec2-volume-unencrypted.entity';
+export { RdsInstanceUnencrypted } from './entities/rds-instance-unencrypted.entity';
+export type { RdsInstanceUnencryptedProps } from './entities/rds-instance-unencrypted.entity';
+export { S3BucketEncryptionMissing } from './entities/s3-bucket-encryption-missing.entity';
+export type { S3BucketEncryptionMissingProps } from './entities/s3-bucket-encryption-missing.entity';
+export { RdsInstancePubliclyAccessible } from './entities/rds-instance-publicly-accessible.entity';
+export type { RdsInstancePubliclyAccessibleProps } from './entities/rds-instance-publicly-accessible.entity';
+export { CloudtrailNotMultiregion } from './entities/cloudtrail-not-multiregion.entity';
+export type { CloudtrailNotMultiregionProps } from './entities/cloudtrail-not-multiregion.entity';
+
+// Policies
+export {
+  ResourceSecurityPolicy,
+  flagged,
+  notFlagged,
+  DEFAULT_IGNORE_TAG,
+} from './policies/resource-security-policy';
+export type { RiskVerdict, ResourceSecurityPolicyOptions } from './policies/resource-security-policy';
+export { IamRootMfaDisabledPolicy } from './policies/iam-root-mfa-disabled.policy';
+export { IamUserMfaDisabledPolicy } from './policies/iam-user-mfa-disabled.policy';
+export { IamAccessKeyRotationOverduePolicy, DEFAULT_ACCESS_KEY_MAX_AGE_DAYS } from './policies/iam-access-key-rotation-overdue.policy';
+export { IamRootAccessKeyActivePolicy } from './policies/iam-root-access-key-active.policy';
+export { IamPasswordPolicyWeakPolicy } from './policies/iam-password-policy-weak.policy';
+export { Ec2SecurityGroupOpenIngressPolicy } from './policies/ec2-security-group-open-ingress.policy';
+export { Ec2DefaultSecurityGroupPermissivePolicy } from './policies/ec2-default-security-group-permissive.policy';
+export { S3BucketPublicPolicy } from './policies/s3-bucket-public.policy';
+export { Ec2SnapshotPublicPolicy } from './policies/ec2-snapshot-public.policy';
+export { Ec2VolumeUnencryptedPolicy } from './policies/ec2-volume-unencrypted.policy';
+export { RdsInstanceUnencryptedPolicy } from './policies/rds-instance-unencrypted.policy';
+export { S3BucketEncryptionMissingPolicy } from './policies/s3-bucket-encryption-missing.policy';
+export { RdsInstancePubliclyAccessiblePolicy } from './policies/rds-instance-publicly-accessible.policy';
+export { CloudtrailNotMultiregionPolicy } from './policies/cloudtrail-not-multiregion.policy';
+
+// Ports
+export type { ResourceSecurityScannerPort } from './ports/outbound/resource-security-scanner.port';
+export type {
+  FindResourceSecurityFindingsRequest,
+  ResourceSecurityScanError,
+  ResourceSecuritySummary,
+  FindResourceSecurityFindingsUseCasePort,
+} from './ports/inbound/find-resource-security-findings.use-case.port';

--- a/libs/resource-security/domain/src/policies/cloudtrail-not-multiregion.policy.spec.ts
+++ b/libs/resource-security/domain/src/policies/cloudtrail-not-multiregion.policy.spec.ts
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+import { CloudtrailNotMultiregion } from '../entities/cloudtrail-not-multiregion.entity';
+import type { CloudtrailNotMultiregionProps } from '../entities/cloudtrail-not-multiregion.entity';
+import { CloudtrailNotMultiregionPolicy } from './cloudtrail-not-multiregion.policy';
+
+function makeFinding(overrides: Partial<CloudtrailNotMultiregionProps> = {}): CloudtrailNotMultiregion {
+  return new CloudtrailNotMultiregion({
+    accountId: '123456789012',
+    hasMultiRegionTrail: false,
+    detectedAt: new Date('2026-07-23'),
+    tags: {},
+    ...overrides,
+  });
+}
+
+describe('CloudtrailNotMultiregionPolicy', () => {
+  const policy = new CloudtrailNotMultiregionPolicy();
+
+  it('flags when no multi-region trail exists', () => {
+    expect(policy.evaluate(makeFinding({ hasMultiRegionTrail: false })).flagged).toBe(true);
+  });
+
+  it('does not flag when a multi-region trail exists', () => {
+    expect(policy.evaluate(makeFinding({ hasMultiRegionTrail: true })).flagged).toBe(false);
+  });
+});

--- a/libs/resource-security/domain/src/policies/cloudtrail-not-multiregion.policy.ts
+++ b/libs/resource-security/domain/src/policies/cloudtrail-not-multiregion.policy.ts
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0
+import { ResourceSecurityPolicy, flagged, notFlagged, type RiskVerdict } from './resource-security-policy';
+import type { CloudtrailNotMultiregion } from '../entities/cloudtrail-not-multiregion.entity';
+
+export class CloudtrailNotMultiregionPolicy extends ResourceSecurityPolicy<CloudtrailNotMultiregion> {
+  protected judge(resource: CloudtrailNotMultiregion): RiskVerdict {
+    return resource.hasMultiRegionTrail ? notFlagged('a multi-region trail exists') : flagged(resource.riskReason);
+  }
+}

--- a/libs/resource-security/domain/src/policies/ec2-default-security-group-permissive.policy.spec.ts
+++ b/libs/resource-security/domain/src/policies/ec2-default-security-group-permissive.policy.spec.ts
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+import { AwsRegion } from 'cloud-cost-domain';
+import { Ec2DefaultSecurityGroupPermissive } from '../entities/ec2-default-security-group-permissive.entity';
+import type { Ec2DefaultSecurityGroupPermissiveProps } from '../entities/ec2-default-security-group-permissive.entity';
+import { Ec2DefaultSecurityGroupPermissivePolicy } from './ec2-default-security-group-permissive.policy';
+
+function makeFinding(overrides: Partial<Ec2DefaultSecurityGroupPermissiveProps> = {}): Ec2DefaultSecurityGroupPermissive {
+  return new Ec2DefaultSecurityGroupPermissive({
+    groupId: 'sg-default-1',
+    vpcId: 'vpc-1',
+    region: AwsRegion.create('us-east-1'),
+    accountId: '123456789012',
+    hasIngressRules: true,
+    hasEgressRules: true,
+    detectedAt: new Date('2026-07-23'),
+    tags: {},
+    ...overrides,
+  });
+}
+
+describe('Ec2DefaultSecurityGroupPermissivePolicy', () => {
+  const policy = new Ec2DefaultSecurityGroupPermissivePolicy();
+
+  it('flags a default security group carrying rules', () => {
+    expect(policy.evaluate(makeFinding()).flagged).toBe(true);
+  });
+});

--- a/libs/resource-security/domain/src/policies/ec2-default-security-group-permissive.policy.ts
+++ b/libs/resource-security/domain/src/policies/ec2-default-security-group-permissive.policy.ts
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+import { ResourceSecurityPolicy, flagged, type RiskVerdict } from './resource-security-policy';
+import type { Ec2DefaultSecurityGroupPermissive } from '../entities/ec2-default-security-group-permissive.entity';
+
+/** The scanner only emits default security groups that already carry at least one rule. */
+export class Ec2DefaultSecurityGroupPermissivePolicy extends ResourceSecurityPolicy<Ec2DefaultSecurityGroupPermissive> {
+  protected judge(resource: Ec2DefaultSecurityGroupPermissive): RiskVerdict {
+    return flagged(resource.riskReason);
+  }
+}

--- a/libs/resource-security/domain/src/policies/ec2-security-group-open-ingress.policy.spec.ts
+++ b/libs/resource-security/domain/src/policies/ec2-security-group-open-ingress.policy.spec.ts
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+import { AwsRegion } from 'cloud-cost-domain';
+import { Ec2SecurityGroupOpenIngress } from '../entities/ec2-security-group-open-ingress.entity';
+import type { Ec2SecurityGroupOpenIngressProps } from '../entities/ec2-security-group-open-ingress.entity';
+import { Ec2SecurityGroupOpenIngressPolicy } from './ec2-security-group-open-ingress.policy';
+import { DEFAULT_IGNORE_TAG } from './resource-security-policy';
+
+function makeFinding(overrides: Partial<Ec2SecurityGroupOpenIngressProps> = {}): Ec2SecurityGroupOpenIngress {
+  return new Ec2SecurityGroupOpenIngress({
+    groupId: 'sg-1',
+    groupName: 'web',
+    region: AwsRegion.create('us-east-1'),
+    accountId: '123456789012',
+    matchedRules: ['22/tcp from 0.0.0.0/0'],
+    detectedAt: new Date('2026-07-23'),
+    tags: overrides.tags ?? {},
+    ...overrides,
+  });
+}
+
+describe('Ec2SecurityGroupOpenIngressPolicy', () => {
+  const policy = new Ec2SecurityGroupOpenIngressPolicy();
+
+  it('flags a security group with a matched open-ingress rule', () => {
+    expect(policy.evaluate(makeFinding()).flagged).toBe(true);
+  });
+
+  it('does not flag a security group carrying the ignore tag', () => {
+    const verdict = policy.evaluate(makeFinding({ tags: { [DEFAULT_IGNORE_TAG]: 'true' } }));
+    expect(verdict.flagged).toBe(false);
+  });
+});

--- a/libs/resource-security/domain/src/policies/ec2-security-group-open-ingress.policy.ts
+++ b/libs/resource-security/domain/src/policies/ec2-security-group-open-ingress.policy.ts
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+import { ResourceSecurityPolicy, flagged, type RiskVerdict } from './resource-security-policy';
+import type { Ec2SecurityGroupOpenIngress } from '../entities/ec2-security-group-open-ingress.entity';
+
+/** The scanner only emits security groups that already have a matched sensitive-port rule. */
+export class Ec2SecurityGroupOpenIngressPolicy extends ResourceSecurityPolicy<Ec2SecurityGroupOpenIngress> {
+  protected judge(resource: Ec2SecurityGroupOpenIngress): RiskVerdict {
+    return flagged(resource.riskReason);
+  }
+}

--- a/libs/resource-security/domain/src/policies/ec2-snapshot-public.policy.spec.ts
+++ b/libs/resource-security/domain/src/policies/ec2-snapshot-public.policy.spec.ts
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+import { AwsRegion } from 'cloud-cost-domain';
+import { Ec2SnapshotPublic } from '../entities/ec2-snapshot-public.entity';
+import type { Ec2SnapshotPublicProps } from '../entities/ec2-snapshot-public.entity';
+import { Ec2SnapshotPublicPolicy } from './ec2-snapshot-public.policy';
+
+function makeFinding(overrides: Partial<Ec2SnapshotPublicProps> = {}): Ec2SnapshotPublic {
+  return new Ec2SnapshotPublic({
+    snapshotId: 'snap-1',
+    volumeId: 'vol-1',
+    region: AwsRegion.create('us-east-1'),
+    accountId: '123456789012',
+    detectedAt: new Date('2026-07-23'),
+    tags: {},
+    ...overrides,
+  });
+}
+
+describe('Ec2SnapshotPublicPolicy', () => {
+  const policy = new Ec2SnapshotPublicPolicy();
+
+  it('flags a public snapshot', () => {
+    expect(policy.evaluate(makeFinding()).flagged).toBe(true);
+  });
+});

--- a/libs/resource-security/domain/src/policies/ec2-snapshot-public.policy.ts
+++ b/libs/resource-security/domain/src/policies/ec2-snapshot-public.policy.ts
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+import { ResourceSecurityPolicy, flagged, type RiskVerdict } from './resource-security-policy';
+import type { Ec2SnapshotPublic } from '../entities/ec2-snapshot-public.entity';
+
+/** The scanner only emits snapshots already confirmed public via `DescribeSnapshotAttribute`. */
+export class Ec2SnapshotPublicPolicy extends ResourceSecurityPolicy<Ec2SnapshotPublic> {
+  protected judge(resource: Ec2SnapshotPublic): RiskVerdict {
+    return flagged(resource.riskReason);
+  }
+}

--- a/libs/resource-security/domain/src/policies/ec2-volume-unencrypted.policy.spec.ts
+++ b/libs/resource-security/domain/src/policies/ec2-volume-unencrypted.policy.spec.ts
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+import { AwsRegion } from 'cloud-cost-domain';
+import { Ec2VolumeUnencrypted } from '../entities/ec2-volume-unencrypted.entity';
+import { Ec2VolumeUnencryptedPolicy } from './ec2-volume-unencrypted.policy';
+
+describe('Ec2VolumeUnencryptedPolicy', () => {
+  it('flags an unencrypted volume', () => {
+    const policy = new Ec2VolumeUnencryptedPolicy();
+    const finding = new Ec2VolumeUnencrypted({
+      volumeId: 'vol-1',
+      region: AwsRegion.create('us-east-1'),
+      accountId: '123456789012',
+      detectedAt: new Date('2026-07-23'),
+      tags: {},
+    });
+    expect(policy.evaluate(finding).flagged).toBe(true);
+  });
+});

--- a/libs/resource-security/domain/src/policies/ec2-volume-unencrypted.policy.ts
+++ b/libs/resource-security/domain/src/policies/ec2-volume-unencrypted.policy.ts
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+import { ResourceSecurityPolicy, flagged, type RiskVerdict } from './resource-security-policy';
+import type { Ec2VolumeUnencrypted } from '../entities/ec2-volume-unencrypted.entity';
+
+/** The scanner only emits volumes already confirmed unencrypted. */
+export class Ec2VolumeUnencryptedPolicy extends ResourceSecurityPolicy<Ec2VolumeUnencrypted> {
+  protected judge(resource: Ec2VolumeUnencrypted): RiskVerdict {
+    return flagged(resource.riskReason);
+  }
+}

--- a/libs/resource-security/domain/src/policies/iam-access-key-rotation-overdue.policy.spec.ts
+++ b/libs/resource-security/domain/src/policies/iam-access-key-rotation-overdue.policy.spec.ts
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+import { IamAccessKeyRotationOverdue } from '../entities/iam-access-key-rotation-overdue.entity';
+import type { IamAccessKeyRotationOverdueProps } from '../entities/iam-access-key-rotation-overdue.entity';
+import { IamAccessKeyRotationOverduePolicy, DEFAULT_ACCESS_KEY_MAX_AGE_DAYS } from './iam-access-key-rotation-overdue.policy';
+
+const now = new Date('2026-07-15T00:00:00Z');
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+function makeFinding(overrides: Partial<IamAccessKeyRotationOverdueProps> = {}): IamAccessKeyRotationOverdue {
+  return new IamAccessKeyRotationOverdue({
+    accessKeyId: 'AKIA1',
+    userName: 'alice',
+    accountId: '123456789012',
+    createdAt: overrides.createdAt ?? now,
+    detectedAt: now,
+    tags: overrides.tags ?? {},
+    ...overrides,
+  });
+}
+
+describe('IamAccessKeyRotationOverduePolicy', () => {
+  const policy = new IamAccessKeyRotationOverduePolicy();
+
+  it('does not flag a key created within the rotation window', () => {
+    const createdAt = new Date(now.getTime() - (DEFAULT_ACCESS_KEY_MAX_AGE_DAYS - 1) * MS_PER_DAY);
+    expect(policy.evaluate(makeFinding({ createdAt }), now).flagged).toBe(false);
+  });
+
+  it('flags a key older than the rotation window', () => {
+    const createdAt = new Date(now.getTime() - (DEFAULT_ACCESS_KEY_MAX_AGE_DAYS + 1) * MS_PER_DAY);
+    expect(policy.evaluate(makeFinding({ createdAt }), now).flagged).toBe(true);
+  });
+});

--- a/libs/resource-security/domain/src/policies/iam-access-key-rotation-overdue.policy.ts
+++ b/libs/resource-security/domain/src/policies/iam-access-key-rotation-overdue.policy.ts
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+import { ResourceSecurityPolicy, flagged, notFlagged, type RiskVerdict } from './resource-security-policy';
+import type { IamAccessKeyRotationOverdue } from '../entities/iam-access-key-rotation-overdue.entity';
+
+/** CIS AWS Foundations Benchmark's own threshold for access-key rotation. */
+export const DEFAULT_ACCESS_KEY_MAX_AGE_DAYS = 90;
+
+export class IamAccessKeyRotationOverduePolicy extends ResourceSecurityPolicy<IamAccessKeyRotationOverdue> {
+  constructor(
+    options = {},
+    private readonly maxAgeDays = DEFAULT_ACCESS_KEY_MAX_AGE_DAYS,
+  ) {
+    super(options);
+  }
+
+  protected judge(resource: IamAccessKeyRotationOverdue, now: Date): RiskVerdict {
+    if (this.ageInDays(resource.createdAt, now) < this.maxAgeDays) {
+      return notFlagged(`created within the last ${this.maxAgeDays}d`);
+    }
+    return flagged(resource.riskReason);
+  }
+}

--- a/libs/resource-security/domain/src/policies/iam-password-policy-weak.policy.spec.ts
+++ b/libs/resource-security/domain/src/policies/iam-password-policy-weak.policy.spec.ts
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+import { IamPasswordPolicyWeak } from '../entities/iam-password-policy-weak.entity';
+import type { IamPasswordPolicyWeakProps } from '../entities/iam-password-policy-weak.entity';
+import { IamPasswordPolicyWeakPolicy } from './iam-password-policy-weak.policy';
+
+function makeFinding(overrides: Partial<IamPasswordPolicyWeakProps> = {}): IamPasswordPolicyWeak {
+  return new IamPasswordPolicyWeak({
+    accountId: '123456789012',
+    exists: false,
+    detectedAt: new Date('2026-07-23'),
+    tags: {},
+    ...overrides,
+  });
+}
+
+describe('IamPasswordPolicyWeakPolicy', () => {
+  const policy = new IamPasswordPolicyWeakPolicy();
+
+  it('flags a missing password policy', () => {
+    expect(policy.evaluate(makeFinding({ exists: false })).flagged).toBe(true);
+  });
+
+  it('does not flag a policy meeting the CIS baseline', () => {
+    const verdict = policy.evaluate(
+      makeFinding({
+        exists: true,
+        minimumPasswordLength: 14,
+        requireSymbols: true,
+        requireNumbers: true,
+        requireUppercaseCharacters: true,
+        requireLowercaseCharacters: true,
+        maxPasswordAge: 90,
+        passwordReusePrevention: 24,
+      }),
+    );
+    expect(verdict.flagged).toBe(false);
+  });
+});

--- a/libs/resource-security/domain/src/policies/iam-password-policy-weak.policy.ts
+++ b/libs/resource-security/domain/src/policies/iam-password-policy-weak.policy.ts
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0
+import { ResourceSecurityPolicy, flagged, notFlagged, type RiskVerdict } from './resource-security-policy';
+import type { IamPasswordPolicyWeak } from '../entities/iam-password-policy-weak.entity';
+
+export class IamPasswordPolicyWeakPolicy extends ResourceSecurityPolicy<IamPasswordPolicyWeak> {
+  protected judge(resource: IamPasswordPolicyWeak): RiskVerdict {
+    return resource.isWeak ? flagged(resource.riskReason) : notFlagged('meets CIS baseline');
+  }
+}

--- a/libs/resource-security/domain/src/policies/iam-root-access-key-active.policy.spec.ts
+++ b/libs/resource-security/domain/src/policies/iam-root-access-key-active.policy.spec.ts
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+import { IamRootAccessKeyActive } from '../entities/iam-root-access-key-active.entity';
+import type { IamRootAccessKeyActiveProps } from '../entities/iam-root-access-key-active.entity';
+import { IamRootAccessKeyActivePolicy } from './iam-root-access-key-active.policy';
+
+function makeFinding(overrides: Partial<IamRootAccessKeyActiveProps> = {}): IamRootAccessKeyActive {
+  return new IamRootAccessKeyActive({
+    accountId: '123456789012',
+    accessKeysPresent: true,
+    detectedAt: new Date('2026-07-23'),
+    tags: {},
+    ...overrides,
+  });
+}
+
+describe('IamRootAccessKeyActivePolicy', () => {
+  const policy = new IamRootAccessKeyActivePolicy();
+
+  it('flags when root has active access keys', () => {
+    expect(policy.evaluate(makeFinding({ accessKeysPresent: true })).flagged).toBe(true);
+  });
+
+  it('does not flag when root has no access keys', () => {
+    expect(policy.evaluate(makeFinding({ accessKeysPresent: false })).flagged).toBe(false);
+  });
+});

--- a/libs/resource-security/domain/src/policies/iam-root-access-key-active.policy.ts
+++ b/libs/resource-security/domain/src/policies/iam-root-access-key-active.policy.ts
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0
+import { ResourceSecurityPolicy, flagged, notFlagged, type RiskVerdict } from './resource-security-policy';
+import type { IamRootAccessKeyActive } from '../entities/iam-root-access-key-active.entity';
+
+export class IamRootAccessKeyActivePolicy extends ResourceSecurityPolicy<IamRootAccessKeyActive> {
+  protected judge(resource: IamRootAccessKeyActive): RiskVerdict {
+    return resource.accessKeysPresent ? flagged(resource.riskReason) : notFlagged('root has no access keys');
+  }
+}

--- a/libs/resource-security/domain/src/policies/iam-root-mfa-disabled.policy.spec.ts
+++ b/libs/resource-security/domain/src/policies/iam-root-mfa-disabled.policy.spec.ts
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+import { IamRootMfaDisabled } from '../entities/iam-root-mfa-disabled.entity';
+import type { IamRootMfaDisabledProps } from '../entities/iam-root-mfa-disabled.entity';
+import { IamRootMfaDisabledPolicy } from './iam-root-mfa-disabled.policy';
+import { DEFAULT_IGNORE_TAG } from './resource-security-policy';
+
+function makeFinding(overrides: Partial<IamRootMfaDisabledProps> = {}): IamRootMfaDisabled {
+  return new IamRootMfaDisabled({
+    accountId: '123456789012',
+    mfaEnabled: false,
+    detectedAt: new Date('2026-07-23'),
+    tags: {},
+    ...overrides,
+  });
+}
+
+describe('IamRootMfaDisabledPolicy', () => {
+  const policy = new IamRootMfaDisabledPolicy();
+
+  it('flags when root MFA is disabled', () => {
+    expect(policy.evaluate(makeFinding({ mfaEnabled: false })).flagged).toBe(true);
+  });
+
+  it('does not flag when root MFA is enabled', () => {
+    expect(policy.evaluate(makeFinding({ mfaEnabled: true })).flagged).toBe(false);
+  });
+
+  it('does not flag a finding carrying the ignore tag', () => {
+    const verdict = policy.evaluate(makeFinding({ tags: { [DEFAULT_IGNORE_TAG]: 'true' } }));
+    expect(verdict.flagged).toBe(false);
+  });
+});

--- a/libs/resource-security/domain/src/policies/iam-root-mfa-disabled.policy.ts
+++ b/libs/resource-security/domain/src/policies/iam-root-mfa-disabled.policy.ts
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0
+import { ResourceSecurityPolicy, flagged, notFlagged, type RiskVerdict } from './resource-security-policy';
+import type { IamRootMfaDisabled } from '../entities/iam-root-mfa-disabled.entity';
+
+export class IamRootMfaDisabledPolicy extends ResourceSecurityPolicy<IamRootMfaDisabled> {
+  protected judge(resource: IamRootMfaDisabled): RiskVerdict {
+    return resource.mfaEnabled ? notFlagged('root MFA is enabled') : flagged(resource.riskReason);
+  }
+}

--- a/libs/resource-security/domain/src/policies/iam-user-mfa-disabled.policy.spec.ts
+++ b/libs/resource-security/domain/src/policies/iam-user-mfa-disabled.policy.spec.ts
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+import { IamUserMfaDisabled } from '../entities/iam-user-mfa-disabled.entity';
+import type { IamUserMfaDisabledProps } from '../entities/iam-user-mfa-disabled.entity';
+import { IamUserMfaDisabledPolicy } from './iam-user-mfa-disabled.policy';
+import { DEFAULT_IGNORE_TAG } from './resource-security-policy';
+
+function makeFinding(overrides: Partial<IamUserMfaDisabledProps> = {}): IamUserMfaDisabled {
+  return new IamUserMfaDisabled({
+    userName: 'alice',
+    arn: 'arn:aws:iam::123456789012:user/alice',
+    accountId: '123456789012',
+    createdAt: new Date('2024-01-01'),
+    detectedAt: new Date('2026-07-23'),
+    tags: overrides.tags ?? {},
+    ...overrides,
+  });
+}
+
+describe('IamUserMfaDisabledPolicy', () => {
+  const policy = new IamUserMfaDisabledPolicy();
+
+  it('flags a user with no MFA device', () => {
+    expect(policy.evaluate(makeFinding()).flagged).toBe(true);
+  });
+
+  it('does not flag a user carrying the ignore tag', () => {
+    const verdict = policy.evaluate(makeFinding({ tags: { [DEFAULT_IGNORE_TAG]: 'true' } }));
+    expect(verdict.flagged).toBe(false);
+  });
+});

--- a/libs/resource-security/domain/src/policies/iam-user-mfa-disabled.policy.ts
+++ b/libs/resource-security/domain/src/policies/iam-user-mfa-disabled.policy.ts
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+import { ResourceSecurityPolicy, flagged, type RiskVerdict } from './resource-security-policy';
+import type { IamUserMfaDisabled } from '../entities/iam-user-mfa-disabled.entity';
+
+/** The scanner only emits candidates that already lack MFA, so beyond the shared tag exclusion there is nothing left to judge. */
+export class IamUserMfaDisabledPolicy extends ResourceSecurityPolicy<IamUserMfaDisabled> {
+  protected judge(resource: IamUserMfaDisabled): RiskVerdict {
+    return flagged(resource.riskReason);
+  }
+}

--- a/libs/resource-security/domain/src/policies/rds-instance-publicly-accessible.policy.spec.ts
+++ b/libs/resource-security/domain/src/policies/rds-instance-publicly-accessible.policy.spec.ts
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+import { AwsRegion } from 'cloud-cost-domain';
+import { RdsInstancePubliclyAccessible } from '../entities/rds-instance-publicly-accessible.entity';
+import { RdsInstancePubliclyAccessiblePolicy } from './rds-instance-publicly-accessible.policy';
+
+describe('RdsInstancePubliclyAccessiblePolicy', () => {
+  it('flags a publicly accessible instance', () => {
+    const policy = new RdsInstancePubliclyAccessiblePolicy();
+    const finding = new RdsInstancePubliclyAccessible({
+      dbInstanceIdentifier: 'db-1',
+      region: AwsRegion.create('us-east-1'),
+      accountId: '123456789012',
+      detectedAt: new Date('2026-07-23'),
+      tags: {},
+    });
+    expect(policy.evaluate(finding).flagged).toBe(true);
+  });
+});

--- a/libs/resource-security/domain/src/policies/rds-instance-publicly-accessible.policy.ts
+++ b/libs/resource-security/domain/src/policies/rds-instance-publicly-accessible.policy.ts
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+import { ResourceSecurityPolicy, flagged, type RiskVerdict } from './resource-security-policy';
+import type { RdsInstancePubliclyAccessible } from '../entities/rds-instance-publicly-accessible.entity';
+
+/** The scanner only emits instances already confirmed publicly accessible. */
+export class RdsInstancePubliclyAccessiblePolicy extends ResourceSecurityPolicy<RdsInstancePubliclyAccessible> {
+  protected judge(resource: RdsInstancePubliclyAccessible): RiskVerdict {
+    return flagged(resource.riskReason);
+  }
+}

--- a/libs/resource-security/domain/src/policies/rds-instance-unencrypted.policy.spec.ts
+++ b/libs/resource-security/domain/src/policies/rds-instance-unencrypted.policy.spec.ts
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+import { AwsRegion } from 'cloud-cost-domain';
+import { RdsInstanceUnencrypted } from '../entities/rds-instance-unencrypted.entity';
+import { RdsInstanceUnencryptedPolicy } from './rds-instance-unencrypted.policy';
+
+describe('RdsInstanceUnencryptedPolicy', () => {
+  it('flags an unencrypted instance', () => {
+    const policy = new RdsInstanceUnencryptedPolicy();
+    const finding = new RdsInstanceUnencrypted({
+      dbInstanceIdentifier: 'db-1',
+      region: AwsRegion.create('us-east-1'),
+      accountId: '123456789012',
+      detectedAt: new Date('2026-07-23'),
+      tags: {},
+    });
+    expect(policy.evaluate(finding).flagged).toBe(true);
+  });
+});

--- a/libs/resource-security/domain/src/policies/rds-instance-unencrypted.policy.ts
+++ b/libs/resource-security/domain/src/policies/rds-instance-unencrypted.policy.ts
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+import { ResourceSecurityPolicy, flagged, type RiskVerdict } from './resource-security-policy';
+import type { RdsInstanceUnencrypted } from '../entities/rds-instance-unencrypted.entity';
+
+/** The scanner only emits instances already confirmed unencrypted. */
+export class RdsInstanceUnencryptedPolicy extends ResourceSecurityPolicy<RdsInstanceUnencrypted> {
+  protected judge(resource: RdsInstanceUnencrypted): RiskVerdict {
+    return flagged(resource.riskReason);
+  }
+}

--- a/libs/resource-security/domain/src/policies/resource-security-policy.ts
+++ b/libs/resource-security/domain/src/policies/resource-security-policy.ts
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+import type { SecurityFinding } from '../resource-security';
+
+export interface RiskVerdict {
+  flagged: boolean;
+  reason: string;
+}
+
+export interface ResourceSecurityPolicyOptions {
+  /** Tag that explicitly excludes a resource from the report. */
+  ignoreTag?: string;
+  /**
+   * tag=value pairs that exclude a resource from the report
+   * (e.g. { Environment: 'Sandbox' }). The match is exact, case-sensitive.
+   */
+  excludeTagValues?: Record<string, string>;
+}
+
+export const DEFAULT_IGNORE_TAG = 'cloudrift:ignore';
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+export function flagged(reason: string): RiskVerdict {
+  return { flagged: true, reason };
+}
+
+export function notFlagged(reason: string): RiskVerdict {
+  return { flagged: false, reason };
+}
+
+/**
+ * Decides whether a candidate is really worth flagging. Scanners collect
+ * candidates; the policy applies the exclusion tag and the type-specific
+ * criteria. Structurally similar to `dead-resources-domain`'s
+ * `DeadResourcePolicy` but deliberately has no `minAgeDays`/grace-period
+ * concept: a security misconfiguration (open ingress, no MFA, unencrypted
+ * volume) is a risk from the moment it exists, not after N days — unlike
+ * cost-hygiene findings there is no "still settling in" period to wait out.
+ * The one kind that does need an age threshold (`iam-access-key-rotation-
+ * overdue`) computes it itself in its own `judge()`, using the `now`
+ * parameter below, rather than adding grace-period machinery every other
+ * kind would have to ignore.
+ */
+export abstract class ResourceSecurityPolicy<T extends SecurityFinding> {
+  protected readonly ignoreTag: string;
+  protected readonly excludeTagValues: Record<string, string>;
+
+  constructor(options: ResourceSecurityPolicyOptions = {}) {
+    this.ignoreTag = options.ignoreTag ?? DEFAULT_IGNORE_TAG;
+    this.excludeTagValues = options.excludeTagValues ?? {};
+  }
+
+  evaluate(resource: T, now: Date = new Date()): RiskVerdict {
+    if (this.ignoreTag in resource.tags) {
+      return notFlagged(`excluded by tag ${this.ignoreTag}`);
+    }
+    for (const [key, value] of Object.entries(this.excludeTagValues)) {
+      if (resource.tags[key] === value) {
+        return notFlagged(`excluded by tag ${key}=${value}`);
+      }
+    }
+    return this.judge(resource, now);
+  }
+
+  protected abstract judge(resource: T, now: Date): RiskVerdict;
+
+  protected ageInDays(since: Date, now: Date): number {
+    return (now.getTime() - since.getTime()) / MS_PER_DAY;
+  }
+}

--- a/libs/resource-security/domain/src/policies/s3-bucket-encryption-missing.policy.spec.ts
+++ b/libs/resource-security/domain/src/policies/s3-bucket-encryption-missing.policy.spec.ts
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+import { S3BucketEncryptionMissing } from '../entities/s3-bucket-encryption-missing.entity';
+import { S3BucketEncryptionMissingPolicy } from './s3-bucket-encryption-missing.policy';
+
+describe('S3BucketEncryptionMissingPolicy', () => {
+  it('flags a bucket with no default encryption', () => {
+    const policy = new S3BucketEncryptionMissingPolicy();
+    const finding = new S3BucketEncryptionMissing({
+      bucketName: 'my-bucket',
+      accountId: '123456789012',
+      detectedAt: new Date('2026-07-23'),
+      tags: {},
+    });
+    expect(policy.evaluate(finding).flagged).toBe(true);
+  });
+});

--- a/libs/resource-security/domain/src/policies/s3-bucket-encryption-missing.policy.ts
+++ b/libs/resource-security/domain/src/policies/s3-bucket-encryption-missing.policy.ts
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+import { ResourceSecurityPolicy, flagged, type RiskVerdict } from './resource-security-policy';
+import type { S3BucketEncryptionMissing } from '../entities/s3-bucket-encryption-missing.entity';
+
+/** The scanner only emits buckets already confirmed to have no default encryption. */
+export class S3BucketEncryptionMissingPolicy extends ResourceSecurityPolicy<S3BucketEncryptionMissing> {
+  protected judge(resource: S3BucketEncryptionMissing): RiskVerdict {
+    return flagged(resource.riskReason);
+  }
+}

--- a/libs/resource-security/domain/src/policies/s3-bucket-public.policy.spec.ts
+++ b/libs/resource-security/domain/src/policies/s3-bucket-public.policy.spec.ts
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+import { S3BucketPublic } from '../entities/s3-bucket-public.entity';
+import type { S3BucketPublicProps } from '../entities/s3-bucket-public.entity';
+import { S3BucketPublicPolicy } from './s3-bucket-public.policy';
+
+function makeFinding(overrides: Partial<S3BucketPublicProps> = {}): S3BucketPublic {
+  return new S3BucketPublic({
+    bucketName: 'my-bucket',
+    accountId: '123456789012',
+    publicVia: ['bucket policy allows public access'],
+    detectedAt: new Date('2026-07-23'),
+    tags: {},
+    ...overrides,
+  });
+}
+
+describe('S3BucketPublicPolicy', () => {
+  const policy = new S3BucketPublicPolicy();
+
+  it('flags a bucket already confirmed public', () => {
+    expect(policy.evaluate(makeFinding()).flagged).toBe(true);
+  });
+});

--- a/libs/resource-security/domain/src/policies/s3-bucket-public.policy.ts
+++ b/libs/resource-security/domain/src/policies/s3-bucket-public.policy.ts
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+import { ResourceSecurityPolicy, flagged, type RiskVerdict } from './resource-security-policy';
+import type { S3BucketPublic } from '../entities/s3-bucket-public.entity';
+
+/** The scanner only emits buckets already confirmed public via ACL and/or policy. */
+export class S3BucketPublicPolicy extends ResourceSecurityPolicy<S3BucketPublic> {
+  protected judge(resource: S3BucketPublic): RiskVerdict {
+    return flagged(resource.riskReason);
+  }
+}

--- a/libs/resource-security/domain/src/ports/inbound/find-resource-security-findings.use-case.port.ts
+++ b/libs/resource-security/domain/src/ports/inbound/find-resource-security-findings.use-case.port.ts
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+import type { Result } from 'shared-kernel';
+import type { AwsRegion } from 'cloud-cost-domain';
+import type { ResourceSecurityKind, SecurityFinding, ResourceSecuritySeverity } from '../../resource-security';
+
+export interface FindResourceSecurityFindingsRequest {
+  regions: AwsRegion[];
+}
+
+export interface ResourceSecurityScanError {
+  kind: ResourceSecurityKind;
+  region: string;
+  error: Error;
+}
+
+export interface ResourceSecuritySummary {
+  findings: SecurityFinding[];
+  /** Count of findings per severity — the headline instead of a dollar total. */
+  countBySeverity: Record<ResourceSecuritySeverity, number>;
+  scanErrors: ResourceSecurityScanError[];
+}
+
+export interface FindResourceSecurityFindingsUseCasePort {
+  execute(request: FindResourceSecurityFindingsRequest): Promise<Result<ResourceSecuritySummary>>;
+}

--- a/libs/resource-security/domain/src/ports/outbound/resource-security-scanner.port.ts
+++ b/libs/resource-security/domain/src/ports/outbound/resource-security-scanner.port.ts
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+import type { Result } from 'shared-kernel';
+import type { AwsRegion } from 'cloud-cost-domain';
+import type { ResourceSecurityKind, SecurityFinding, ResourceSecurityScope } from '../../resource-security';
+
+/**
+ * Single outbound port for security-posture detection: each check kind is
+ * an implementation (plugin) of this port. Mirrors `dead-resources-domain`'s
+ * `DeadResourceScannerPort`.
+ *
+ * `scope` (default `'regional'`) tells the coordinator how many jobs to
+ * create: a `'global'` scanner (IAM, S3 bucket listing, CloudTrail) is
+ * called exactly once regardless of how many regions were requested — the
+ * `region` it receives in that call is an arbitrary one of the requested
+ * regions and MUST be ignored by the implementation.
+ */
+export interface ResourceSecurityScannerPort {
+  readonly kind: ResourceSecurityKind;
+  readonly scope?: ResourceSecurityScope;
+  scan(region: AwsRegion): Promise<Result<SecurityFinding[]>>;
+}

--- a/libs/resource-security/domain/src/resource-security.ts
+++ b/libs/resource-security/domain/src/resource-security.ts
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: Apache-2.0
+import type { AwsRegion } from 'cloud-cost-domain';
+
+/**
+ * One resource kind per security-posture check this domain covers: IAM/
+ * account-level configuration, network exposure, public storage, encryption
+ * at rest, and visibility/audit. Deliberately its own domain, not folded
+ * into `dead-resources-domain` — these findings are not "dead" resources
+ * (they're actively used, in-service resources with a risky configuration),
+ * so `hygieneReason`/`DeadResource` would misdescribe them. Mirrors the
+ * `dead-resources` vs `cloud-cost` split (ADR-0078) one level further.
+ */
+export const RESOURCE_SECURITY_KINDS = [
+  'iam-root-mfa-disabled',
+  'iam-user-mfa-disabled',
+  'iam-access-key-rotation-overdue',
+  'iam-root-access-key-active',
+  'iam-password-policy-weak',
+  'ec2-security-group-open-ingress',
+  'ec2-default-security-group-permissive',
+  's3-bucket-public',
+  'ec2-snapshot-public',
+  'ec2-volume-unencrypted',
+  'rds-instance-unencrypted',
+  's3-bucket-encryption-missing',
+  'rds-instance-publicly-accessible',
+  'cloudtrail-not-multiregion',
+] as const;
+export type ResourceSecurityKind = (typeof RESOURCE_SECURITY_KINDS)[number];
+
+/** How urgent a finding is. Same three-level scale as `dead-resources-domain`'s `DeadResourceSeverity`. */
+export type ResourceSecuritySeverity = 'info' | 'warning' | 'critical';
+
+/** Whether a kind's scanner is called once per requested region, or exactly once (account-wide/global AWS services: IAM, S3 bucket listing, CloudTrail). */
+export type ResourceSecurityScope = 'regional' | 'global';
+
+export interface ResourceSecurityKindMeta {
+  label: string;
+  scope: ResourceSecurityScope;
+}
+
+export const RESOURCE_SECURITY_KIND_META: Record<ResourceSecurityKind, ResourceSecurityKindMeta> = {
+  'iam-root-mfa-disabled': { label: 'Root Account (MFA disabled)', scope: 'global' },
+  'iam-user-mfa-disabled': { label: 'IAM Users (MFA disabled)', scope: 'global' },
+  'iam-access-key-rotation-overdue': { label: 'IAM Access Keys (rotation overdue)', scope: 'global' },
+  'iam-root-access-key-active': { label: 'Root Account (active access key)', scope: 'global' },
+  'iam-password-policy-weak': { label: 'Account Password Policy (weak or missing)', scope: 'global' },
+  'ec2-security-group-open-ingress': { label: 'EC2 Security Groups (open ingress on sensitive ports)', scope: 'regional' },
+  'ec2-default-security-group-permissive': { label: 'EC2 Default Security Groups (permissive)', scope: 'regional' },
+  's3-bucket-public': { label: 'S3 Buckets (public)', scope: 'global' },
+  'ec2-snapshot-public': { label: 'EC2 Snapshots (public)', scope: 'regional' },
+  'ec2-volume-unencrypted': { label: 'EBS Volumes (unencrypted)', scope: 'regional' },
+  'rds-instance-unencrypted': { label: 'RDS Instances (unencrypted)', scope: 'regional' },
+  's3-bucket-encryption-missing': { label: 'S3 Buckets (default encryption missing)', scope: 'global' },
+  'rds-instance-publicly-accessible': { label: 'RDS Instances (publicly accessible)', scope: 'regional' },
+  'cloudtrail-not-multiregion': { label: 'CloudTrail (no multi-region trail)', scope: 'global' },
+};
+
+/**
+ * The sole inbound-boundary type for this domain (mirrors `DeadResource` in
+ * `dead-resources-domain`, itself mirroring `WastedResource`, ADR-0014):
+ * coordinator, summary and formatters depend only on this interface, never
+ * on the concrete entities.
+ *
+ * `region` is optional: global-scope kinds (IAM, S3 bucket listing,
+ * CloudTrail) have no single region to report.
+ */
+export interface SecurityFinding {
+  readonly id: string;
+  readonly kind: ResourceSecurityKind;
+  readonly region?: AwsRegion;
+  readonly accountId: string;
+  readonly detectedAt: Date;
+  readonly tags: Record<string, string>;
+  /** Why this was flagged — e.g. "no MFA device registered". */
+  readonly riskReason: string;
+  readonly severity: ResourceSecuritySeverity;
+}

--- a/libs/resource-security/domain/tsconfig.json
+++ b/libs/resource-security/domain/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/libs/resource-security/domain/tsconfig.lib.json
+++ b/libs/resource-security/domain/tsconfig.lib.json
@@ -1,0 +1,21 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "dist/tsconfig.lib.tsbuildinfo",
+    "emitDeclarationOnly": false,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"],
+  "references": [
+    {
+      "path": "../../cloud-cost/domain/tsconfig.lib.json"
+    },
+    {
+      "path": "../../shared/kernel/tsconfig.lib.json"
+    }
+  ]
+}

--- a/libs/resource-security/domain/tsconfig.spec.json
+++ b/libs/resource-security/domain/tsconfig.spec.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "outDir": "./dist/test",
+    "types": ["jest", "node"],
+    "strict": true,
+    "esModuleInterop": true
+  },
+  "include": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/libs/resource-security/infrastructure/aws-adapter/eslint.config.mjs
+++ b/libs/resource-security/infrastructure/aws-adapter/eslint.config.mjs
@@ -1,0 +1,14 @@
+import baseConfig from '../../../../eslint.config.mjs';
+
+export default [
+  ...baseConfig,
+  {
+    files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
+    rules: {
+      // Global-scope scanners (IAM/S3/CloudTrail, mirroring ADR-0078) must
+      // still accept a `region` param to satisfy ResourceSecurityScannerPort,
+      // but ignore it. `_`-prefixed is the signal.
+      '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
+    },
+  },
+];

--- a/libs/resource-security/infrastructure/aws-adapter/jest.config.cjs
+++ b/libs/resource-security/infrastructure/aws-adapter/jest.config.cjs
@@ -1,0 +1,23 @@
+/** @type {import('@jest/types').Config.InitialOptions} */
+module.exports = {
+  displayName: 'resource-security-infrastructure-aws-adapter',
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      { tsconfig: '<rootDir>/tsconfig.spec.json', diagnostics: false },
+    ],
+  },
+  moduleFileExtensions: ['ts', 'js', 'json'],
+  testMatch: ['<rootDir>/src/**/*.spec.ts'],
+  moduleNameMapper: {
+    '^shared-kernel$': '<rootDir>/../../../shared/kernel/src/index.ts',
+    '^shared-kernel/(.*)$': '<rootDir>/../../../shared/kernel/src/$1',
+    '^cloud-cost-domain$': '<rootDir>/../../../cloud-cost/domain/src/index.ts',
+    '^cloud-cost-domain/(.*)$': '<rootDir>/../../../cloud-cost/domain/src/$1',
+    '^resource-security-domain$': '<rootDir>/../../domain/src/index.ts',
+    '^resource-security-domain/(.*)$': '<rootDir>/../../domain/src/$1',
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
+};

--- a/libs/resource-security/infrastructure/aws-adapter/package.json
+++ b/libs/resource-security/infrastructure/aws-adapter/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "resource-security-infrastructure-aws-adapter",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "@cloudrift/source": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "nx": {
+    "tags": [
+      "scope:infrastructure"
+    ],
+    "targets": {
+      "test": {
+        "executor": "@nx/jest:jest",
+        "outputs": [
+          "{workspaceRoot}/coverage/{projectRoot}"
+        ],
+        "options": {
+          "jestConfig": "libs/resource-security/infrastructure/aws-adapter/jest.config.cjs",
+          "passWithNoTests": true
+        }
+      }
+    }
+  },
+  "dependencies": {
+    "resource-security-domain": "workspace:*",
+    "shared-kernel": "workspace:*",
+    "tslib": "^2.8.1"
+  }
+}

--- a/libs/resource-security/infrastructure/aws-adapter/src/errors/aws-adapter.error.ts
+++ b/libs/resource-security/infrastructure/aws-adapter/src/errors/aws-adapter.error.ts
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+import { InfrastructureError, createLogger } from 'shared-kernel';
+
+const logger = createLogger('cloudrift:scanner');
+
+/** Deliberate copy of `dead-resources-infrastructure-aws-adapter`'s own `AwsAdapterError` (ADR-0078). */
+export class AwsAdapterError extends InfrastructureError {
+  constructor(
+    readonly service: string,
+    override readonly cause: Error,
+  ) {
+    super('AWS_ADAPTER_ERROR', `AWS ${service} adapter failed: ${cause.message}`);
+    const meta = cause as Error & { $metadata?: { attempts?: number }; code?: string };
+    logger.debug(`${service} adapter error`, {
+      name: cause.name,
+      code: meta.code,
+      attempts: meta.$metadata?.attempts,
+    });
+  }
+}

--- a/libs/resource-security/infrastructure/aws-adapter/src/index.ts
+++ b/libs/resource-security/infrastructure/aws-adapter/src/index.ts
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+export { AwsIamRootMfaDisabledScanner } from './scanners/aws-iam-root-mfa-disabled.scanner';
+export { AwsIamUserMfaDisabledScanner } from './scanners/aws-iam-user-mfa-disabled.scanner';
+export { AwsIamAccessKeyRotationOverdueScanner } from './scanners/aws-iam-access-key-rotation-overdue.scanner';
+export { AwsIamRootAccessKeyActiveScanner } from './scanners/aws-iam-root-access-key-active.scanner';
+export { AwsIamPasswordPolicyWeakScanner } from './scanners/aws-iam-password-policy-weak.scanner';
+export { AwsEc2SecurityGroupOpenIngressScanner } from './scanners/aws-ec2-security-group-open-ingress.scanner';
+export { AwsEc2DefaultSecurityGroupPermissiveScanner } from './scanners/aws-ec2-default-security-group-permissive.scanner';
+export { AwsS3BucketPublicScanner } from './scanners/aws-s3-bucket-public.scanner';
+export { AwsEc2SnapshotPublicScanner } from './scanners/aws-ec2-snapshot-public.scanner';
+export { AwsEc2VolumeUnencryptedScanner } from './scanners/aws-ec2-volume-unencrypted.scanner';
+export { AwsRdsInstanceUnencryptedScanner } from './scanners/aws-rds-instance-unencrypted.scanner';
+export { AwsS3BucketEncryptionMissingScanner } from './scanners/aws-s3-bucket-encryption-missing.scanner';
+export { AwsRdsInstancePubliclyAccessibleScanner } from './scanners/aws-rds-instance-publicly-accessible.scanner';
+export { AwsCloudtrailNotMultiregionScanner } from './scanners/aws-cloudtrail-not-multiregion.scanner';
+export { AwsAdapterError } from './errors/aws-adapter.error';

--- a/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-cloudtrail-not-multiregion.scanner.spec.ts
+++ b/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-cloudtrail-not-multiregion.scanner.spec.ts
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+import { CloudTrailClient, DescribeTrailsCommand } from '@aws-sdk/client-cloudtrail';
+import { AwsCloudtrailNotMultiregionScanner } from './aws-cloudtrail-not-multiregion.scanner';
+import { AwsRegion } from 'resource-security-domain';
+import { AwsAdapterError } from '../errors/aws-adapter.error';
+
+jest.mock('@aws-sdk/client-cloudtrail');
+
+const mockSend = jest.fn();
+const mockDestroy = jest.fn();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (CloudTrailClient as jest.Mock).mockImplementation(() => ({ send: mockSend, destroy: mockDestroy }));
+});
+
+const region = AwsRegion.create('us-east-1');
+const scanner = new AwsCloudtrailNotMultiregionScanner();
+
+describe('AwsCloudtrailNotMultiregionScanner', () => {
+  it('exposes its resource kind and global scope', () => {
+    expect(scanner.kind).toBe('cloudtrail-not-multiregion');
+    expect(scanner.scope).toBe('global');
+  });
+
+  it('flags an account with no multi-region trail', async () => {
+    mockSend.mockResolvedValueOnce({ trailList: [{ Name: 'regional-trail', IsMultiRegionTrail: false }] });
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toHaveLength(1);
+  });
+
+  it('does not flag an account with a multi-region trail', async () => {
+    mockSend.mockResolvedValueOnce({ trailList: [{ Name: 'org-trail', IsMultiRegionTrail: true }] });
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toHaveLength(0);
+  });
+
+  it('sends DescribeTrailsCommand', async () => {
+    mockSend.mockResolvedValueOnce({ trailList: [] });
+
+    await scanner.scan(region);
+
+    expect(mockSend).toHaveBeenCalledWith(expect.any(DescribeTrailsCommand));
+  });
+
+  it('returns Result.fail wrapping AwsAdapterError on SDK error and destroys the client', async () => {
+    mockSend.mockRejectedValueOnce(new Error('AccessDenied'));
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toBeInstanceOf(AwsAdapterError);
+    expect(mockDestroy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-cloudtrail-not-multiregion.scanner.ts
+++ b/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-cloudtrail-not-multiregion.scanner.ts
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+import { CloudTrailClient, DescribeTrailsCommand } from '@aws-sdk/client-cloudtrail';
+import { Result } from 'shared-kernel';
+import type { AwsRegion, ResourceSecurityScannerPort, SecurityFinding } from 'resource-security-domain';
+import { CloudtrailNotMultiregion, CloudtrailNotMultiregionPolicy } from 'resource-security-domain';
+import { AwsAdapterError } from '../errors/aws-adapter.error';
+import { createAwsClientConfig } from '../utils/client-config';
+
+/** CloudTrail's `DescribeTrails` (with `includeShadowTrails`) needs one home-region endpoint to see every trail account-wide. */
+const CLOUDTRAIL_ENDPOINT_REGION = 'us-east-1';
+
+/** Detects accounts with no CloudTrail trail configured for multi-region logging (CIS AWS Foundations 3.1). `scope: 'global'`. */
+export class AwsCloudtrailNotMultiregionScanner implements ResourceSecurityScannerPort {
+  readonly kind = 'cloudtrail-not-multiregion' as const;
+  readonly scope = 'global' as const;
+
+  constructor(
+    private readonly accountId = 'unknown',
+    private readonly policy = new CloudtrailNotMultiregionPolicy(),
+  ) {}
+
+  async scan(_region: AwsRegion): Promise<Result<SecurityFinding[]>> {
+    const client = new CloudTrailClient({ ...createAwsClientConfig(), region: CLOUDTRAIL_ENDPOINT_REGION });
+    try {
+      const { trailList } = await client.send(new DescribeTrailsCommand({ includeShadowTrails: true }));
+      const now = new Date();
+      const finding = new CloudtrailNotMultiregion({
+        accountId: this.accountId,
+        hasMultiRegionTrail: (trailList ?? []).some((t) => t.IsMultiRegionTrail === true),
+        detectedAt: now,
+        tags: {},
+      });
+
+      return Result.ok(this.policy.evaluate(finding, now).flagged ? [finding] : []);
+    } catch (err) {
+      return Result.fail(new AwsAdapterError('CloudTrail', err as Error));
+    } finally {
+      client.destroy();
+    }
+  }
+}

--- a/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-ec2-default-security-group-permissive.scanner.spec.ts
+++ b/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-ec2-default-security-group-permissive.scanner.spec.ts
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+import { EC2Client } from '@aws-sdk/client-ec2';
+import { AwsEc2DefaultSecurityGroupPermissiveScanner } from './aws-ec2-default-security-group-permissive.scanner';
+import { AwsRegion } from 'resource-security-domain';
+import { AwsAdapterError } from '../errors/aws-adapter.error';
+
+jest.mock('@aws-sdk/client-ec2');
+
+const mockSend = jest.fn();
+const mockDestroy = jest.fn();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (EC2Client as jest.Mock).mockImplementation(() => ({ send: mockSend, destroy: mockDestroy }));
+});
+
+const region = AwsRegion.create('us-east-1');
+const scanner = new AwsEc2DefaultSecurityGroupPermissiveScanner();
+
+describe('AwsEc2DefaultSecurityGroupPermissiveScanner', () => {
+  it('exposes its resource kind', () => {
+    expect(scanner.kind).toBe('ec2-default-security-group-permissive');
+  });
+
+  it('flags a default security group carrying ingress rules', async () => {
+    mockSend.mockResolvedValueOnce({
+      SecurityGroups: [{ GroupId: 'sg-default-1', VpcId: 'vpc-1', IpPermissions: [{ IpProtocol: '-1' }], IpPermissionsEgress: [] }],
+    });
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value.map((f) => f.id)).toEqual(['sg-default-1']);
+  });
+
+  it('does not flag a default security group with no rules at all', async () => {
+    mockSend.mockResolvedValueOnce({
+      SecurityGroups: [{ GroupId: 'sg-default-2', VpcId: 'vpc-2', IpPermissions: [], IpPermissionsEgress: [] }],
+    });
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toHaveLength(0);
+  });
+
+  it('returns Result.fail wrapping AwsAdapterError on SDK error and destroys the client', async () => {
+    mockSend.mockRejectedValueOnce(new Error('AccessDenied'));
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toBeInstanceOf(AwsAdapterError);
+    expect(mockDestroy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-ec2-default-security-group-permissive.scanner.ts
+++ b/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-ec2-default-security-group-permissive.scanner.ts
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+import { EC2Client, DescribeSecurityGroupsCommand, type SecurityGroup } from '@aws-sdk/client-ec2';
+import { Result } from 'shared-kernel';
+import type { AwsRegion, ResourceSecurityScannerPort, SecurityFinding } from 'resource-security-domain';
+import { Ec2DefaultSecurityGroupPermissive, Ec2DefaultSecurityGroupPermissivePolicy } from 'resource-security-domain';
+import { AwsAdapterError } from '../errors/aws-adapter.error';
+import { paginate } from '../utils/paginate';
+import { createAwsClientConfig } from '../utils/client-config';
+
+const DEFAULT_GROUP_NAME = 'default';
+
+type SecurityGroupWithId = SecurityGroup & { GroupId: string; VpcId: string };
+
+/** Detects a VPC's auto-created `default` security group still carrying ingress/egress rules (CIS AWS Foundations 5.3). */
+export class AwsEc2DefaultSecurityGroupPermissiveScanner implements ResourceSecurityScannerPort {
+  readonly kind = 'ec2-default-security-group-permissive' as const;
+
+  constructor(
+    private readonly accountId = 'unknown',
+    private readonly policy = new Ec2DefaultSecurityGroupPermissivePolicy(),
+  ) {}
+
+  async scan(region: AwsRegion): Promise<Result<SecurityFinding[]>> {
+    const client = new EC2Client({ ...createAwsClientConfig(), region: region.code });
+    try {
+      const rawGroups = await paginate<SecurityGroup>(async (cursor) => {
+        const r = await client.send(
+          new DescribeSecurityGroupsCommand({
+            NextToken: cursor,
+            Filters: [{ Name: 'group-name', Values: [DEFAULT_GROUP_NAME] }],
+          }),
+        );
+        return { items: r.SecurityGroups ?? [], cursor: r.NextToken };
+      });
+
+      const now = new Date();
+      const validGroups = rawGroups.filter((g): g is SecurityGroupWithId => !!g.GroupId && !!g.VpcId);
+
+      const results = validGroups
+        .map(
+          (g) =>
+            new Ec2DefaultSecurityGroupPermissive({
+              groupId: g.GroupId,
+              vpcId: g.VpcId,
+              region,
+              accountId: this.accountId,
+              hasIngressRules: (g.IpPermissions ?? []).length > 0,
+              hasEgressRules: (g.IpPermissionsEgress ?? []).length > 0,
+              detectedAt: now,
+              tags: Object.fromEntries((g.Tags ?? []).map((t) => [t.Key ?? '', t.Value ?? ''])),
+            }),
+        )
+        .filter((g) => g.hasIngressRules || g.hasEgressRules)
+        .filter((finding) => this.policy.evaluate(finding, now).flagged);
+
+      return Result.ok(results);
+    } catch (err) {
+      return Result.fail(new AwsAdapterError('EC2', err as Error));
+    } finally {
+      client.destroy();
+    }
+  }
+}

--- a/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-ec2-security-group-open-ingress.scanner.spec.ts
+++ b/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-ec2-security-group-open-ingress.scanner.spec.ts
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: Apache-2.0
+import { EC2Client, DescribeSecurityGroupsCommand } from '@aws-sdk/client-ec2';
+import { AwsEc2SecurityGroupOpenIngressScanner } from './aws-ec2-security-group-open-ingress.scanner';
+import { AwsRegion } from 'resource-security-domain';
+import { AwsAdapterError } from '../errors/aws-adapter.error';
+
+jest.mock('@aws-sdk/client-ec2');
+
+const mockSend = jest.fn();
+const mockDestroy = jest.fn();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (EC2Client as jest.Mock).mockImplementation(() => ({ send: mockSend, destroy: mockDestroy }));
+});
+
+const region = AwsRegion.create('us-east-1');
+const scanner = new AwsEc2SecurityGroupOpenIngressScanner();
+
+describe('AwsEc2SecurityGroupOpenIngressScanner', () => {
+  it('exposes its resource kind', () => {
+    expect(scanner.kind).toBe('ec2-security-group-open-ingress');
+  });
+
+  it('flags a security group with SSH open to the internet', async () => {
+    mockSend.mockResolvedValueOnce({
+      SecurityGroups: [
+        {
+          GroupId: 'sg-1',
+          GroupName: 'web',
+          IpPermissions: [{ IpProtocol: 'tcp', FromPort: 22, ToPort: 22, IpRanges: [{ CidrIp: '0.0.0.0/0' }] }],
+        },
+      ],
+    });
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value.map((f) => f.id)).toEqual(['sg-1']);
+  });
+
+  it('flags a security group open to the internet on all ports (protocol -1)', async () => {
+    mockSend.mockResolvedValueOnce({
+      SecurityGroups: [
+        { GroupId: 'sg-2', GroupName: 'all-open', IpPermissions: [{ IpProtocol: '-1', IpRanges: [{ CidrIp: '0.0.0.0/0' }] }] },
+      ],
+    });
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toHaveLength(1);
+  });
+
+  it('does not flag a security group restricted to a private CIDR', async () => {
+    mockSend.mockResolvedValueOnce({
+      SecurityGroups: [
+        {
+          GroupId: 'sg-3',
+          GroupName: 'internal',
+          IpPermissions: [{ IpProtocol: 'tcp', FromPort: 22, ToPort: 22, IpRanges: [{ CidrIp: '10.0.0.0/16' }] }],
+        },
+      ],
+    });
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toHaveLength(0);
+  });
+
+  it('does not flag a security group open to the internet on a non-sensitive port', async () => {
+    mockSend.mockResolvedValueOnce({
+      SecurityGroups: [
+        {
+          GroupId: 'sg-4',
+          GroupName: 'web-http',
+          IpPermissions: [{ IpProtocol: 'tcp', FromPort: 443, ToPort: 443, IpRanges: [{ CidrIp: '0.0.0.0/0' }] }],
+        },
+      ],
+    });
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toHaveLength(0);
+  });
+
+  it('sends DescribeSecurityGroupsCommand', async () => {
+    mockSend.mockResolvedValueOnce({ SecurityGroups: [] });
+
+    await scanner.scan(region);
+
+    expect(mockSend).toHaveBeenCalledWith(expect.any(DescribeSecurityGroupsCommand));
+  });
+
+  it('returns Result.fail wrapping AwsAdapterError on SDK error and destroys the client', async () => {
+    mockSend.mockRejectedValueOnce(new Error('AccessDenied'));
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toBeInstanceOf(AwsAdapterError);
+    expect(mockDestroy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-ec2-security-group-open-ingress.scanner.ts
+++ b/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-ec2-security-group-open-ingress.scanner.ts
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Apache-2.0
+import { EC2Client, DescribeSecurityGroupsCommand, type SecurityGroup, type IpPermission } from '@aws-sdk/client-ec2';
+import { Result } from 'shared-kernel';
+import type { AwsRegion, ResourceSecurityScannerPort, SecurityFinding } from 'resource-security-domain';
+import { Ec2SecurityGroupOpenIngress, Ec2SecurityGroupOpenIngressPolicy } from 'resource-security-domain';
+import { AwsAdapterError } from '../errors/aws-adapter.error';
+import { paginate } from '../utils/paginate';
+import { createAwsClientConfig } from '../utils/client-config';
+
+const OPEN_IPV4 = '0.0.0.0/0';
+const OPEN_IPV6 = '::/0';
+
+/** Commonly-attacked ports worth calling out by name: remote administration and default database ports. */
+const SENSITIVE_PORTS: ReadonlyArray<{ port: number; label: string }> = [
+  { port: 22, label: 'SSH' },
+  { port: 3389, label: 'RDP' },
+  { port: 3306, label: 'MySQL' },
+  { port: 5432, label: 'PostgreSQL' },
+  { port: 1433, label: 'MSSQL' },
+  { port: 27017, label: 'MongoDB' },
+  { port: 6379, label: 'Redis' },
+];
+
+type SecurityGroupWithId = SecurityGroup & { GroupId: string; GroupName: string };
+
+function portInRange(port: number, permission: IpPermission): boolean {
+  if (permission.IpProtocol === '-1') return true; // all ports
+  const from = permission.FromPort ?? -1;
+  const to = permission.ToPort ?? -1;
+  return port >= from && port <= to;
+}
+
+function matchedRulesFor(group: SecurityGroup): string[] {
+  const matches: string[] = [];
+  for (const permission of group.IpPermissions ?? []) {
+    const openToInternet =
+      (permission.IpRanges ?? []).some((r) => r.CidrIp === OPEN_IPV4) ||
+      (permission.Ipv6Ranges ?? []).some((r) => r.CidrIpv6 === OPEN_IPV6);
+    if (!openToInternet) continue;
+    for (const { port, label } of SENSITIVE_PORTS) {
+      if (portInRange(port, permission)) matches.push(`${port}/${label} from 0.0.0.0/0`);
+    }
+  }
+  return [...new Set(matches)];
+}
+
+/** Detects EC2 security groups with an ingress rule open to the internet on a commonly-attacked port. */
+export class AwsEc2SecurityGroupOpenIngressScanner implements ResourceSecurityScannerPort {
+  readonly kind = 'ec2-security-group-open-ingress' as const;
+
+  constructor(
+    private readonly accountId = 'unknown',
+    private readonly policy = new Ec2SecurityGroupOpenIngressPolicy(),
+  ) {}
+
+  async scan(region: AwsRegion): Promise<Result<SecurityFinding[]>> {
+    const client = new EC2Client({ ...createAwsClientConfig(), region: region.code });
+    try {
+      const rawGroups = await paginate<SecurityGroup>(async (cursor) => {
+        const r = await client.send(new DescribeSecurityGroupsCommand({ NextToken: cursor }));
+        return { items: r.SecurityGroups ?? [], cursor: r.NextToken };
+      });
+
+      const now = new Date();
+      const validGroups = rawGroups.filter((g): g is SecurityGroupWithId => !!g.GroupId && !!g.GroupName);
+
+      const results = validGroups
+        .map((g) => ({ group: g, matchedRules: matchedRulesFor(g) }))
+        .filter(({ matchedRules }) => matchedRules.length > 0)
+        .map(
+          ({ group, matchedRules }) =>
+            new Ec2SecurityGroupOpenIngress({
+              groupId: group.GroupId,
+              groupName: group.GroupName,
+              region,
+              accountId: this.accountId,
+              matchedRules,
+              detectedAt: now,
+              tags: Object.fromEntries((group.Tags ?? []).map((t) => [t.Key ?? '', t.Value ?? ''])),
+            }),
+        )
+        .filter((finding) => this.policy.evaluate(finding, now).flagged);
+
+      return Result.ok(results);
+    } catch (err) {
+      return Result.fail(new AwsAdapterError('EC2', err as Error));
+    } finally {
+      client.destroy();
+    }
+  }
+}

--- a/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-ec2-snapshot-public.scanner.spec.ts
+++ b/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-ec2-snapshot-public.scanner.spec.ts
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+import { EC2Client, DescribeSnapshotsCommand, DescribeSnapshotAttributeCommand } from '@aws-sdk/client-ec2';
+import { AwsEc2SnapshotPublicScanner } from './aws-ec2-snapshot-public.scanner';
+import { AwsRegion } from 'resource-security-domain';
+import { AwsAdapterError } from '../errors/aws-adapter.error';
+
+jest.mock('@aws-sdk/client-ec2');
+
+const mockSend = jest.fn();
+const mockDestroy = jest.fn();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (EC2Client as jest.Mock).mockImplementation(() => ({ send: mockSend, destroy: mockDestroy }));
+});
+
+const region = AwsRegion.create('us-east-1');
+const scanner = new AwsEc2SnapshotPublicScanner();
+
+describe('AwsEc2SnapshotPublicScanner', () => {
+  it('exposes its resource kind', () => {
+    expect(scanner.kind).toBe('ec2-snapshot-public');
+  });
+
+  it('flags a snapshot with createVolumePermission granted to "all"', async () => {
+    mockSend.mockImplementation((command: unknown) => {
+      if (command instanceof DescribeSnapshotsCommand) return Promise.resolve({ Snapshots: [{ SnapshotId: 'snap-1', VolumeId: 'vol-1' }] });
+      if (command instanceof DescribeSnapshotAttributeCommand) return Promise.resolve({ CreateVolumePermissions: [{ Group: 'all' }] });
+      throw new Error('unexpected command');
+    });
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value.map((f) => f.id)).toEqual(['snap-1']);
+  });
+
+  it('does not flag a private snapshot', async () => {
+    mockSend.mockImplementation((command: unknown) => {
+      if (command instanceof DescribeSnapshotsCommand) return Promise.resolve({ Snapshots: [{ SnapshotId: 'snap-2', VolumeId: 'vol-2' }] });
+      if (command instanceof DescribeSnapshotAttributeCommand) return Promise.resolve({ CreateVolumePermissions: [] });
+      throw new Error('unexpected command');
+    });
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toHaveLength(0);
+  });
+
+  it('returns Result.fail wrapping AwsAdapterError on SDK error and destroys the client', async () => {
+    mockSend.mockRejectedValueOnce(new Error('AccessDenied'));
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toBeInstanceOf(AwsAdapterError);
+    expect(mockDestroy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-ec2-snapshot-public.scanner.ts
+++ b/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-ec2-snapshot-public.scanner.ts
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+import { EC2Client, DescribeSnapshotsCommand, DescribeSnapshotAttributeCommand, type Snapshot } from '@aws-sdk/client-ec2';
+import { Result } from 'shared-kernel';
+import type { AwsRegion, ResourceSecurityScannerPort, SecurityFinding } from 'resource-security-domain';
+import { Ec2SnapshotPublic, Ec2SnapshotPublicPolicy } from 'resource-security-domain';
+import { AwsAdapterError } from '../errors/aws-adapter.error';
+import { paginate } from '../utils/paginate';
+import { mapWithConcurrency } from '../utils/map-with-concurrency';
+import { createAwsClientConfig } from '../utils/client-config';
+
+/** Per-snapshot `DescribeSnapshotAttribute` calls in flight at once. */
+const SNAPSHOT_CHECK_CONCURRENCY = 8;
+const PUBLIC_GROUP = 'all';
+
+type SnapshotWithId = Snapshot & { SnapshotId: string };
+
+/** Detects EBS snapshots with `createVolumePermission` granted to the `all` group. */
+export class AwsEc2SnapshotPublicScanner implements ResourceSecurityScannerPort {
+  readonly kind = 'ec2-snapshot-public' as const;
+
+  constructor(
+    private readonly accountId = 'unknown',
+    private readonly policy = new Ec2SnapshotPublicPolicy(),
+  ) {}
+
+  async scan(region: AwsRegion): Promise<Result<SecurityFinding[]>> {
+    const client = new EC2Client({ ...createAwsClientConfig(), region: region.code });
+    try {
+      const rawSnapshots = await paginate<Snapshot>(async (cursor) => {
+        const r = await client.send(new DescribeSnapshotsCommand({ OwnerIds: ['self'], NextToken: cursor }));
+        return { items: r.Snapshots ?? [], cursor: r.NextToken };
+      });
+      const validSnapshots = rawSnapshots.filter((s): s is SnapshotWithId => !!s.SnapshotId);
+      const now = new Date();
+
+      const candidates = await mapWithConcurrency(validSnapshots, SNAPSHOT_CHECK_CONCURRENCY, async (snapshot) => {
+        const { CreateVolumePermissions } = await client.send(
+          new DescribeSnapshotAttributeCommand({ SnapshotId: snapshot.SnapshotId, Attribute: 'createVolumePermission' }),
+        );
+        const isPublic = (CreateVolumePermissions ?? []).some((p) => p.Group === PUBLIC_GROUP);
+        if (!isPublic) return undefined;
+        return new Ec2SnapshotPublic({
+          snapshotId: snapshot.SnapshotId,
+          volumeId: snapshot.VolumeId ?? 'unknown',
+          region,
+          accountId: this.accountId,
+          detectedAt: now,
+          tags: Object.fromEntries((snapshot.Tags ?? []).map((t) => [t.Key ?? '', t.Value ?? ''])),
+        });
+      });
+
+      const results = candidates
+        .filter((c): c is Ec2SnapshotPublic => c !== undefined)
+        .filter((c) => this.policy.evaluate(c, now).flagged);
+
+      return Result.ok(results);
+    } catch (err) {
+      return Result.fail(new AwsAdapterError('EC2', err as Error));
+    } finally {
+      client.destroy();
+    }
+  }
+}

--- a/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-ec2-volume-unencrypted.scanner.spec.ts
+++ b/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-ec2-volume-unencrypted.scanner.spec.ts
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+import { EC2Client, DescribeVolumesCommand } from '@aws-sdk/client-ec2';
+import { AwsEc2VolumeUnencryptedScanner } from './aws-ec2-volume-unencrypted.scanner';
+import { AwsRegion } from 'resource-security-domain';
+import { AwsAdapterError } from '../errors/aws-adapter.error';
+
+jest.mock('@aws-sdk/client-ec2');
+
+const mockSend = jest.fn();
+const mockDestroy = jest.fn();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (EC2Client as jest.Mock).mockImplementation(() => ({ send: mockSend, destroy: mockDestroy }));
+});
+
+const region = AwsRegion.create('us-east-1');
+const scanner = new AwsEc2VolumeUnencryptedScanner();
+
+describe('AwsEc2VolumeUnencryptedScanner', () => {
+  it('exposes its resource kind', () => {
+    expect(scanner.kind).toBe('ec2-volume-unencrypted');
+  });
+
+  it('flags an unencrypted volume', async () => {
+    mockSend.mockResolvedValueOnce({ Volumes: [{ VolumeId: 'vol-1', Encrypted: false }] });
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value.map((f) => f.id)).toEqual(['vol-1']);
+  });
+
+  it('does not flag an encrypted volume', async () => {
+    mockSend.mockResolvedValueOnce({ Volumes: [{ VolumeId: 'vol-2', Encrypted: true }] });
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toHaveLength(0);
+  });
+
+  it('sends DescribeVolumesCommand', async () => {
+    mockSend.mockResolvedValueOnce({ Volumes: [] });
+
+    await scanner.scan(region);
+
+    expect(mockSend).toHaveBeenCalledWith(expect.any(DescribeVolumesCommand));
+  });
+
+  it('returns Result.fail wrapping AwsAdapterError on SDK error and destroys the client', async () => {
+    mockSend.mockRejectedValueOnce(new Error('AccessDenied'));
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toBeInstanceOf(AwsAdapterError);
+    expect(mockDestroy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-ec2-volume-unencrypted.scanner.ts
+++ b/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-ec2-volume-unencrypted.scanner.ts
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+import { EC2Client, DescribeVolumesCommand, type Volume } from '@aws-sdk/client-ec2';
+import { Result } from 'shared-kernel';
+import type { AwsRegion, ResourceSecurityScannerPort, SecurityFinding } from 'resource-security-domain';
+import { Ec2VolumeUnencrypted, Ec2VolumeUnencryptedPolicy } from 'resource-security-domain';
+import { AwsAdapterError } from '../errors/aws-adapter.error';
+import { paginate } from '../utils/paginate';
+import { createAwsClientConfig } from '../utils/client-config';
+
+type VolumeWithId = Volume & { VolumeId: string };
+
+/** Detects EBS volumes not encrypted at rest (CIS AWS Foundations 2.2.1). */
+export class AwsEc2VolumeUnencryptedScanner implements ResourceSecurityScannerPort {
+  readonly kind = 'ec2-volume-unencrypted' as const;
+
+  constructor(
+    private readonly accountId = 'unknown',
+    private readonly policy = new Ec2VolumeUnencryptedPolicy(),
+  ) {}
+
+  async scan(region: AwsRegion): Promise<Result<SecurityFinding[]>> {
+    const client = new EC2Client({ ...createAwsClientConfig(), region: region.code });
+    try {
+      const rawVolumes = await paginate<Volume>(async (cursor) => {
+        const r = await client.send(new DescribeVolumesCommand({ NextToken: cursor }));
+        return { items: r.Volumes ?? [], cursor: r.NextToken };
+      });
+
+      const now = new Date();
+      const validVolumes = rawVolumes.filter((v): v is VolumeWithId => !!v.VolumeId);
+
+      const results = validVolumes
+        .filter((v) => v.Encrypted !== true)
+        .map(
+          (v) =>
+            new Ec2VolumeUnencrypted({
+              volumeId: v.VolumeId,
+              region,
+              accountId: this.accountId,
+              detectedAt: now,
+              tags: Object.fromEntries((v.Tags ?? []).map((t) => [t.Key ?? '', t.Value ?? ''])),
+            }),
+        )
+        .filter((finding) => this.policy.evaluate(finding, now).flagged);
+
+      return Result.ok(results);
+    } catch (err) {
+      return Result.fail(new AwsAdapterError('EC2', err as Error));
+    } finally {
+      client.destroy();
+    }
+  }
+}

--- a/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-iam-access-key-rotation-overdue.scanner.spec.ts
+++ b/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-iam-access-key-rotation-overdue.scanner.spec.ts
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: Apache-2.0
+import { IAMClient, ListUsersCommand, ListAccessKeysCommand } from '@aws-sdk/client-iam';
+import { AwsIamAccessKeyRotationOverdueScanner } from './aws-iam-access-key-rotation-overdue.scanner';
+import { AwsRegion } from 'resource-security-domain';
+import { AwsAdapterError } from '../errors/aws-adapter.error';
+
+jest.mock('@aws-sdk/client-iam');
+
+const mockSend = jest.fn();
+const mockDestroy = jest.fn();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (IAMClient as jest.Mock).mockImplementation(() => ({ send: mockSend, destroy: mockDestroy }));
+});
+
+const region = AwsRegion.create('us-east-1');
+const scanner = new AwsIamAccessKeyRotationOverdueScanner();
+const oldDate = new Date(Date.now() - 200 * 24 * 60 * 60 * 1000);
+const recentDate = new Date();
+
+describe('AwsIamAccessKeyRotationOverdueScanner', () => {
+  it('exposes its resource kind and global scope', () => {
+    expect(scanner.kind).toBe('iam-access-key-rotation-overdue');
+    expect(scanner.scope).toBe('global');
+  });
+
+  it('flags an active access key older than the rotation window', async () => {
+    mockSend.mockImplementation((command: unknown) => {
+      if (command instanceof ListUsersCommand) return Promise.resolve({ Users: [{ UserName: 'alice' }] });
+      if (command instanceof ListAccessKeysCommand) {
+        return Promise.resolve({
+          AccessKeyMetadata: [{ AccessKeyId: 'AKIA1', UserName: 'alice', CreateDate: oldDate, Status: 'Active' }],
+        });
+      }
+      throw new Error('unexpected command');
+    });
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value.map((f) => f.id)).toEqual(['AKIA1']);
+  });
+
+  it('does not flag a recently created key', async () => {
+    mockSend.mockImplementation((command: unknown) => {
+      if (command instanceof ListUsersCommand) return Promise.resolve({ Users: [{ UserName: 'alice' }] });
+      if (command instanceof ListAccessKeysCommand) {
+        return Promise.resolve({
+          AccessKeyMetadata: [{ AccessKeyId: 'AKIA2', UserName: 'alice', CreateDate: recentDate, Status: 'Active' }],
+        });
+      }
+      throw new Error('unexpected command');
+    });
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toHaveLength(0);
+  });
+
+  it('does not flag an inactive key', async () => {
+    mockSend.mockImplementation((command: unknown) => {
+      if (command instanceof ListUsersCommand) return Promise.resolve({ Users: [{ UserName: 'alice' }] });
+      if (command instanceof ListAccessKeysCommand) {
+        return Promise.resolve({
+          AccessKeyMetadata: [{ AccessKeyId: 'AKIA3', UserName: 'alice', CreateDate: oldDate, Status: 'Inactive' }],
+        });
+      }
+      throw new Error('unexpected command');
+    });
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toHaveLength(0);
+  });
+
+  it('returns Result.fail wrapping AwsAdapterError on SDK error and destroys the client', async () => {
+    mockSend.mockRejectedValueOnce(new Error('AccessDenied'));
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toBeInstanceOf(AwsAdapterError);
+    expect(mockDestroy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-iam-access-key-rotation-overdue.scanner.ts
+++ b/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-iam-access-key-rotation-overdue.scanner.ts
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+import { IAMClient, ListUsersCommand, ListAccessKeysCommand, type User, type AccessKeyMetadata } from '@aws-sdk/client-iam';
+import { Result } from 'shared-kernel';
+import type { AwsRegion, ResourceSecurityScannerPort, SecurityFinding } from 'resource-security-domain';
+import { IamAccessKeyRotationOverdue, IamAccessKeyRotationOverduePolicy } from 'resource-security-domain';
+import { AwsAdapterError } from '../errors/aws-adapter.error';
+import { paginate } from '../utils/paginate';
+import { mapWithConcurrency } from '../utils/map-with-concurrency';
+import { createAwsClientConfig } from '../utils/client-config';
+
+const IAM_ENDPOINT_REGION = 'us-east-1';
+/** Per-user `ListAccessKeysCommand` calls in flight at once. */
+const USER_CHECK_CONCURRENCY = 8;
+
+type UserWithName = User & { UserName: string };
+type KeyWithId = AccessKeyMetadata & { AccessKeyId: string; UserName: string; CreateDate: Date };
+
+/** Detects active IAM access keys older than the rotation policy (CIS AWS Foundations 1.14, default 90d). `scope: 'global'`. */
+export class AwsIamAccessKeyRotationOverdueScanner implements ResourceSecurityScannerPort {
+  readonly kind = 'iam-access-key-rotation-overdue' as const;
+  readonly scope = 'global' as const;
+
+  constructor(
+    private readonly accountId = 'unknown',
+    private readonly policy = new IamAccessKeyRotationOverduePolicy(),
+  ) {}
+
+  async scan(_region: AwsRegion): Promise<Result<SecurityFinding[]>> {
+    const client = new IAMClient({ ...createAwsClientConfig(), region: IAM_ENDPOINT_REGION });
+    try {
+      const rawUsers = await paginate<User>(async (cursor) => {
+        const r = await client.send(new ListUsersCommand({ Marker: cursor }));
+        return { items: r.Users ?? [], cursor: r.Marker };
+      });
+      const validUsers = rawUsers.filter((u): u is UserWithName => !!u.UserName);
+
+      const keysByUser = await mapWithConcurrency(validUsers, USER_CHECK_CONCURRENCY, async (user) => {
+        const { AccessKeyMetadata: keys } = await client.send(new ListAccessKeysCommand({ UserName: user.UserName }));
+        return (keys ?? []).filter(
+          (k): k is KeyWithId => !!k.AccessKeyId && !!k.UserName && !!k.CreateDate && k.Status === 'Active',
+        );
+      });
+
+      const now = new Date();
+      const results = keysByUser
+        .flat()
+        .map(
+          (key) =>
+            new IamAccessKeyRotationOverdue({
+              accessKeyId: key.AccessKeyId,
+              userName: key.UserName,
+              accountId: this.accountId,
+              createdAt: key.CreateDate,
+              detectedAt: now,
+              tags: {},
+            }),
+        )
+        .filter((finding) => this.policy.evaluate(finding, now).flagged);
+
+      return Result.ok(results);
+    } catch (err) {
+      return Result.fail(new AwsAdapterError('IAM', err as Error));
+    } finally {
+      client.destroy();
+    }
+  }
+}

--- a/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-iam-password-policy-weak.scanner.spec.ts
+++ b/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-iam-password-policy-weak.scanner.spec.ts
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+import { IAMClient } from '@aws-sdk/client-iam';
+import { AwsIamPasswordPolicyWeakScanner } from './aws-iam-password-policy-weak.scanner';
+import { AwsRegion } from 'resource-security-domain';
+import { AwsAdapterError } from '../errors/aws-adapter.error';
+
+jest.mock('@aws-sdk/client-iam');
+
+const mockSend = jest.fn();
+const mockDestroy = jest.fn();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (IAMClient as jest.Mock).mockImplementation(() => ({ send: mockSend, destroy: mockDestroy }));
+});
+
+const region = AwsRegion.create('us-east-1');
+const scanner = new AwsIamPasswordPolicyWeakScanner();
+
+const strongPolicy = {
+  MinimumPasswordLength: 14,
+  RequireSymbols: true,
+  RequireNumbers: true,
+  RequireUppercaseCharacters: true,
+  RequireLowercaseCharacters: true,
+  MaxPasswordAge: 90,
+  PasswordReusePrevention: 24,
+};
+
+describe('AwsIamPasswordPolicyWeakScanner', () => {
+  it('exposes its resource kind and global scope', () => {
+    expect(scanner.kind).toBe('iam-password-policy-weak');
+    expect(scanner.scope).toBe('global');
+  });
+
+  it('flags when no password policy exists', async () => {
+    mockSend.mockRejectedValueOnce(Object.assign(new Error('no policy'), { name: 'NoSuchEntityException' }));
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toHaveLength(1);
+  });
+
+  it('flags a policy weaker than the CIS baseline', async () => {
+    mockSend.mockResolvedValueOnce({ PasswordPolicy: { ...strongPolicy, MinimumPasswordLength: 8 } });
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toHaveLength(1);
+  });
+
+  it('does not flag a policy meeting the CIS baseline', async () => {
+    mockSend.mockResolvedValueOnce({ PasswordPolicy: strongPolicy });
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toHaveLength(0);
+  });
+
+  it('returns Result.fail on an unexpected SDK error and destroys the client', async () => {
+    mockSend.mockRejectedValueOnce(new Error('Throttled'));
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toBeInstanceOf(AwsAdapterError);
+    expect(mockDestroy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-iam-password-policy-weak.scanner.ts
+++ b/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-iam-password-policy-weak.scanner.ts
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+import { IAMClient, GetAccountPasswordPolicyCommand } from '@aws-sdk/client-iam';
+import { Result } from 'shared-kernel';
+import type { AwsRegion, ResourceSecurityScannerPort, SecurityFinding } from 'resource-security-domain';
+import { IamPasswordPolicyWeak, IamPasswordPolicyWeakPolicy } from 'resource-security-domain';
+import { AwsAdapterError } from '../errors/aws-adapter.error';
+import { createAwsClientConfig } from '../utils/client-config';
+
+const IAM_ENDPOINT_REGION = 'us-east-1';
+
+/** AWS's own name for "no password policy configured at all". */
+const NO_POLICY_ERROR_NAME = 'NoSuchEntityException';
+
+/** Detects a missing or CIS-baseline-violating account password policy (CIS AWS Foundations 1.8/1.9). `scope: 'global'`. */
+export class AwsIamPasswordPolicyWeakScanner implements ResourceSecurityScannerPort {
+  readonly kind = 'iam-password-policy-weak' as const;
+  readonly scope = 'global' as const;
+
+  constructor(
+    private readonly accountId = 'unknown',
+    private readonly policy = new IamPasswordPolicyWeakPolicy(),
+  ) {}
+
+  async scan(_region: AwsRegion): Promise<Result<SecurityFinding[]>> {
+    const client = new IAMClient({ ...createAwsClientConfig(), region: IAM_ENDPOINT_REGION });
+    try {
+      const now = new Date();
+      let finding: IamPasswordPolicyWeak;
+      try {
+        const { PasswordPolicy: p } = await client.send(new GetAccountPasswordPolicyCommand({}));
+        finding = new IamPasswordPolicyWeak({
+          accountId: this.accountId,
+          exists: true,
+          minimumPasswordLength: p?.MinimumPasswordLength,
+          requireSymbols: p?.RequireSymbols,
+          requireNumbers: p?.RequireNumbers,
+          requireUppercaseCharacters: p?.RequireUppercaseCharacters,
+          requireLowercaseCharacters: p?.RequireLowercaseCharacters,
+          maxPasswordAge: p?.MaxPasswordAge,
+          passwordReusePrevention: p?.PasswordReusePrevention,
+          detectedAt: now,
+          tags: {},
+        });
+      } catch (err) {
+        if ((err as Error).name !== NO_POLICY_ERROR_NAME) throw err;
+        finding = new IamPasswordPolicyWeak({ accountId: this.accountId, exists: false, detectedAt: now, tags: {} });
+      }
+
+      return Result.ok(this.policy.evaluate(finding, now).flagged ? [finding] : []);
+    } catch (err) {
+      return Result.fail(new AwsAdapterError('IAM', err as Error));
+    } finally {
+      client.destroy();
+    }
+  }
+}

--- a/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-iam-root-access-key-active.scanner.spec.ts
+++ b/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-iam-root-access-key-active.scanner.spec.ts
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+import { IAMClient } from '@aws-sdk/client-iam';
+import { AwsIamRootAccessKeyActiveScanner } from './aws-iam-root-access-key-active.scanner';
+import { AwsRegion } from 'resource-security-domain';
+import { AwsAdapterError } from '../errors/aws-adapter.error';
+
+jest.mock('@aws-sdk/client-iam');
+
+const mockSend = jest.fn();
+const mockDestroy = jest.fn();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (IAMClient as jest.Mock).mockImplementation(() => ({ send: mockSend, destroy: mockDestroy }));
+});
+
+const region = AwsRegion.create('us-east-1');
+const scanner = new AwsIamRootAccessKeyActiveScanner();
+
+describe('AwsIamRootAccessKeyActiveScanner', () => {
+  it('exposes its resource kind and global scope', () => {
+    expect(scanner.kind).toBe('iam-root-access-key-active');
+    expect(scanner.scope).toBe('global');
+  });
+
+  it('flags when the root account has active access keys', async () => {
+    mockSend.mockResolvedValueOnce({ SummaryMap: { AccountAccessKeysPresent: 1 } });
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toHaveLength(1);
+  });
+
+  it('does not flag when the root account has no access keys', async () => {
+    mockSend.mockResolvedValueOnce({ SummaryMap: { AccountAccessKeysPresent: 0 } });
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toHaveLength(0);
+  });
+
+  it('returns Result.fail wrapping AwsAdapterError on SDK error and destroys the client', async () => {
+    mockSend.mockRejectedValueOnce(new Error('AccessDenied'));
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toBeInstanceOf(AwsAdapterError);
+    expect(mockDestroy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-iam-root-access-key-active.scanner.ts
+++ b/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-iam-root-access-key-active.scanner.ts
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+import { IAMClient, GetAccountSummaryCommand } from '@aws-sdk/client-iam';
+import { Result } from 'shared-kernel';
+import type { AwsRegion, ResourceSecurityScannerPort, SecurityFinding } from 'resource-security-domain';
+import { IamRootAccessKeyActive, IamRootAccessKeyActivePolicy } from 'resource-security-domain';
+import { AwsAdapterError } from '../errors/aws-adapter.error';
+import { createAwsClientConfig } from '../utils/client-config';
+
+const IAM_ENDPOINT_REGION = 'us-east-1';
+
+/** Detects whether the account's root user has at least one active access key (CIS AWS Foundations 1.4). `scope: 'global'`. */
+export class AwsIamRootAccessKeyActiveScanner implements ResourceSecurityScannerPort {
+  readonly kind = 'iam-root-access-key-active' as const;
+  readonly scope = 'global' as const;
+
+  constructor(
+    private readonly accountId = 'unknown',
+    private readonly policy = new IamRootAccessKeyActivePolicy(),
+  ) {}
+
+  async scan(_region: AwsRegion): Promise<Result<SecurityFinding[]>> {
+    const client = new IAMClient({ ...createAwsClientConfig(), region: IAM_ENDPOINT_REGION });
+    try {
+      const { SummaryMap } = await client.send(new GetAccountSummaryCommand({}));
+      const now = new Date();
+      const finding = new IamRootAccessKeyActive({
+        accountId: this.accountId,
+        accessKeysPresent: SummaryMap?.AccountAccessKeysPresent === 1,
+        detectedAt: now,
+        tags: {},
+      });
+
+      return Result.ok(this.policy.evaluate(finding, now).flagged ? [finding] : []);
+    } catch (err) {
+      return Result.fail(new AwsAdapterError('IAM', err as Error));
+    } finally {
+      client.destroy();
+    }
+  }
+}

--- a/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-iam-root-mfa-disabled.scanner.spec.ts
+++ b/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-iam-root-mfa-disabled.scanner.spec.ts
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+import { IAMClient, GetAccountSummaryCommand } from '@aws-sdk/client-iam';
+import { AwsIamRootMfaDisabledScanner } from './aws-iam-root-mfa-disabled.scanner';
+import { AwsRegion } from 'resource-security-domain';
+import { AwsAdapterError } from '../errors/aws-adapter.error';
+
+jest.mock('@aws-sdk/client-iam');
+
+const mockSend = jest.fn();
+const mockDestroy = jest.fn();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (IAMClient as jest.Mock).mockImplementation(() => ({ send: mockSend, destroy: mockDestroy }));
+});
+
+const region = AwsRegion.create('us-east-1');
+const scanner = new AwsIamRootMfaDisabledScanner();
+
+describe('AwsIamRootMfaDisabledScanner', () => {
+  it('exposes its resource kind and global scope', () => {
+    expect(scanner.kind).toBe('iam-root-mfa-disabled');
+    expect(scanner.scope).toBe('global');
+  });
+
+  it('flags when root MFA is disabled', async () => {
+    mockSend.mockResolvedValueOnce({ SummaryMap: { AccountMFAEnabled: 0 } });
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toHaveLength(1);
+  });
+
+  it('does not flag when root MFA is enabled', async () => {
+    mockSend.mockResolvedValueOnce({ SummaryMap: { AccountMFAEnabled: 1 } });
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toHaveLength(0);
+  });
+
+  it('sends GetAccountSummaryCommand', async () => {
+    mockSend.mockResolvedValueOnce({ SummaryMap: { AccountMFAEnabled: 1 } });
+
+    await scanner.scan(region);
+
+    expect(mockSend).toHaveBeenCalledWith(expect.any(GetAccountSummaryCommand));
+  });
+
+  it('returns Result.fail wrapping AwsAdapterError on SDK error and destroys the client', async () => {
+    mockSend.mockRejectedValueOnce(new Error('AccessDenied'));
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toBeInstanceOf(AwsAdapterError);
+    expect(mockDestroy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-iam-root-mfa-disabled.scanner.ts
+++ b/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-iam-root-mfa-disabled.scanner.ts
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+import { IAMClient, GetAccountSummaryCommand } from '@aws-sdk/client-iam';
+import { Result } from 'shared-kernel';
+import type { AwsRegion, ResourceSecurityScannerPort, SecurityFinding } from 'resource-security-domain';
+import { IamRootMfaDisabled, IamRootMfaDisabledPolicy } from 'resource-security-domain';
+import { AwsAdapterError } from '../errors/aws-adapter.error';
+import { createAwsClientConfig } from '../utils/client-config';
+
+/** IAM has a single global endpoint — always sign against this region, never the one `scan()` receives. */
+const IAM_ENDPOINT_REGION = 'us-east-1';
+
+/**
+ * Detects whether the account's root user has no MFA device enrolled
+ * (CIS AWS Foundations 1.5/1.6). `scope: 'global'` — IAM has no per-region
+ * data.
+ */
+export class AwsIamRootMfaDisabledScanner implements ResourceSecurityScannerPort {
+  readonly kind = 'iam-root-mfa-disabled' as const;
+  readonly scope = 'global' as const;
+
+  constructor(
+    private readonly accountId = 'unknown',
+    private readonly policy = new IamRootMfaDisabledPolicy(),
+  ) {}
+
+  async scan(_region: AwsRegion): Promise<Result<SecurityFinding[]>> {
+    const client = new IAMClient({ ...createAwsClientConfig(), region: IAM_ENDPOINT_REGION });
+    try {
+      const { SummaryMap } = await client.send(new GetAccountSummaryCommand({}));
+      const now = new Date();
+      const finding = new IamRootMfaDisabled({
+        accountId: this.accountId,
+        mfaEnabled: SummaryMap?.AccountMFAEnabled === 1,
+        detectedAt: now,
+        tags: {},
+      });
+
+      return Result.ok(this.policy.evaluate(finding, now).flagged ? [finding] : []);
+    } catch (err) {
+      return Result.fail(new AwsAdapterError('IAM', err as Error));
+    } finally {
+      client.destroy();
+    }
+  }
+}

--- a/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-iam-user-mfa-disabled.scanner.spec.ts
+++ b/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-iam-user-mfa-disabled.scanner.spec.ts
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+import { IAMClient, ListUsersCommand, ListMFADevicesCommand } from '@aws-sdk/client-iam';
+import { AwsIamUserMfaDisabledScanner } from './aws-iam-user-mfa-disabled.scanner';
+import { AwsRegion } from 'resource-security-domain';
+import { AwsAdapterError } from '../errors/aws-adapter.error';
+
+jest.mock('@aws-sdk/client-iam');
+
+const mockSend = jest.fn();
+const mockDestroy = jest.fn();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (IAMClient as jest.Mock).mockImplementation(() => ({ send: mockSend, destroy: mockDestroy }));
+});
+
+const region = AwsRegion.create('us-east-1');
+const scanner = new AwsIamUserMfaDisabledScanner();
+const createdAt = new Date('2024-01-01');
+
+function makeUser(userName: string) {
+  return { UserName: userName, Arn: `arn:aws:iam::123:user/${userName}`, CreateDate: createdAt };
+}
+
+describe('AwsIamUserMfaDisabledScanner', () => {
+  it('exposes its resource kind and global scope', () => {
+    expect(scanner.kind).toBe('iam-user-mfa-disabled');
+    expect(scanner.scope).toBe('global');
+  });
+
+  it('flags a user with no MFA device', async () => {
+    mockSend.mockImplementation((command: unknown) => {
+      if (command instanceof ListUsersCommand) return Promise.resolve({ Users: [makeUser('alice')] });
+      if (command instanceof ListMFADevicesCommand) return Promise.resolve({ MFADevices: [] });
+      throw new Error('unexpected command');
+    });
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value.map((f) => f.id)).toEqual(['arn:aws:iam::123:user/alice']);
+  });
+
+  it('does not flag a user with an MFA device registered', async () => {
+    mockSend.mockImplementation((command: unknown) => {
+      if (command instanceof ListUsersCommand) return Promise.resolve({ Users: [makeUser('alice')] });
+      if (command instanceof ListMFADevicesCommand) return Promise.resolve({ MFADevices: [{ SerialNumber: 'mfa-1' }] });
+      throw new Error('unexpected command');
+    });
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toHaveLength(0);
+  });
+
+  it('returns Result.fail wrapping AwsAdapterError on SDK error and destroys the client', async () => {
+    mockSend.mockRejectedValueOnce(new Error('AccessDenied'));
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toBeInstanceOf(AwsAdapterError);
+    expect(mockDestroy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-iam-user-mfa-disabled.scanner.ts
+++ b/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-iam-user-mfa-disabled.scanner.ts
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+import { IAMClient, ListUsersCommand, ListMFADevicesCommand, type User } from '@aws-sdk/client-iam';
+import { Result } from 'shared-kernel';
+import type { AwsRegion, ResourceSecurityScannerPort, SecurityFinding } from 'resource-security-domain';
+import { IamUserMfaDisabled, IamUserMfaDisabledPolicy } from 'resource-security-domain';
+import { AwsAdapterError } from '../errors/aws-adapter.error';
+import { paginate } from '../utils/paginate';
+import { mapWithConcurrency } from '../utils/map-with-concurrency';
+import { createAwsClientConfig } from '../utils/client-config';
+
+const IAM_ENDPOINT_REGION = 'us-east-1';
+/** Per-user `ListMFADevicesCommand` calls in flight at once. */
+const USER_CHECK_CONCURRENCY = 8;
+
+type UserWithName = User & { UserName: string; Arn: string; CreateDate: Date };
+
+/** Detects IAM users with no MFA device registered (CIS AWS Foundations 1.10). `scope: 'global'`. */
+export class AwsIamUserMfaDisabledScanner implements ResourceSecurityScannerPort {
+  readonly kind = 'iam-user-mfa-disabled' as const;
+  readonly scope = 'global' as const;
+
+  constructor(
+    private readonly accountId = 'unknown',
+    private readonly policy = new IamUserMfaDisabledPolicy(),
+  ) {}
+
+  async scan(_region: AwsRegion): Promise<Result<SecurityFinding[]>> {
+    const client = new IAMClient({ ...createAwsClientConfig(), region: IAM_ENDPOINT_REGION });
+    try {
+      const rawUsers = await paginate<User>(async (cursor) => {
+        const r = await client.send(new ListUsersCommand({ Marker: cursor }));
+        return { items: r.Users ?? [], cursor: r.Marker };
+      });
+
+      const validUsers = rawUsers.filter((u): u is UserWithName => !!u.UserName && !!u.Arn && !!u.CreateDate);
+      const now = new Date();
+
+      const candidates = await mapWithConcurrency(validUsers, USER_CHECK_CONCURRENCY, async (user) => {
+        const { MFADevices } = await client.send(new ListMFADevicesCommand({ UserName: user.UserName }));
+        if ((MFADevices ?? []).length > 0) return undefined;
+        return new IamUserMfaDisabled({
+          userName: user.UserName,
+          arn: user.Arn,
+          accountId: this.accountId,
+          createdAt: user.CreateDate,
+          detectedAt: now,
+          tags: Object.fromEntries((user.Tags ?? []).map((t) => [t.Key ?? '', t.Value ?? ''])),
+        });
+      });
+
+      const results = candidates
+        .filter((c): c is IamUserMfaDisabled => c !== undefined)
+        .filter((c) => this.policy.evaluate(c, now).flagged);
+
+      return Result.ok(results);
+    } catch (err) {
+      return Result.fail(new AwsAdapterError('IAM', err as Error));
+    } finally {
+      client.destroy();
+    }
+  }
+}

--- a/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-rds-instance-publicly-accessible.scanner.spec.ts
+++ b/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-rds-instance-publicly-accessible.scanner.spec.ts
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+import { RDSClient, DescribeDBInstancesCommand } from '@aws-sdk/client-rds';
+import { AwsRdsInstancePubliclyAccessibleScanner } from './aws-rds-instance-publicly-accessible.scanner';
+import { AwsRegion } from 'resource-security-domain';
+import { AwsAdapterError } from '../errors/aws-adapter.error';
+
+jest.mock('@aws-sdk/client-rds');
+
+const mockSend = jest.fn();
+const mockDestroy = jest.fn();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (RDSClient as jest.Mock).mockImplementation(() => ({ send: mockSend, destroy: mockDestroy }));
+});
+
+const region = AwsRegion.create('us-east-1');
+const scanner = new AwsRdsInstancePubliclyAccessibleScanner();
+
+describe('AwsRdsInstancePubliclyAccessibleScanner', () => {
+  it('exposes its resource kind', () => {
+    expect(scanner.kind).toBe('rds-instance-publicly-accessible');
+  });
+
+  it('flags a publicly accessible RDS instance', async () => {
+    mockSend.mockResolvedValueOnce({ DBInstances: [{ DBInstanceIdentifier: 'db-1', PubliclyAccessible: true }] });
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value.map((f) => f.id)).toEqual(['db-1']);
+  });
+
+  it('does not flag a private RDS instance', async () => {
+    mockSend.mockResolvedValueOnce({ DBInstances: [{ DBInstanceIdentifier: 'db-2', PubliclyAccessible: false }] });
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toHaveLength(0);
+  });
+
+  it('sends DescribeDBInstancesCommand', async () => {
+    mockSend.mockResolvedValueOnce({ DBInstances: [] });
+
+    await scanner.scan(region);
+
+    expect(mockSend).toHaveBeenCalledWith(expect.any(DescribeDBInstancesCommand));
+  });
+
+  it('returns Result.fail wrapping AwsAdapterError on SDK error and destroys the client', async () => {
+    mockSend.mockRejectedValueOnce(new Error('AccessDenied'));
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toBeInstanceOf(AwsAdapterError);
+    expect(mockDestroy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-rds-instance-publicly-accessible.scanner.ts
+++ b/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-rds-instance-publicly-accessible.scanner.ts
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+import { RDSClient, DescribeDBInstancesCommand, type DBInstance } from '@aws-sdk/client-rds';
+import { Result } from 'shared-kernel';
+import type { AwsRegion, ResourceSecurityScannerPort, SecurityFinding } from 'resource-security-domain';
+import { RdsInstancePubliclyAccessible, RdsInstancePubliclyAccessiblePolicy } from 'resource-security-domain';
+import { AwsAdapterError } from '../errors/aws-adapter.error';
+import { paginate } from '../utils/paginate';
+import { createAwsClientConfig } from '../utils/client-config';
+
+type DbInstanceWithId = DBInstance & { DBInstanceIdentifier: string };
+
+/** Detects RDS instances reachable from outside their VPC (CIS AWS Foundations 2.3.3). */
+export class AwsRdsInstancePubliclyAccessibleScanner implements ResourceSecurityScannerPort {
+  readonly kind = 'rds-instance-publicly-accessible' as const;
+
+  constructor(
+    private readonly accountId = 'unknown',
+    private readonly policy = new RdsInstancePubliclyAccessiblePolicy(),
+  ) {}
+
+  async scan(region: AwsRegion): Promise<Result<SecurityFinding[]>> {
+    const client = new RDSClient({ ...createAwsClientConfig(), region: region.code });
+    try {
+      const rawInstances = await paginate<DBInstance>(async (cursor) => {
+        const r = await client.send(new DescribeDBInstancesCommand({ Marker: cursor }));
+        return { items: r.DBInstances ?? [], cursor: r.Marker };
+      });
+
+      const now = new Date();
+      const validInstances = rawInstances.filter((i): i is DbInstanceWithId => !!i.DBInstanceIdentifier);
+
+      const results = validInstances
+        .filter((i) => i.PubliclyAccessible === true)
+        .map(
+          (i) =>
+            new RdsInstancePubliclyAccessible({
+              dbInstanceIdentifier: i.DBInstanceIdentifier,
+              region,
+              accountId: this.accountId,
+              detectedAt: now,
+              tags: Object.fromEntries((i.TagList ?? []).map((t) => [t.Key ?? '', t.Value ?? ''])),
+            }),
+        )
+        .filter((finding) => this.policy.evaluate(finding, now).flagged);
+
+      return Result.ok(results);
+    } catch (err) {
+      return Result.fail(new AwsAdapterError('RDS', err as Error));
+    } finally {
+      client.destroy();
+    }
+  }
+}

--- a/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-rds-instance-unencrypted.scanner.spec.ts
+++ b/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-rds-instance-unencrypted.scanner.spec.ts
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+import { RDSClient, DescribeDBInstancesCommand } from '@aws-sdk/client-rds';
+import { AwsRdsInstanceUnencryptedScanner } from './aws-rds-instance-unencrypted.scanner';
+import { AwsRegion } from 'resource-security-domain';
+import { AwsAdapterError } from '../errors/aws-adapter.error';
+
+jest.mock('@aws-sdk/client-rds');
+
+const mockSend = jest.fn();
+const mockDestroy = jest.fn();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (RDSClient as jest.Mock).mockImplementation(() => ({ send: mockSend, destroy: mockDestroy }));
+});
+
+const region = AwsRegion.create('us-east-1');
+const scanner = new AwsRdsInstanceUnencryptedScanner();
+
+describe('AwsRdsInstanceUnencryptedScanner', () => {
+  it('exposes its resource kind', () => {
+    expect(scanner.kind).toBe('rds-instance-unencrypted');
+  });
+
+  it('flags an unencrypted RDS instance', async () => {
+    mockSend.mockResolvedValueOnce({ DBInstances: [{ DBInstanceIdentifier: 'db-1', StorageEncrypted: false }] });
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value.map((f) => f.id)).toEqual(['db-1']);
+  });
+
+  it('does not flag an encrypted RDS instance', async () => {
+    mockSend.mockResolvedValueOnce({ DBInstances: [{ DBInstanceIdentifier: 'db-2', StorageEncrypted: true }] });
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toHaveLength(0);
+  });
+
+  it('sends DescribeDBInstancesCommand', async () => {
+    mockSend.mockResolvedValueOnce({ DBInstances: [] });
+
+    await scanner.scan(region);
+
+    expect(mockSend).toHaveBeenCalledWith(expect.any(DescribeDBInstancesCommand));
+  });
+
+  it('returns Result.fail wrapping AwsAdapterError on SDK error and destroys the client', async () => {
+    mockSend.mockRejectedValueOnce(new Error('AccessDenied'));
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toBeInstanceOf(AwsAdapterError);
+    expect(mockDestroy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-rds-instance-unencrypted.scanner.ts
+++ b/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-rds-instance-unencrypted.scanner.ts
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+import { RDSClient, DescribeDBInstancesCommand, type DBInstance } from '@aws-sdk/client-rds';
+import { Result } from 'shared-kernel';
+import type { AwsRegion, ResourceSecurityScannerPort, SecurityFinding } from 'resource-security-domain';
+import { RdsInstanceUnencrypted, RdsInstanceUnencryptedPolicy } from 'resource-security-domain';
+import { AwsAdapterError } from '../errors/aws-adapter.error';
+import { paginate } from '../utils/paginate';
+import { createAwsClientConfig } from '../utils/client-config';
+
+type DbInstanceWithId = DBInstance & { DBInstanceIdentifier: string };
+
+/** Detects RDS instances not encrypted at rest (CIS AWS Foundations 2.3.1). */
+export class AwsRdsInstanceUnencryptedScanner implements ResourceSecurityScannerPort {
+  readonly kind = 'rds-instance-unencrypted' as const;
+
+  constructor(
+    private readonly accountId = 'unknown',
+    private readonly policy = new RdsInstanceUnencryptedPolicy(),
+  ) {}
+
+  async scan(region: AwsRegion): Promise<Result<SecurityFinding[]>> {
+    const client = new RDSClient({ ...createAwsClientConfig(), region: region.code });
+    try {
+      const rawInstances = await paginate<DBInstance>(async (cursor) => {
+        const r = await client.send(new DescribeDBInstancesCommand({ Marker: cursor }));
+        return { items: r.DBInstances ?? [], cursor: r.Marker };
+      });
+
+      const now = new Date();
+      const validInstances = rawInstances.filter((i): i is DbInstanceWithId => !!i.DBInstanceIdentifier);
+
+      const results = validInstances
+        .filter((i) => i.StorageEncrypted !== true)
+        .map(
+          (i) =>
+            new RdsInstanceUnencrypted({
+              dbInstanceIdentifier: i.DBInstanceIdentifier,
+              region,
+              accountId: this.accountId,
+              detectedAt: now,
+              tags: Object.fromEntries((i.TagList ?? []).map((t) => [t.Key ?? '', t.Value ?? ''])),
+            }),
+        )
+        .filter((finding) => this.policy.evaluate(finding, now).flagged);
+
+      return Result.ok(results);
+    } catch (err) {
+      return Result.fail(new AwsAdapterError('RDS', err as Error));
+    } finally {
+      client.destroy();
+    }
+  }
+}

--- a/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-s3-bucket-encryption-missing.scanner.spec.ts
+++ b/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-s3-bucket-encryption-missing.scanner.spec.ts
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: Apache-2.0
+import { S3Client, ListBucketsCommand, GetBucketEncryptionCommand } from '@aws-sdk/client-s3';
+import { AwsS3BucketEncryptionMissingScanner } from './aws-s3-bucket-encryption-missing.scanner';
+import { AwsRegion } from 'resource-security-domain';
+import { AwsAdapterError } from '../errors/aws-adapter.error';
+
+jest.mock('@aws-sdk/client-s3');
+
+const mockSend = jest.fn();
+const mockDestroy = jest.fn();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (S3Client as jest.Mock).mockImplementation(() => ({ send: mockSend, destroy: mockDestroy }));
+});
+
+const region = AwsRegion.create('us-east-1');
+const scanner = new AwsS3BucketEncryptionMissingScanner();
+
+describe('AwsS3BucketEncryptionMissingScanner', () => {
+  it('exposes its resource kind and global scope', () => {
+    expect(scanner.kind).toBe('s3-bucket-encryption-missing');
+    expect(scanner.scope).toBe('global');
+  });
+
+  it('flags a bucket with no default encryption configured', async () => {
+    mockSend.mockImplementation((command: unknown) => {
+      if (command instanceof ListBucketsCommand) return Promise.resolve({ Buckets: [{ Name: 'my-bucket' }] });
+      if (command instanceof GetBucketEncryptionCommand) {
+        return Promise.reject(Object.assign(new Error('not configured'), { name: 'ServerSideEncryptionConfigurationNotFoundError' }));
+      }
+      throw new Error('unexpected command');
+    });
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value.map((f) => f.id)).toEqual(['my-bucket']);
+  });
+
+  it('does not flag a bucket with default encryption configured', async () => {
+    mockSend.mockImplementation((command: unknown) => {
+      if (command instanceof ListBucketsCommand) return Promise.resolve({ Buckets: [{ Name: 'my-bucket' }] });
+      if (command instanceof GetBucketEncryptionCommand) {
+        return Promise.resolve({ ServerSideEncryptionConfiguration: { Rules: [{}] } });
+      }
+      throw new Error('unexpected command');
+    });
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toHaveLength(0);
+  });
+
+  it('skips a bucket that errors unexpectedly without failing the whole scan', async () => {
+    mockSend.mockImplementation((command: unknown) => {
+      if (command instanceof ListBucketsCommand) return Promise.resolve({ Buckets: [{ Name: 'my-bucket' }] });
+      if (command instanceof GetBucketEncryptionCommand) return Promise.reject(new Error('AccessDenied'));
+      throw new Error('unexpected command');
+    });
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toHaveLength(0);
+  });
+
+  it('returns Result.fail wrapping AwsAdapterError when ListBuckets itself fails, and destroys the client', async () => {
+    mockSend.mockRejectedValueOnce(new Error('AccessDenied'));
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toBeInstanceOf(AwsAdapterError);
+    expect(mockDestroy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-s3-bucket-encryption-missing.scanner.ts
+++ b/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-s3-bucket-encryption-missing.scanner.ts
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+import { S3Client, ListBucketsCommand, GetBucketEncryptionCommand } from '@aws-sdk/client-s3';
+import { Result, createLogger } from 'shared-kernel';
+import type { AwsRegion, ResourceSecurityScannerPort, SecurityFinding } from 'resource-security-domain';
+import { S3BucketEncryptionMissing, S3BucketEncryptionMissingPolicy } from 'resource-security-domain';
+import { AwsAdapterError } from '../errors/aws-adapter.error';
+import { mapWithConcurrency } from '../utils/map-with-concurrency';
+import { createAwsClientConfig } from '../utils/client-config';
+
+const logger = createLogger('cloudrift:scanner');
+/** Per-bucket `GetBucketEncryption` calls in flight at once. */
+const BUCKET_CHECK_CONCURRENCY = 8;
+const NO_ENCRYPTION_ERROR_NAME = 'ServerSideEncryptionConfigurationNotFoundError';
+
+/**
+ * Detects S3 buckets with no default server-side encryption configured
+ * (CIS AWS Foundations 2.1.1). `scope: 'global'` — bucket names are
+ * account-wide, `ListBuckets` is called once, not per region.
+ */
+export class AwsS3BucketEncryptionMissingScanner implements ResourceSecurityScannerPort {
+  readonly kind = 's3-bucket-encryption-missing' as const;
+  readonly scope = 'global' as const;
+
+  constructor(
+    private readonly accountId = 'unknown',
+    private readonly policy = new S3BucketEncryptionMissingPolicy(),
+  ) {}
+
+  async scan(_region: AwsRegion): Promise<Result<SecurityFinding[]>> {
+    const client = new S3Client({ ...createAwsClientConfig(), region: 'us-east-1' });
+    try {
+      const { Buckets } = await client.send(new ListBucketsCommand({}));
+      const bucketNames = (Buckets ?? []).map((b) => b.Name).filter((n): n is string => !!n);
+      const now = new Date();
+
+      const candidates = await mapWithConcurrency(bucketNames, BUCKET_CHECK_CONCURRENCY, async (bucketName) => {
+        try {
+          await client.send(new GetBucketEncryptionCommand({ Bucket: bucketName }));
+          return undefined; // encryption configuration exists
+        } catch (err) {
+          if ((err as Error).name !== NO_ENCRYPTION_ERROR_NAME) {
+            logger.debug('s3-bucket-encryption-missing: skipping bucket after error', { bucketName, error: (err as Error).message });
+            return undefined;
+          }
+          return new S3BucketEncryptionMissing({ bucketName, accountId: this.accountId, detectedAt: now, tags: {} });
+        }
+      });
+
+      const results = candidates
+        .filter((c): c is S3BucketEncryptionMissing => c !== undefined)
+        .filter((c) => this.policy.evaluate(c, now).flagged);
+
+      return Result.ok(results);
+    } catch (err) {
+      return Result.fail(new AwsAdapterError('S3', err as Error));
+    } finally {
+      client.destroy();
+    }
+  }
+}

--- a/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-s3-bucket-public.scanner.spec.ts
+++ b/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-s3-bucket-public.scanner.spec.ts
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: Apache-2.0
+import { S3Client, ListBucketsCommand, GetPublicAccessBlockCommand, GetBucketPolicyStatusCommand, GetBucketAclCommand } from '@aws-sdk/client-s3';
+import { AwsS3BucketPublicScanner } from './aws-s3-bucket-public.scanner';
+import { AwsRegion } from 'resource-security-domain';
+import { AwsAdapterError } from '../errors/aws-adapter.error';
+
+jest.mock('@aws-sdk/client-s3');
+
+const mockSend = jest.fn();
+const mockDestroy = jest.fn();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (S3Client as jest.Mock).mockImplementation(() => ({ send: mockSend, destroy: mockDestroy }));
+});
+
+const region = AwsRegion.create('us-east-1');
+const scanner = new AwsS3BucketPublicScanner();
+
+const notBlocked = Object.assign(new Error('not configured'), { name: 'NoSuchPublicAccessBlockConfiguration' });
+const noPolicy = Object.assign(new Error('no policy'), { name: 'NoSuchBucketPolicy' });
+
+function mockClient(handlers: {
+  publicAccessBlock?: () => Promise<unknown>;
+  policyStatus?: () => Promise<unknown>;
+  acl?: () => Promise<unknown>;
+}) {
+  mockSend.mockImplementation((command: unknown) => {
+    if (command instanceof ListBucketsCommand) return Promise.resolve({ Buckets: [{ Name: 'my-bucket' }] });
+    if (command instanceof GetPublicAccessBlockCommand) return (handlers.publicAccessBlock ?? (() => Promise.reject(notBlocked)))();
+    if (command instanceof GetBucketPolicyStatusCommand) return (handlers.policyStatus ?? (() => Promise.reject(noPolicy)))();
+    if (command instanceof GetBucketAclCommand) return (handlers.acl ?? (() => Promise.resolve({ Grants: [] })))();
+    throw new Error('unexpected command');
+  });
+}
+
+describe('AwsS3BucketPublicScanner', () => {
+  it('exposes its resource kind and global scope', () => {
+    expect(scanner.kind).toBe('s3-bucket-public');
+    expect(scanner.scope).toBe('global');
+  });
+
+  it('flags a bucket with a public policy', async () => {
+    mockClient({ policyStatus: () => Promise.resolve({ PolicyStatus: { IsPublic: true } }) });
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value.map((f) => f.id)).toEqual(['my-bucket']);
+  });
+
+  it('flags a bucket with a public ACL grant', async () => {
+    mockClient({
+      acl: () =>
+        Promise.resolve({
+          Grants: [{ Grantee: { Type: 'Group', URI: 'http://acs.amazonaws.com/groups/global/AllUsers' }, Permission: 'READ' }],
+        }),
+    });
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toHaveLength(1);
+  });
+
+  it('does not flag a bucket with full public access block enabled, even if the ACL looks public', async () => {
+    mockClient({
+      publicAccessBlock: () =>
+        Promise.resolve({
+          PublicAccessBlockConfiguration: {
+            BlockPublicAcls: true,
+            IgnorePublicAcls: true,
+            BlockPublicPolicy: true,
+            RestrictPublicBuckets: true,
+          },
+        }),
+      acl: () =>
+        Promise.resolve({
+          Grants: [{ Grantee: { Type: 'Group', URI: 'http://acs.amazonaws.com/groups/global/AllUsers' }, Permission: 'READ' }],
+        }),
+    });
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toHaveLength(0);
+  });
+
+  it('does not flag a private bucket', async () => {
+    mockClient({});
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toHaveLength(0);
+  });
+
+  it('skips a bucket that errors on a per-bucket call without failing the whole scan', async () => {
+    mockClient({ acl: () => Promise.reject(new Error('AccessDenied')) });
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toHaveLength(0);
+  });
+
+  it('returns Result.fail wrapping AwsAdapterError when ListBuckets itself fails, and destroys the client', async () => {
+    mockSend.mockRejectedValueOnce(new Error('AccessDenied'));
+
+    const result = await scanner.scan(region);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toBeInstanceOf(AwsAdapterError);
+    expect(mockDestroy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-s3-bucket-public.scanner.ts
+++ b/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-s3-bucket-public.scanner.ts
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+import {
+  S3Client,
+  ListBucketsCommand,
+  GetPublicAccessBlockCommand,
+  GetBucketPolicyStatusCommand,
+  GetBucketAclCommand,
+} from '@aws-sdk/client-s3';
+import { Result, createLogger } from 'shared-kernel';
+import type { AwsRegion, ResourceSecurityScannerPort, SecurityFinding } from 'resource-security-domain';
+import { S3BucketPublic, S3BucketPublicPolicy } from 'resource-security-domain';
+import { AwsAdapterError } from '../errors/aws-adapter.error';
+import { mapWithConcurrency } from '../utils/map-with-concurrency';
+import { createAwsClientConfig } from '../utils/client-config';
+
+const logger = createLogger('cloudrift:scanner');
+/** Per-bucket check calls in flight at once. */
+const BUCKET_CHECK_CONCURRENCY = 8;
+const PUBLIC_GROUP_URIS = new Set([
+  'http://acs.amazonaws.com/groups/global/AllUsers',
+  'http://acs.amazonaws.com/groups/global/AuthenticatedUsers',
+]);
+
+async function findPublicVia(client: S3Client, bucketName: string): Promise<string[]> {
+  let fullyBlocked = false;
+  try {
+    const { PublicAccessBlockConfiguration: cfg } = await client.send(new GetPublicAccessBlockCommand({ Bucket: bucketName }));
+    fullyBlocked = !!(cfg?.BlockPublicAcls && cfg?.IgnorePublicAcls && cfg?.BlockPublicPolicy && cfg?.RestrictPublicBuckets);
+  } catch (err) {
+    if ((err as Error).name !== 'NoSuchPublicAccessBlockConfiguration') throw err;
+  }
+  // S3 Block Public Access, when fully enabled, overrides both ACLs and bucket policies account/bucket-wide.
+  if (fullyBlocked) return [];
+
+  const reasons: string[] = [];
+
+  try {
+    const { PolicyStatus } = await client.send(new GetBucketPolicyStatusCommand({ Bucket: bucketName }));
+    if (PolicyStatus?.IsPublic) reasons.push('bucket policy allows public access');
+  } catch (err) {
+    if ((err as Error).name !== 'NoSuchBucketPolicy') throw err;
+  }
+
+  const { Grants } = await client.send(new GetBucketAclCommand({ Bucket: bucketName }));
+  const hasPublicGrant = (Grants ?? []).some((g) => g.Grantee?.Type === 'Group' && PUBLIC_GROUP_URIS.has(g.Grantee.URI ?? ''));
+  if (hasPublicGrant) reasons.push('bucket ACL grants public access');
+
+  return reasons;
+}
+
+/**
+ * Detects S3 buckets reachable by the internet via their ACL and/or bucket
+ * policy (CIS AWS Foundations 2.1.5). `scope: 'global'` — bucket names are
+ * account-wide, `ListBuckets` is called once, not per region.
+ */
+export class AwsS3BucketPublicScanner implements ResourceSecurityScannerPort {
+  readonly kind = 's3-bucket-public' as const;
+  readonly scope = 'global' as const;
+
+  constructor(
+    private readonly accountId = 'unknown',
+    private readonly policy = new S3BucketPublicPolicy(),
+  ) {}
+
+  async scan(_region: AwsRegion): Promise<Result<SecurityFinding[]>> {
+    const client = new S3Client({ ...createAwsClientConfig(), region: 'us-east-1' });
+    try {
+      const { Buckets } = await client.send(new ListBucketsCommand({}));
+      const bucketNames = (Buckets ?? []).map((b) => b.Name).filter((n): n is string => !!n);
+      const now = new Date();
+
+      const candidates = await mapWithConcurrency(bucketNames, BUCKET_CHECK_CONCURRENCY, async (bucketName) => {
+        try {
+          const publicVia = await findPublicVia(client, bucketName);
+          if (publicVia.length === 0) return undefined;
+          return new S3BucketPublic({ bucketName, accountId: this.accountId, publicVia, detectedAt: now, tags: {} });
+        } catch (err) {
+          // A single unreadable bucket (e.g. a bucket policy denying this principal) shouldn't fail the whole scan.
+          logger.debug('s3-bucket-public: skipping bucket after error', { bucketName, error: (err as Error).message });
+          return undefined;
+        }
+      });
+
+      const results = candidates
+        .filter((c): c is S3BucketPublic => c !== undefined)
+        .filter((c) => this.policy.evaluate(c, now).flagged);
+
+      return Result.ok(results);
+    } catch (err) {
+      return Result.fail(new AwsAdapterError('S3', err as Error));
+    } finally {
+      client.destroy();
+    }
+  }
+}

--- a/libs/resource-security/infrastructure/aws-adapter/src/utils/client-config.ts
+++ b/libs/resource-security/infrastructure/aws-adapter/src/utils/client-config.ts
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+import { NodeHttpHandler } from '@smithy/node-http-handler';
+import { createLogger } from 'shared-kernel';
+
+const httpLog = createLogger('cloudrift:http');
+
+const smithyLogger = {
+  trace: (...args: unknown[]) => httpLog.debug('trace', { args }),
+  debug: (...args: unknown[]) => httpLog.debug('debug', { args }),
+  info: (...args: unknown[]) => httpLog.debug('info', { args }),
+  warn: (...args: unknown[]) => httpLog.debug('warn', { args }),
+  error: (...args: unknown[]) => httpLog.debug('error', { args }),
+};
+
+const keepAlive = process.env.CLOUDRIFT_HTTP_KEEPALIVE !== 'false';
+
+/**
+ * Default options spread into every AWS SDK v3 client created by scanners
+ * in this lib. Deliberate copy of `dead-resources-infrastructure-aws-
+ * adapter`'s own `createAwsClientConfig` (itself a copy from `cloud-cost`,
+ * ADR-0078) — not a shared import, keeps this infrastructure lib decoupled.
+ * The one-`NodeHttpHandler`-per-client shape is not optional: see ADR-0064
+ * for the production bug (a shared handler destroyed mid-flight by a
+ * concurrent job's `finally`) this specifically prevents.
+ *
+ * Usage:
+ * ```ts
+ * const ec2 = new EC2Client({ ...createAwsClientConfig(), region: region.code });
+ * ```
+ */
+export function createAwsClientConfig() {
+  return {
+    maxAttempts: 3,
+    requestHandler: new NodeHttpHandler({
+      connectionTimeout: 10_000,
+      requestTimeout: 30_000,
+      logger: smithyLogger,
+      httpsAgent: { keepAlive },
+    }),
+  } as const;
+}

--- a/libs/resource-security/infrastructure/aws-adapter/src/utils/map-with-concurrency.ts
+++ b/libs/resource-security/infrastructure/aws-adapter/src/utils/map-with-concurrency.ts
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Runs `fn` over each item with at most `limit` calls in flight, preserving
+ * result order. Deliberate copy of `dead-resources-infrastructure-aws-
+ * adapter`'s own `mapWithConcurrency` (ADR-0078) — see `paginate.ts`/
+ * `client-config.ts` in this same directory for why.
+ */
+export async function mapWithConcurrency<T, R>(
+  items: readonly T[],
+  limit: number,
+  fn: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let nextIndex = 0;
+
+  const workers = Array.from(
+    { length: Math.max(1, Math.min(limit, items.length)) },
+    async () => {
+      for (;;) {
+        const index = nextIndex++;
+        if (index >= items.length) return;
+        results[index] = await fn(items[index]);
+      }
+    },
+  );
+
+  await Promise.all(workers);
+  return results;
+}

--- a/libs/resource-security/infrastructure/aws-adapter/src/utils/paginate.ts
+++ b/libs/resource-security/infrastructure/aws-adapter/src/utils/paginate.ts
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Fetches every page and accumulates the result of `select` per page.
+ * Deliberate copy of `dead-resources-infrastructure-aws-adapter`'s own
+ * `paginate` (ADR-0078) rather than a shared import — keeps this
+ * infrastructure lib decoupled from that one, at the cost of duplicating a
+ * ~15-line, fully generic utility.
+ */
+export async function paginate<TItem, TResult = TItem>(
+  fetchPage: (cursor: string | undefined) => Promise<{ items: TItem[]; cursor: string | undefined }>,
+  select: (items: TItem[]) => TResult[] = (items) => items as unknown as TResult[],
+): Promise<TResult[]> {
+  const all: TResult[] = [];
+  let cursor: string | undefined;
+  do {
+    const page = await fetchPage(cursor);
+    all.push(...select(page.items));
+    cursor = page.cursor;
+  } while (cursor !== undefined);
+  return all;
+}

--- a/libs/resource-security/infrastructure/aws-adapter/tsconfig.json
+++ b/libs/resource-security/infrastructure/aws-adapter/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/libs/resource-security/infrastructure/aws-adapter/tsconfig.lib.json
+++ b/libs/resource-security/infrastructure/aws-adapter/tsconfig.lib.json
@@ -1,0 +1,21 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "dist/tsconfig.lib.tsbuildinfo",
+    "emitDeclarationOnly": false,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"],
+  "references": [
+    {
+      "path": "../../domain/tsconfig.lib.json"
+    },
+    {
+      "path": "../../../shared/kernel/tsconfig.lib.json"
+    }
+  ]
+}

--- a/libs/resource-security/infrastructure/aws-adapter/tsconfig.spec.json
+++ b/libs/resource-security/infrastructure/aws-adapter/tsconfig.spec.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "outDir": "./dist/test",
+    "types": ["jest", "node"],
+    "strict": true,
+    "esModuleInterop": true
+  },
+  "include": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   "dependencies": {
     "@aws-sdk/client-acm": "^3.1093.0",
     "@aws-sdk/client-cloudformation": "^3.1093.0",
+    "@aws-sdk/client-cloudtrail": "^3.1093.0",
     "@aws-sdk/client-cloudwatch": "^3.1093.0",
     "@aws-sdk/client-cloudwatch-logs": "^3.1093.0",
     "@aws-sdk/client-codepipeline": "^3.1093.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@aws-sdk/client-cloudformation':
         specifier: ^3.1093.0
         version: 3.1093.0
+      '@aws-sdk/client-cloudtrail':
+        specifier: ^3.1093.0
+        version: 3.1093.0
       '@aws-sdk/client-cloudwatch':
         specifier: ^3.1093.0
         version: 3.1093.0
@@ -246,6 +249,15 @@ importers:
       pdfkit:
         specifier: ^0.15.2
         version: 0.15.2
+      resource-security-application:
+        specifier: workspace:*
+        version: link:../../libs/resource-security/application
+      resource-security-domain:
+        specifier: workspace:*
+        version: link:../../libs/resource-security/domain
+      resource-security-infrastructure-aws-adapter:
+        specifier: workspace:*
+        version: link:../../libs/resource-security/infrastructure/aws-adapter
       shared-kernel:
         specifier: workspace:*
         version: link:../../libs/shared/kernel
@@ -355,6 +367,42 @@ importers:
         specifier: ^2.8.1
         version: 2.8.1
 
+  libs/resource-security/application:
+    dependencies:
+      resource-security-domain:
+        specifier: workspace:*
+        version: link:../domain
+      shared-kernel:
+        specifier: workspace:*
+        version: link:../../shared/kernel
+      tslib:
+        specifier: ^2.8.1
+        version: 2.8.1
+
+  libs/resource-security/domain:
+    dependencies:
+      cloud-cost-domain:
+        specifier: workspace:*
+        version: link:../../cloud-cost/domain
+      shared-kernel:
+        specifier: workspace:*
+        version: link:../../shared/kernel
+      tslib:
+        specifier: ^2.8.1
+        version: 2.8.1
+
+  libs/resource-security/infrastructure/aws-adapter:
+    dependencies:
+      resource-security-domain:
+        specifier: workspace:*
+        version: link:../../domain
+      shared-kernel:
+        specifier: workspace:*
+        version: link:../../../shared/kernel
+      tslib:
+        specifier: ^2.8.1
+        version: 2.8.1
+
   libs/shared/kernel:
     dependencies:
       tslib:
@@ -386,6 +434,10 @@ packages:
 
   '@aws-sdk/client-cloudformation@3.1093.0':
     resolution: {integrity: sha512-Vgou0Jucnacw7sTabHQAI98vdlC0/vbs05LsGb4QdHxg4lf7MNCxiJqXonP9Ry0fQPEZMSO+3hkB80KVbaSRpg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-cloudtrail@3.1093.0':
+    resolution: {integrity: sha512-2PKtdaXYIt3iAZP3qe8VhZJ+P34omB49CgnHioHlEJRvDhXs9XAShFsanS7LfHTVG1xmfQOkd2f6cycJsTFe7g==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/client-cloudwatch-logs@3.1093.0':
@@ -4614,6 +4666,17 @@ snapshots:
       tslib: 2.8.1
 
   '@aws-sdk/client-cloudformation@3.1093.0':
+    dependencies:
+      '@aws-sdk/core': 3.976.0
+      '@aws-sdk/credential-provider-node': 3.972.71
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.7
+      '@smithy/fetch-http-handler': 5.6.9
+      '@smithy/node-http-handler': 4.9.9
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/client-cloudtrail@3.1093.0':
     dependencies:
       '@aws-sdk/core': 3.976.0
       '@aws-sdk/credential-provider-node': 3.972.71

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -35,6 +35,15 @@
     },
     {
       "path": "./libs/dead-resources/infrastructure/aws-adapter"
+    },
+    {
+      "path": "./libs/resource-security/domain"
+    },
+    {
+      "path": "./libs/resource-security/application"
+    },
+    {
+      "path": "./libs/resource-security/infrastructure/aws-adapter"
     }
   ]
 }


### PR DESCRIPTION
…el domain)## Summary
- New `resource-security` domain (mirrors `dead-resources`, ADR-0078/0079) with 14 read-only security-posture checks: IAM/account hygiene (root MFA, user MFA, access-key rotation, root access keys, password policy), network exposure (open ingress, permissive default security groups), public storage (S3 buckets, EBS snapshots), encryption at rest (EBS, RDS, S3), and visibility/audit (RDS public accessibility, CloudTrail multi-region coverage) — see ADR-0081.
- New `resource-security` CLI command (table/json/PDF output, `--scanners`/`--ignore-tag`/`--pdf`), wired into the interactive wizard as a fifth mode.
- Docs updated: README, usage.md/utilizzo.md (EN+IT), iam-permissions.md/permessi-iam.md (EN+IT), new ADR-0081.

## Test plan
- [x] `pnpm nx run-many --target=lint --all` — all 14 projects clean
- [x] `pnpm nx run-many --target=build --all` — all 14 projects build
- [x] `pnpm nx run-many --target=test --all` — all 14 projects green (154 new tests: 47 domain, 7 application, 70 infrastructure-adapter, 30 CLI; zero regressions)
- [x] Manual verification against a real AWS account (not yet run)
