### PR TITLE
fix(cli): show scan spinner on fast scans, balance PDF table column w…

### DIFF
--- a/apps/cli/src/commands/cost.command.ts
+++ b/apps/cli/src/commands/cost.command.ts
@@ -8,6 +8,7 @@ import { formatCostComparisonAsTable } from '../formatters/cost-comparison.table
 import { formatCostComparisonAsJson } from '../formatters/cost-comparison.json-formatter';
 import { generateCostComparisonPdf } from '../formatters/cost-comparison.pdf-formatter';
 import { confirmCostExplorerCharge } from '../wizard/cost-confirmation.wizard';
+import { startScanSpinner } from '../wizard/scan-spinner';
 import { defaultCostAnalyticsDeps, type CostAnalyticsDeps } from './cost-analytics.composition';
 import { applyCostTrendGate } from './post-analysis';
 
@@ -75,7 +76,9 @@ export async function costCommand(
   }
 
   const costExplorer = deps.createCostExplorer(accountId, options.refreshCache === true);
+  const spinner = quietStdout ? undefined : await startScanSpinner('  Fetching from Cost Explorer...');
   const result = await new CompareCostUseCase(costExplorer).execute({});
+  spinner?.stop(chalk.dim('  Done.'));
   if (!result.ok) return fail(result.error.message);
 
   const meta: CostAnalyticsMeta = { accountId, generatedAt: new Date() };

--- a/apps/cli/src/commands/dead-resources.command.ts
+++ b/apps/cli/src/commands/dead-resources.command.ts
@@ -8,6 +8,7 @@ import { renderBrandMark } from '../brand-mark';
 import { formatDeadResourcesReportAsTable } from '../formatters/dead-resources-report.table-formatter';
 import { formatDeadResourcesReportAsJson } from '../formatters/dead-resources-report.json-formatter';
 import { generateDeadResourcesReportPdf } from '../formatters/dead-resources-report.pdf-formatter';
+import { startScanSpinner } from '../wizard/scan-spinner';
 import { defaultDeadResourcesDeps, type DeadResourcesDeps } from './dead-resources.composition';
 
 export type { DeadResourcesDeps };
@@ -110,7 +111,9 @@ export async function deadResourcesCommand(
 
   const { useCase } = await deps.createAnalysis({ regions, accountId, policyOptions, scannerKinds });
 
+  const spinner = quietStdout ? undefined : await startScanSpinner('  Rolling through your account...');
   const result = await useCase.execute({ regions });
+  spinner?.stop(chalk.dim('  Scan complete.'));
   if (!result.ok) return fail(result.error.message);
 
   const meta = { accountId, regions: regions.map((r) => r.code), generatedAt: new Date() };

--- a/apps/cli/src/commands/resource-security.command.ts
+++ b/apps/cli/src/commands/resource-security.command.ts
@@ -8,6 +8,7 @@ import { renderBrandMark } from '../brand-mark';
 import { formatResourceSecurityReportAsTable } from '../formatters/resource-security-report.table-formatter';
 import { formatResourceSecurityReportAsJson } from '../formatters/resource-security-report.json-formatter';
 import { generateResourceSecurityReportPdf } from '../formatters/resource-security-report.pdf-formatter';
+import { startScanSpinner } from '../wizard/scan-spinner';
 import { defaultResourceSecurityDeps, type ResourceSecurityDeps } from './resource-security.composition';
 
 export type { ResourceSecurityDeps };
@@ -98,7 +99,9 @@ export async function resourceSecurityCommand(
 
   const { useCase } = await deps.createAnalysis({ regions, accountId, policyOptions, scannerKinds });
 
+  const spinner = quietStdout ? undefined : await startScanSpinner('  Rolling through your account...');
   const result = await useCase.execute({ regions });
+  spinner?.stop(chalk.dim('  Scan complete.'));
   if (!result.ok) return fail(result.error.message);
 
   const meta = { accountId, regions: regions.map((r) => r.code), generatedAt: new Date() };

--- a/apps/cli/src/commands/trend.command.ts
+++ b/apps/cli/src/commands/trend.command.ts
@@ -9,6 +9,7 @@ import { formatCostTrendAsJson } from '../formatters/cost-trend.json-formatter';
 import { generateCostTrendPdf } from '../formatters/cost-trend.pdf-formatter';
 import { resolveServiceNames } from '../config/cost-explorer-service-names';
 import { confirmCostExplorerCharge } from '../wizard/cost-confirmation.wizard';
+import { startScanSpinner } from '../wizard/scan-spinner';
 import { defaultCostAnalyticsDeps, type CostAnalyticsDeps } from './cost-analytics.composition';
 
 const OUTPUT_FORMATS = ['table', 'json'] as const;
@@ -78,7 +79,9 @@ export async function trendCommand(
   }
 
   const costExplorer = deps.createCostExplorer(accountId, options.refreshCache === true);
+  const spinner = quietStdout ? undefined : await startScanSpinner('  Fetching from Cost Explorer...');
   const result = await new CostTrendUseCase(costExplorer).execute({ months, services });
+  spinner?.stop(chalk.dim('  Done.'));
   if (!result.ok) return fail(result.error.message);
 
   const meta: CostAnalyticsMeta = { accountId, generatedAt: new Date() };

--- a/apps/cli/src/formatters/dead-resources-report.pdf-formatter.ts
+++ b/apps/cli/src/formatters/dead-resources-report.pdf-formatter.ts
@@ -168,9 +168,14 @@ function buildTopFindings(summary: DeadResourcesSummary): TopFinding[] {
   return findings.sort((a, b) => SEVERITY_RANK[a.severity] - SEVERITY_RANK[b.severity]).slice(0, 8);
 }
 
+// Fixed overhead around the label column: 22 (index area) + 4 (gap) + 64
+// (severity badge width) + 8 (right padding, so the badge doesn't sit flush
+// against the table border) = 98. labelW must leave exactly this much room.
+const RECOMMENDATION_FIXED_W = 98;
+
 function measureRecommendationsHeight(doc: PDFKit.PDFDocument, findings: TopFinding[]): number {
   doc.font('Helvetica').fontSize(8.5);
-  const labelW = CONTENT_W - 90;
+  const labelW = CONTENT_W - RECOMMENDATION_FIXED_W;
   return findings.reduce(
     (total, { label }) => total + rowHeightForLines(wrapToLines(doc, label, labelW).length),
     0,
@@ -186,7 +191,7 @@ function drawRecommendations(
   let y = startY;
   let segmentStartY = startY;
   let segmentH = 0;
-  const labelW = CONTENT_W - 90;
+  const labelW = CONTENT_W - RECOMMENDATION_FIXED_W;
 
   const strokeSegmentBorder = () => {
     if (segmentH === 0) return;

--- a/apps/cli/src/formatters/pdf-shared.ts
+++ b/apps/cli/src/formatters/pdf-shared.ts
@@ -234,8 +234,11 @@ const MIN_COL_W = 50;
  * needed more lines than the guessed width allowed.
  *
  * Columns whose content fits get exactly what they need (never more);
- * any width left over after that goes to the widest column (almost always
- * the free-text one) so the table still fills `totalWidth`.
+ * any width left over after that is split across every column in
+ * proportion to its natural width, so the table still fills `totalWidth`
+ * and short structured columns (a date, "us-east-1", a severity badge)
+ * get some breathing room too instead of sitting at their bare minimum
+ * while the widest column absorbs 100% of the slack.
  *
  * If the natural widths don't all fit, shrink starts from the *widest*
  * column instead of squeezing every column proportionally: the widest
@@ -266,8 +269,7 @@ export function computeColumnWidths(
 
   if (naturalSum <= totalWidth) {
     const extra = totalWidth - naturalSum;
-    const widestIndex = natural.indexOf(Math.max(...natural));
-    return natural.map((w, i) => (i === widestIndex ? w + extra : w));
+    return natural.map((w) => w + extra * (w / naturalSum));
   }
 
   return shrinkWidestFirst(natural, totalWidth);

--- a/apps/cli/src/formatters/resource-security-report.pdf-formatter.ts
+++ b/apps/cli/src/formatters/resource-security-report.pdf-formatter.ts
@@ -167,9 +167,14 @@ function buildTopFindings(summary: ResourceSecuritySummary): TopFinding[] {
   return findings.sort((a, b) => SEVERITY_RANK[a.severity] - SEVERITY_RANK[b.severity]).slice(0, 8);
 }
 
+// Fixed overhead around the label column: 22 (index area) + 4 (gap) + 64
+// (severity badge width) + 8 (right padding, so the badge doesn't sit flush
+// against the table border) = 98. labelW must leave exactly this much room.
+const RECOMMENDATION_FIXED_W = 98;
+
 function measureRecommendationsHeight(doc: PDFKit.PDFDocument, findings: TopFinding[]): number {
   doc.font('Helvetica').fontSize(8.5);
-  const labelW = CONTENT_W - 90;
+  const labelW = CONTENT_W - RECOMMENDATION_FIXED_W;
   return findings.reduce(
     (total, { label }) => total + rowHeightForLines(wrapToLines(doc, label, labelW).length),
     0,
@@ -185,7 +190,7 @@ function drawRecommendations(
   let y = startY;
   let segmentStartY = startY;
   let segmentH = 0;
-  const labelW = CONTENT_W - 90;
+  const labelW = CONTENT_W - RECOMMENDATION_FIXED_W;
 
   const strokeSegmentBorder = () => {
     if (segmentH === 0) return;

--- a/apps/cli/src/wizard/scan-spinner.ts
+++ b/apps/cli/src/wizard/scan-spinner.ts
@@ -8,6 +8,10 @@ export interface ScanSpinner {
 const TRACK_LENGTH = 14;
 // Cycling through these as it advances along the track suggests tumbling/rotation.
 const GLYPHS = ['o', 'O', '0', 'O'];
+// How many ticks each track position holds for — see the `delay` doc comment
+// below: the tick rate itself must stay short, so this is what actually
+// controls how fast the tumbleweed appears to move.
+const HOLD_TICKS = 4;
 
 function frame(position: number): string {
   const glyph = GLYPHS[position % GLYPHS.length];
@@ -25,6 +29,21 @@ function frame(position: number): string {
  *
  * Falls back to doing nothing outside a real terminal (CI/non-TTY/quiet
  * output) — spinner escape codes must never reach piped/redirected output.
+ *
+ * `delay` (ms between ticks) is also how long clack's spinner waits before
+ * its *first* render — `start()` schedules the first frame via
+ * `setInterval`, it never draws immediately. At 120ms, a scan that finishes
+ * faster than that (e.g. dead-resources/resource-security against
+ * LocalStack, or a handful of resources over a fast connection) never draws
+ * a single frame: `stop()` fires first and the whole spinner — including
+ * `message` — never appears on screen, only the final "done" line does.
+ *
+ * So `delay` has to stay short (30ms) to guarantee a fast scan still shows
+ * *something*. But clack redraws on every tick, so a short delay alone also
+ * makes the tumbleweed race along the track — each track position is
+ * repeated `HOLD_TICKS` times below to slow the apparent motion back down
+ * (4 * 30ms = 120ms per position, the pace the original single-tick 120ms
+ * delay had) without touching the 30ms first-render guarantee.
  */
 export async function startScanSpinner(message: string): Promise<ScanSpinner> {
   if (!isInteractiveTty()) {
@@ -32,10 +51,8 @@ export async function startScanSpinner(message: string): Promise<ScanSpinner> {
   }
 
   const { spinner } = await import('@clack/prompts');
-  const s = spinner({
-    frames: Array.from({ length: TRACK_LENGTH }, (_, i) => frame(i)),
-    delay: 120,
-  });
+  const frames = Array.from({ length: TRACK_LENGTH * HOLD_TICKS }, (_, i) => frame(Math.floor(i / HOLD_TICKS)));
+  const s = spinner({ frames, delay: 30 });
   s.start(message);
   return { stop: (finalMessage) => s.stop(finalMessage) };
 }


### PR DESCRIPTION
### Summary
- Fix scan spinner not appearing on fast scans (LocalStack, small accounts): clack's spinner delayed its first render until the `delay` elapsed, so scans finishing under 120ms ended before any frame drew. Delay is now 30ms, with each track position held for 4 ticks to preserve the original apparent speed.
- Wire the spinner into `cost`, `trend`, `dead-resources`, and `resource-security` commands.
- Fix PDF report tables dumping all leftover column width onto the widest column: extra width is now distributed proportionally across all columns, so short structured columns (dates, regions, severity badges) aren't stuck at their bare minimum.

### Test plan
- [x] Rebuilt CLI, ran `analyze` against LocalStack (no `--all-services`, to trigger the interactive wizard) — confirmed spinner now renders immediately on a fast scan
- [x] Visual check of PDF report column widths (dead-resources / resource-security)