### PR TITLE
refactor(types): remove avoidable TypeScript  casts, document the rest

### DIFF
--- a/apps/cli/src/brand-mark.ts
+++ b/apps/cli/src/brand-mark.ts
@@ -26,10 +26,10 @@ import type { PixelArtCell } from './pixel-art-cell';
  * actually is show through instead.
  */
 function renderCell({ top, bottom }: PixelArtCell): string {
-  if (top === null && bottom === null) return ' ';
-  if (top === null) return chalk.hex(bottom as string)('▄');
-  if (bottom === null) return chalk.hex(top)('▀');
-  return chalk.hex(top).bgHex(bottom)('▀');
+  if (top !== null && bottom !== null) return chalk.hex(top).bgHex(bottom)('▀');
+  if (top !== null) return chalk.hex(top)('▀');
+  if (bottom !== null) return chalk.hex(bottom)('▄');
+  return ' ';
 }
 
 // Pulled from the logo's own wave palette instead of an unrelated bright
@@ -72,7 +72,7 @@ export function renderBrandMark(): string {
 
   const mid = Math.floor(iconRows.length / 2) - 1;
   const blankText = ' '.repeat(TEXT_WIDTH);
-  const textByRow = new Array(iconRows.length).fill(blankText) as string[];
+  const textByRow = new Array<string>(iconRows.length).fill(blankText);
   textByRow[mid] = textCell(tracked('cloudrift'), (s) => chalk.bold.hex(TITLE_ACCENT)(s));
   textByRow[mid + 1] = textCell('─'.repeat(9), (s) => chalk.hex(TITLE_ACCENT)(s));
   textByRow[mid + 2] = textCell('AWS waste & cost intelligence', (s) => chalk.hex(SUBTITLE)(s));

--- a/apps/cli/src/commands/analyze-waste.command.ts
+++ b/apps/cli/src/commands/analyze-waste.command.ts
@@ -26,6 +26,10 @@ const DEFAULT_UTILIZATION_WINDOW_HOURS = 168;
 const OUTPUT_FORMATS = ['table', 'json', 'markdown'] as const;
 type OutputFormat = (typeof OUTPUT_FORMATS)[number];
 
+function isOutputFormat(format: string): format is OutputFormat {
+  return (OUTPUT_FORMATS as readonly string[]).includes(format);
+}
+
 export interface AnalyzeWasteOptions {
   regions: string[];
   accountId?: string;
@@ -58,8 +62,8 @@ export async function analyzeWasteCommand(
   options: AnalyzeWasteOptions,
   deps: AnalyzeDeps = defaultAnalyzeDeps,
 ): Promise<void> {
-  const format = (options.format ?? 'table') as OutputFormat;
-  if (!OUTPUT_FORMATS.includes(format)) {
+  const format = options.format ?? 'table';
+  if (!isOutputFormat(format)) {
     return fail(
       `--format must be one of: ${OUTPUT_FORMATS.join(', ')}. Got "${options.format}".`,
     );

--- a/apps/cli/src/commands/cost.command.ts
+++ b/apps/cli/src/commands/cost.command.ts
@@ -15,6 +15,10 @@ import { applyCostTrendGate } from './post-analysis';
 const OUTPUT_FORMATS = ['table', 'json'] as const;
 type OutputFormat = (typeof OUTPUT_FORMATS)[number];
 
+function isOutputFormat(format: string): format is OutputFormat {
+  return (OUTPUT_FORMATS as readonly string[]).includes(format);
+}
+
 export interface CostCommandOptions {
   accountId?: string;
   config?: string;
@@ -39,8 +43,8 @@ export async function costCommand(
   options: CostCommandOptions,
   deps: CostAnalyticsDeps = defaultCostAnalyticsDeps,
 ): Promise<void> {
-  const format = (options.format ?? 'table') as OutputFormat;
-  if (!OUTPUT_FORMATS.includes(format)) {
+  const format = options.format ?? 'table';
+  if (!isOutputFormat(format)) {
     return fail(`--format must be one of: ${OUTPUT_FORMATS.join(', ')}. Got "${options.format}".`);
   }
 

--- a/apps/cli/src/commands/dead-resources.command.ts
+++ b/apps/cli/src/commands/dead-resources.command.ts
@@ -16,6 +16,10 @@ export type { DeadResourcesDeps };
 const OUTPUT_FORMATS = ['table', 'json'] as const;
 type OutputFormat = (typeof OUTPUT_FORMATS)[number];
 
+function isOutputFormat(format: string): format is OutputFormat {
+  return (OUTPUT_FORMATS as readonly string[]).includes(format);
+}
+
 export interface DeadResourcesCommandOptions {
   regions: string[];
   accountId?: string;
@@ -35,14 +39,17 @@ function fail(message: string): void {
   process.exitCode = 1;
 }
 
+function isDeadResourceKind(kind: string): kind is DeadResourceKind {
+  return (DEAD_RESOURCE_KINDS as readonly string[]).includes(kind);
+}
+
 /** `--scanners`: Result-free validation against the known DEAD_RESOURCE_KINDS (mirrors `resolveExplicitScanners` for `analyze`). */
 function resolveExplicitScannerKinds(scanners: string[]): DeadResourceKind[] | { error: string } {
-  const valid = new Set<string>(DEAD_RESOURCE_KINDS);
-  const unknown = scanners.filter((kind) => !valid.has(kind));
-  if (unknown.length > 0) {
+  if (!scanners.every(isDeadResourceKind)) {
+    const unknown = scanners.filter((kind) => !isDeadResourceKind(kind));
     return { error: `--scanners: unknown check(s) "${unknown.join(', ')}". Valid values: ${DEAD_RESOURCE_KINDS.join(', ')}.` };
   }
-  return scanners as DeadResourceKind[];
+  return scanners;
 }
 
 /**
@@ -55,8 +62,8 @@ export async function deadResourcesCommand(
   options: DeadResourcesCommandOptions,
   deps: DeadResourcesDeps = defaultDeadResourcesDeps,
 ): Promise<void> {
-  const format = (options.format ?? 'table') as OutputFormat;
-  if (!OUTPUT_FORMATS.includes(format)) {
+  const format = options.format ?? 'table';
+  if (!isOutputFormat(format)) {
     return fail(`--format must be one of: ${OUTPUT_FORMATS.join(', ')}. Got "${options.format}".`);
   }
 

--- a/apps/cli/src/commands/resolve-options.ts
+++ b/apps/cli/src/commands/resolve-options.ts
@@ -24,18 +24,21 @@ export function resolveMinAgeDays(
   return Result.ok(minAgeDays);
 }
 
+function isResourceKind(kind: string): kind is ResourceKind {
+  return (RESOURCE_KINDS as readonly string[]).includes(kind);
+}
+
 /** --scanners: Result-based validation against the known RESOURCE_KINDS (no throw on bad input). */
 export function resolveExplicitScanners(scanners: string[]): Result<ResourceKind[], Error> {
-  const valid = new Set<string>(RESOURCE_KINDS);
-  const unknown = scanners.filter((kind) => !valid.has(kind));
-  if (unknown.length > 0) {
+  if (!scanners.every(isResourceKind)) {
+    const unknown = scanners.filter((kind) => !isResourceKind(kind));
     return Result.fail(
       new Error(
         `--scanners: unknown service(s) "${unknown.join(', ')}". Valid values: ${RESOURCE_KINDS.join(', ')}.`,
       ),
     );
   }
-  return Result.ok(scanners as ResourceKind[]);
+  return Result.ok(scanners);
 }
 
 /** Requested regions: Result-based parse (no throw on input), then exclusion from config. */

--- a/apps/cli/src/commands/resource-security.command.ts
+++ b/apps/cli/src/commands/resource-security.command.ts
@@ -16,6 +16,10 @@ export type { ResourceSecurityDeps };
 const OUTPUT_FORMATS = ['table', 'json'] as const;
 type OutputFormat = (typeof OUTPUT_FORMATS)[number];
 
+function isOutputFormat(format: string): format is OutputFormat {
+  return (OUTPUT_FORMATS as readonly string[]).includes(format);
+}
+
 export interface ResourceSecurityCommandOptions {
   regions: string[];
   accountId?: string;
@@ -34,14 +38,17 @@ function fail(message: string): void {
   process.exitCode = 1;
 }
 
+function isResourceSecurityKind(kind: string): kind is ResourceSecurityKind {
+  return (RESOURCE_SECURITY_KINDS as readonly string[]).includes(kind);
+}
+
 /** `--scanners`: Result-free validation against the known RESOURCE_SECURITY_KINDS. */
 function resolveExplicitScannerKinds(scanners: string[]): ResourceSecurityKind[] | { error: string } {
-  const valid = new Set<string>(RESOURCE_SECURITY_KINDS);
-  const unknown = scanners.filter((kind) => !valid.has(kind));
-  if (unknown.length > 0) {
+  if (!scanners.every(isResourceSecurityKind)) {
+    const unknown = scanners.filter((kind) => !isResourceSecurityKind(kind));
     return { error: `--scanners: unknown check(s) "${unknown.join(', ')}". Valid values: ${RESOURCE_SECURITY_KINDS.join(', ')}.` };
   }
-  return scanners as ResourceSecurityKind[];
+  return scanners;
 }
 
 /**
@@ -55,8 +62,8 @@ export async function resourceSecurityCommand(
   options: ResourceSecurityCommandOptions,
   deps: ResourceSecurityDeps = defaultResourceSecurityDeps,
 ): Promise<void> {
-  const format = (options.format ?? 'table') as OutputFormat;
-  if (!OUTPUT_FORMATS.includes(format)) {
+  const format = options.format ?? 'table';
+  if (!isOutputFormat(format)) {
     return fail(`--format must be one of: ${OUTPUT_FORMATS.join(', ')}. Got "${options.format}".`);
   }
 

--- a/apps/cli/src/commands/trend.command.ts
+++ b/apps/cli/src/commands/trend.command.ts
@@ -14,6 +14,10 @@ import { defaultCostAnalyticsDeps, type CostAnalyticsDeps } from './cost-analyti
 
 const OUTPUT_FORMATS = ['table', 'json'] as const;
 type OutputFormat = (typeof OUTPUT_FORMATS)[number];
+
+function isOutputFormat(format: string): format is OutputFormat {
+  return (OUTPUT_FORMATS as readonly string[]).includes(format);
+}
 const DEFAULT_MONTHS = 6;
 const MAX_MONTHS = 36;
 
@@ -43,8 +47,8 @@ export async function trendCommand(
   options: TrendCommandOptions,
   deps: CostAnalyticsDeps = defaultCostAnalyticsDeps,
 ): Promise<void> {
-  const format = (options.format ?? 'table') as OutputFormat;
-  if (!OUTPUT_FORMATS.includes(format)) {
+  const format = options.format ?? 'table';
+  if (!isOutputFormat(format)) {
     return fail(`--format must be one of: ${OUTPUT_FORMATS.join(', ')}. Got "${options.format}".`);
   }
 

--- a/apps/cli/src/wizard/dead-resource-selection.wizard.ts
+++ b/apps/cli/src/wizard/dead-resource-selection.wizard.ts
@@ -12,6 +12,10 @@ import { DEAD_RESOURCE_KINDS, DEAD_RESOURCE_KIND_META, type DeadResourceKind } f
 export async function promptDeadResourceSelection(): Promise<DeadResourceKind[] | undefined> {
   const { cancel, intro, isCancel, multiselect } = await import('@clack/prompts');
   intro('Select the dead/unused resource checks to run (space to toggle, enter to confirm)');
+  // Cast, not narrowed: `Option<Value>` distributes over the `DeadResourceKind`
+  // union into one variant per literal — TS can't see that a per-entry
+  // literal built by `.map()` always matches its own variant (same reasoning
+  // as `scanner-selection.wizard.ts`).
   const options = DEAD_RESOURCE_KINDS.map((kind) => ({
     value: kind,
     label: DEAD_RESOURCE_KIND_META[kind].label,

--- a/apps/cli/src/wizard/region-input.wizard.ts
+++ b/apps/cli/src/wizard/region-input.wizard.ts
@@ -13,6 +13,10 @@ import { AWS_REGION_CODES } from 'cloud-cost-domain';
 export async function promptRegions(): Promise<string[] | undefined> {
   const { autocompleteMultiselect, cancel, isCancel } = await import('@clack/prompts');
 
+  // Cast, not narrowed: `Option<Value>` distributes over its type parameter —
+  // even here with `Value = string` (not a union of literals), TS can't
+  // correlate a per-entry `.map()` result with the conditional type's
+  // resolved shape (same reasoning as `scanner-selection.wizard.ts`).
   const options = AWS_REGION_CODES.map((code) => ({ value: code, label: code })) as Option<string>[];
   const selected = await autocompleteMultiselect<string>({
     message: 'Which AWS regions do you want to scan? (type to search, space to toggle, enter to confirm)',

--- a/apps/cli/src/wizard/resource-security-selection.wizard.ts
+++ b/apps/cli/src/wizard/resource-security-selection.wizard.ts
@@ -12,6 +12,10 @@ import { RESOURCE_SECURITY_KINDS, RESOURCE_SECURITY_KIND_META, type ResourceSecu
 export async function promptResourceSecuritySelection(): Promise<ResourceSecurityKind[] | undefined> {
   const { cancel, intro, isCancel, multiselect } = await import('@clack/prompts');
   intro('Select the security-posture checks to run (space to toggle, enter to confirm)');
+  // Cast, not narrowed: `Option<Value>` distributes over the
+  // `ResourceSecurityKind` union into one variant per literal — TS can't see
+  // that a per-entry literal built by `.map()` always matches its own variant
+  // (same reasoning as `scanner-selection.wizard.ts`).
   const options = RESOURCE_SECURITY_KINDS.map((kind) => ({
     value: kind,
     label: RESOURCE_SECURITY_KIND_META[kind].label,

--- a/docs/adr/0084-typescript-as-cast-cleanup.md
+++ b/docs/adr/0084-typescript-as-cast-cleanup.md
@@ -1,0 +1,46 @@
+# ADR-0084: TypeScript `as` cast cleanup — mechanical fixes, deferred fallback decisions, legitimate exceptions
+
+- **Status:** Accepted (2026-07-25)
+
+## Context
+
+A codebase-wide review of non-`as const` type assertions applied one heuristic throughout: a cast is only justified when the compiler genuinely cannot derive the information another way (a runtime boundary the type system can't see across, or an SDK/library type that's structurally accurate but incomplete); if the same fact is checked at runtime a few lines away via a plain boolean callback, that's a signal a type predicate should replace the cast instead. ~238 non-`as const` casts existed across production code (excluding tests).
+
+This was done in two passes. The first pass (same week) covered `AwsAdapterError`'s `err as Error` pattern (66 sites across 4 domains), two IAM access-key casts, and `paginate()`'s generic default in three domains (71 casts total) — straightforward because the fix was the same shape each time (widen a constructor parameter, or split a generic default into two overloads).
+
+The second pass (this ADR) re-swept the codebase for everything the first pass didn't touch, since the original count only ever covered those three patterns. It surfaced 19 more casts fixable the same mechanical way, 3 that need a product decision before they can be fixed (not a type-only change), and confirmed 11 more as genuinely unfixable — each verified in isolation against `tsc --strict` before being touched, not assumed from a resemblance to an already-accepted case.
+
+## Decision
+
+**Fixed (19 casts, zero behavior change, each verified to compile without the cast before being applied):**
+
+- `shared-kernel`'s `ValueObject.equals()`/`Entity.deepFreeze()` (4 casts): replaced with an `isRecord` type predicate, or switched from `Object.keys(x as object)` + indexed access to `Object.values(x)` (which needs no cast at all on a generic type parameter narrowed to `object`).
+- Three `--scanners` CLI validators (`resolve-options.ts`, `dead-resources.command.ts`, `resource-security.command.ts`): each already validated every element against a `Set` via a plain `.filter()` callback, then cast the whole array past that check. Replaced with a named `isXKind` type predicate used through `Array.prototype.every`, which TS does narrow the array's element type on.
+- Five CLI commands' `(options.format ?? 'table') as OutputFormat`: same shape — cast *before* the `OUTPUT_FORMATS.includes(format)` check that validates it two lines later. Replaced with an `isOutputFormat` type predicate used for that same check, so the narrowing and the validation are the same line instead of a cast the validation never feeds back into.
+- `static-price-table.adapter.ts`: the `.filter()` that separates real per-region price tables from `prices.json`'s metadata fields (`_comment`, `pricesAsOf`) used a plain boolean callback then cast the result; replaced with an `isRegionPricesEntry` type predicate (one of the two casts here; see Alternatives Considered for why the other one stays).
+- `brand-mark.ts`: `renderCell` cast `bottom` past a `null` check that was only proven by *not* being the two other early-return branches; reordered the three branches so each checks the variable it uses directly, which needs no cast for any of them. Separately, `new Array(n).fill(x) as string[]` → `new Array<string>(n).fill(x)` (the generic overload of the `Array` constructor already returns the right type).
+- `cost-explorer-cache.adapter.ts`: `JSON.parse(raw) as CostPeriodBucket[]` was a fully redundant cast — `JSON.parse` already returns `any`, which needs no cast to satisfy any return type. Removed; this does not add or remove any validation of the cache file's contents.
+- `aws-ec2-instance.scanner.ts`: `(inst.State?.Name ?? 'stopped') as Ec2InstanceState` — verified that the SDK's `InstanceStateName` union and the domain's `Ec2InstanceState` union have exactly the same members, and `'stopped'` (the fallback) is already one of them, so the fallback expression's inferred type already equals `Ec2InstanceState` with no cast needed.
+
+**Deferred — needs a product decision, not a type-only fix (3 casts, left in place with a comment explaining why):**
+
+- `aws-ebs-volume.scanner.ts`'s `v.State as EbsVolumeState` and `aws-load-balancer.scanner.ts`'s `lb.Type as LoadBalancerType`: both SDK unions are exactly identical in membership to their domain counterparts, but the SDK field is optional and neither site has a fallback for the `undefined` case (unlike `aws-ec2-instance`/`aws-rds-instance`, which use `?? 'stopped'`). Removing the cast safely requires picking a placeholder value for "AWS omitted the state/type of a resource that unambiguously exists" — a product choice about what that resource should then look like in a report, not something a cast-removal pass should decide unilaterally.
+- `aws-rds-instance.scanner.ts`'s `(db.DBInstanceStatus ?? 'stopped') as RdsInstanceStatus`: RDS is the one service here where the SDK types the field as an open `string`, not a closed union — AWS documents RDS instance statuses as free-form. A real type guard would need to enumerate every status `RdsInstanceStatus` is meant to cover *and* decide what happens for a real AWS status outside that list (today: silently relabeled via the `stopped` fallback). Both are behavior decisions.
+
+**Confirmed legitimate, left as-is (11 casts, each now commented in place with why):**
+
+- 4× `Option<Value>[]` casts across the wizard files (`scanner-selection`, `dead-resource-selection`, `resource-security-selection`, `region-input`): `@clack/prompts`' `Option<Value>` is a conditional type that distributes over a union `Value`, so `.map()` producing one object shape can't be correlated per-element with its own literal's variant. Confirmed via `tsc`: no restructuring of the `.map()` call avoids this.
+- 4× `normalizedCause as Error & { $metadata?; code? }` in the four `AwsAdapterError` classes (one per domain, ADR-0078 duplication): the AWS SDK attaches these fields to thrown errors only at runtime; its own public `Error` type doesn't declare them.
+- `groupByKind()`'s two casts, duplicated per domain (`cloud-cost`, `dead-resources`, `resource-security`), plus the same pattern newly found in `waste-report.dto.ts` and `wasted-resource.ts`: `Object.keys`/`Object.fromEntries` always return the widened `string`-keyed shape, discarding the fact that the keys/entries were built from an exhaustive `RESOURCE_KINDS`-style list. All now cross-reference each other in comments instead of independently re-deriving the same justification.
+- `aws-pricing-api.adapter.ts`'s `JSON.parse(item as string)`: the AWS Pricing API returns some `PriceList` entries as a boxed `String` object (not a primitive), which `JSON.parse`'s signature doesn't accept even though it works fine at runtime — already commented before this ADR.
+- `static-price-table.adapter.ts`'s `priceTable as Record<string, unknown>` (the other half of the `.filter()` fix above): `prices.json`'s inferred type has fixed, heterogeneous keys rather than a string index signature, so `Object.entries` needs the widened view to iterate it generically before the (now real) type predicate filters it back down.
+
+## Alternatives Considered
+
+- **Fixing all 3 deferred casts by picking a fallback now** (e.g. `v.State ?? 'available'`, `lb.Type ?? 'application'`, a `RdsInstanceStatus` guard defaulting unmapped statuses to `'stopped'`). Rejected for this ADR: each choice silently relabels a resource AWS returned incomplete/unrecognized data for, which changes what a report shows for that resource — worth a deliberate choice, not a side effect of a cast-cleanup pass.
+- **A runtime schema validator (`zod`) for the JSON-sourced casts** (`prices.json`, the Cost Explorer disk cache). Rejected, same reasoning as ADR-0051: both are effectively self-controlled data (`prices.json` is committed and reviewed; the cache is written by this same code and never touched externally), so a full schema layer would validate structure already guaranteed by the code that produced it.
+- **Leaving the `Option<Value>[]` casts uncommented since only one file explained the pattern.** Rejected — the other three wizard files had the identical construct with no explanation, which reads as an oversight rather than a deliberate exception on inspection; now all four cross-reference the same reasoning.
+
+## Consequences
+
+Of the ~34 non-`as const` casts found beyond the first pass's 71, 19 are gone (verified individually against `tsc --strict` before being applied, then confirmed with a full `nx run-many --target=build/test/lint --all` — 1327 tests, 0 lint errors), 3 remain with an explicit comment naming the exact decision blocking their removal, and 11 remain with a comment establishing why no further reduction is possible without moving the problem elsewhere. A grep for `type \w+ as \w+` (import aliases) and the literal string `" as "` inside string/template literals will keep surfacing false positives in any future cast audit — neither is an assertion.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -73,6 +73,7 @@ Each entry follows: Context → Decision → Alternatives Considered → Consequ
 | [0074](0074-waste-policies-one-file-per-policy.md) | Waste policies split into one file per policy | Accepted |
 | [0075](0075-nx-dep-constraints-layer-enforcement.md) | Nx `depConstraints` enforce the hexagonal layering at lint time | Accepted |
 | [0077](0077-scanner-registry-split-on-pricing-seam.md) | Scanner registry split on the always-on/live-pricing seam | Accepted |
+| [0084](0084-typescript-as-cast-cleanup.md) | TypeScript `as` cast cleanup: mechanical fixes, deferred fallback decisions, legitimate exceptions | Accepted |
 
 ## Stack
 

--- a/libs/cloud-cost/application/src/dto/waste-report.dto.ts
+++ b/libs/cloud-cost/application/src/dto/waste-report.dto.ts
@@ -75,6 +75,12 @@ export function toWasteReportDto(
 ): WasteReportDto {
   const grouped = groupByKind(summary.findings);
 
+  // Cast, not narrowed: `Object.keys` always returns plain `string[]`, even
+  // when called on a value typed as `Record<ResourceKind, ...>` — TS
+  // deliberately doesn't trust that a structurally-typed object has exactly
+  // (and only) that key set at runtime. Here it does, because `grouped` was
+  // just built by `groupByKind` from the full `RESOURCE_KINDS` list, one
+  // entry per kind — same reasoning as the casts inside `groupByKind` itself.
   const breakdown = (Object.keys(grouped) as ResourceKind[])
     .filter((kind) => grouped[kind].length > 0)
     .map((kind) => ({

--- a/libs/cloud-cost/domain/src/group-by-kind.ts
+++ b/libs/cloud-cost/domain/src/group-by-kind.ts
@@ -101,6 +101,15 @@ export type FindingsByKind = {
 };
 
 export function groupByKind(findings: readonly WastedResource[]): FindingsByKind {
+  // Casts, not narrowed: `Object.fromEntries` always returns a plain
+  // `{[k: string]: T}`, discarding the per-key literal types `FindingsByKind`
+  // encodes (one concrete entity array per `ResourceKind`) — TS has no way to
+  // recover that from a runtime `.map()` over `RESOURCE_KINDS`. Same for the
+  // per-finding push below: `finding.kind` only proves *which* union member
+  // it is, not that `grouped[finding.kind]` is that member's specific array
+  // type. Both encode the same invariant ("kind discriminates the concrete
+  // type"), already isolated in this one function — moving either cast to a
+  // caller would just multiply it across every consumer instead of removing it.
   const grouped = Object.fromEntries(
     RESOURCE_KINDS.map((kind) => [kind, []]),
   ) as unknown as FindingsByKind;

--- a/libs/cloud-cost/domain/src/wasted-resource.ts
+++ b/libs/cloud-cost/domain/src/wasted-resource.ts
@@ -183,6 +183,10 @@ export const RESOURCE_KIND_META: Record<ResourceKind, ResourceKindMeta> = {
   'codepipeline-pipeline-stale': { label: 'CodePipeline Pipelines (stale)', category: 'waste', estimated: false },
 };
 
+// Cast, not narrowed: `Object.fromEntries` always returns a plain
+// `{[k: string]: T}`, discarding the fact that the entries were built from
+// the exhaustive `RESOURCE_KINDS` list — same reasoning as `groupByKind`'s
+// casts in `group-by-kind.ts`.
 /** Human-readable labels, derived from RESOURCE_KIND_META (single source). */
 export const RESOURCE_KIND_LABELS: Record<ResourceKind, string> = Object.fromEntries(
   RESOURCE_KINDS.map((kind) => [kind, RESOURCE_KIND_META[kind].label]),

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/errors/aws-adapter.error.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/errors/aws-adapter.error.ts
@@ -4,21 +4,28 @@ import { InfrastructureError, createLogger } from 'shared-kernel';
 const logger = createLogger('cloudrift:scanner');
 
 export class AwsAdapterError extends InfrastructureError {
+  override readonly cause: Error;
+
   constructor(
     readonly service: string,
-    override readonly cause: Error,
+    cause: unknown,
   ) {
+    const normalizedCause = cause instanceof Error ? cause : new Error(String(cause));
     super(
       'AWS_ADAPTER_ERROR',
-      `AWS ${service} adapter failed: ${cause.message}`,
+      `AWS ${service} adapter failed: ${normalizedCause.message}`,
     );
+    this.cause = normalizedCause;
     // Diagnostic for the concurrency=12 "socket hang up" investigation
     // (ADR-0063): $metadata.attempts shows whether the SDK's own retries
     // (maxAttempts: 3) were exhausted before surfacing, which distinguishes
     // a transient blip from a sustained connection-level problem.
-    const meta = cause as Error & { $metadata?: { attempts?: number }; code?: string };
+    // Cast, not narrowed: the AWS SDK attaches `$metadata`/`code` to thrown
+    // errors only at runtime — its public `Error` type doesn't declare them,
+    // so there's no structural information to check for.
+    const meta = normalizedCause as Error & { $metadata?: { attempts?: number }; code?: string };
     logger.debug(`${service} adapter error`, {
-      name: cause.name,
+      name: normalizedCause.name,
       code: meta.code,
       attempts: meta.$metadata?.attempts,
     });

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/pricing/aws-pricing-api.adapter.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/pricing/aws-pricing-api.adapter.ts
@@ -200,7 +200,7 @@ export class AwsPricingApiAdapter {
       }
       return Result.ok(table);
     } catch (err) {
-      return Result.fail(new AwsAdapterError('Pricing', err as Error));
+      return Result.fail(new AwsAdapterError('Pricing', err));
     }
   }
 

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/pricing/static-price-table.adapter.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/pricing/static-price-table.adapter.ts
@@ -6,16 +6,24 @@ import {
   type RegionPrices,
 } from './table-pricing.adapter';
 
+function isRegionPricesEntry(entry: [string, unknown]): entry is [string, RegionPrices] {
+  return typeof entry[1] === 'object' && entry[1] !== null;
+}
+
 /**
  * The built-in price table, extracted from `prices.json` by discarding the
  * metadata fields (`_comment`, `pricesAsOf`) and keeping only the per-region
  * tables. Exported so it can be composed with other sources (live API, user
  * overrides).
  */
+// Cast, not narrowed: the JSON module's inferred type has fixed, heterogeneous
+// keys (`_comment`/`pricesAsOf` are strings, each region is an object) rather
+// than a string index signature, so `Object.entries` can't iterate it
+// generically without first widening it to a `Record`. The actual filtering
+// (which entries are real per-region tables) is a real type predicate below,
+// not folded into this cast.
 export const BUILTIN_PRICE_TABLE: PriceTable = Object.fromEntries(
-  Object.entries(priceTable as Record<string, unknown>).filter(
-    ([, value]) => typeof value === 'object' && value !== null,
-  ) as Array<[string, RegionPrices]>,
+  Object.entries(priceTable as Record<string, unknown>).filter(isRegionPricesEntry),
 );
 
 /** Date (YYYY-MM) the built-in price list was last verified. */

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-ami-unused.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-ami-unused.scanner.ts
@@ -116,7 +116,7 @@ export class AwsAmiUnusedScanner implements WasteScannerPort {
 
       return Result.ok(results);
     } catch (err) {
-      return Result.fail(new AwsAdapterError('EC2', err as Error));
+      return Result.fail(new AwsAdapterError('EC2', err));
     } finally {
       client.destroy();
     }

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-codepipeline-pipeline-stale.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-codepipeline-pipeline-stale.scanner.ts
@@ -61,7 +61,7 @@ export class AwsCodepipelinePipelineStaleScanner implements WasteScannerPort {
 
       return Result.ok(results);
     } catch (err) {
-      return Result.fail(new AwsAdapterError('CodePipeline', err as Error));
+      return Result.fail(new AwsAdapterError('CodePipeline', err));
     } finally {
       client.destroy();
     }

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-ebs-snapshot.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-ebs-snapshot.scanner.ts
@@ -116,7 +116,7 @@ export class AwsEbsSnapshotScanner implements WasteScannerPort {
 
       return Result.ok(orphans);
     } catch (err) {
-      return Result.fail(new AwsAdapterError('EC2', err as Error));
+      return Result.fail(new AwsAdapterError('EC2', err));
     } finally {
       client.destroy();
     }

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-ebs-volume.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-ebs-volume.scanner.ts
@@ -64,6 +64,14 @@ export class AwsEbsVolumeScanner implements WasteScannerPort {
             accountId: this.accountId,
             sizeGb: v.Size,
             volumeType,
+            // Cast, not narrowed: the SDK's `VolumeState` union is exactly
+            // `EbsVolumeState`'s member set, but the field is optional in the
+            // SDK type (defensive codegen — AWS always returns it for a real
+            // volume). There's no fallback here unlike `aws-ec2-instance`'s
+            // `?? 'stopped'`/`aws-rds-instance`'s `?? 'stopped'`, because no
+            // `EbsVolumeState` value is a safe stand-in for "AWS omitted the
+            // state of a volume that unambiguously exists" — picking one
+            // needs a product decision (deferred: see cast-cleanup ADR).
             state: v.State as EbsVolumeState,
             createTime: v.CreateTime ?? new Date(),
             detectedAt: now,
@@ -77,7 +85,7 @@ export class AwsEbsVolumeScanner implements WasteScannerPort {
 
       return Result.ok(volumes);
     } catch (err) {
-      return Result.fail(new AwsAdapterError('EBS', err as Error));
+      return Result.fail(new AwsAdapterError('EBS', err));
     } finally {
       client.destroy();
     }

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-ec2-instance.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-ec2-instance.scanner.ts
@@ -11,7 +11,6 @@ import { Result, createLogger } from 'shared-kernel';
 import type {
   AttachedVolume,
   AwsRegion,
-  Ec2InstanceState,
   PricingPort,
   WasteScannerPort,
   WastedResource,
@@ -92,7 +91,7 @@ export class AwsEc2InstanceScanner implements WasteScannerPort {
             region,
             accountId: this.accountId,
             instanceType: inst.InstanceType ?? 'unknown',
-            state: (inst.State?.Name ?? 'stopped') as Ec2InstanceState,
+            state: inst.State?.Name ?? 'stopped',
             launchTime: inst.LaunchTime ?? new Date(0),
             detectedAt: now,
             stoppedSince: parseStoppedSince(inst.StateTransitionReason),
@@ -107,7 +106,7 @@ export class AwsEc2InstanceScanner implements WasteScannerPort {
 
       return Result.ok(instances);
     } catch (err) {
-      return Result.fail(new AwsAdapterError('EC2', err as Error));
+      return Result.fail(new AwsAdapterError('EC2', err));
     } finally {
       client.destroy();
     }

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-ecr-image-untagged.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-ecr-image-untagged.scanner.ts
@@ -83,7 +83,7 @@ export class AwsEcrImageUntaggedScanner implements WasteScannerPort {
 
       return Result.ok(untagged);
     } catch (err) {
-      return Result.fail(new AwsAdapterError('ECR', err as Error));
+      return Result.fail(new AwsAdapterError('ECR', err));
     } finally {
       client.destroy();
     }

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-eks-orphan-pvc.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-eks-orphan-pvc.scanner.ts
@@ -98,7 +98,7 @@ export class AwsEksOrphanPvcScanner implements WasteScannerPort {
 
       return Result.ok(volumes);
     } catch (err) {
-      return Result.fail(new AwsAdapterError('EBS', err as Error));
+      return Result.fail(new AwsAdapterError('EBS', err));
     } finally {
       ec2.destroy();
       eks.destroy();

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-elastic-ip.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-elastic-ip.scanner.ts
@@ -69,7 +69,7 @@ export class AwsElasticIpScanner implements WasteScannerPort {
 
       return Result.ok(unassociated);
     } catch (err) {
-      return Result.fail(new AwsAdapterError('ElasticIP', err as Error));
+      return Result.fail(new AwsAdapterError('ElasticIP', err));
     } finally {
       client.destroy();
     }

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-eni-orphaned.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-eni-orphaned.scanner.ts
@@ -65,7 +65,7 @@ export class AwsEniOrphanedScanner implements WasteScannerPort {
 
       return Result.ok(enis);
     } catch (err) {
-      return Result.fail(new AwsAdapterError('EC2', err as Error));
+      return Result.fail(new AwsAdapterError('EC2', err));
     } finally {
       client.destroy();
     }

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-environment-ghost.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-environment-ghost.scanner.ts
@@ -162,7 +162,7 @@ export class AwsEnvironmentGhostScanner implements WasteScannerPort {
 
       return Result.ok(entities.filter((e) => this.policy.evaluate(e, now).isWaste));
     } catch (err) {
-      return Result.fail(new AwsAdapterError('ResourceGroupsTaggingAPI', err as Error));
+      return Result.fail(new AwsAdapterError('ResourceGroupsTaggingAPI', err));
     } finally {
       taggingClient.destroy();
       ec2Client.destroy();

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-gp2-upgrade.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-gp2-upgrade.scanner.ts
@@ -84,7 +84,7 @@ export class AwsGp2UpgradeScanner implements WasteScannerPort {
 
       return Result.ok(volumes);
     } catch (err) {
-      return Result.fail(new AwsAdapterError('EBS', err as Error));
+      return Result.fail(new AwsAdapterError('EBS', err));
     } finally {
       client.destroy();
     }

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-lambda-loggroup-orphaned.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-lambda-loggroup-orphaned.scanner.ts
@@ -83,7 +83,7 @@ export class AwsLambdaLogGroupOrphanedScanner implements WasteScannerPort {
 
       return Result.ok(entities.filter((group) => this.policy.evaluate(group, now).isWaste));
     } catch (err) {
-      return Result.fail(new AwsAdapterError('CloudWatchLogs', err as Error));
+      return Result.fail(new AwsAdapterError('CloudWatchLogs', err));
     } finally {
       logsClient.destroy();
       lambdaClient.destroy();

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-load-balancer.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-load-balancer.scanner.ts
@@ -62,6 +62,12 @@ export class AwsLoadBalancerScanner implements WasteScannerPort {
             name: lb.LoadBalancerName,
             region,
             accountId: this.accountId,
+            // Cast, not narrowed: same shape as `aws-ebs-volume`'s `state`
+            // cast — the SDK's `LoadBalancerTypeEnum` union exactly matches
+            // `LoadBalancerType`'s member set, but the field is optional in
+            // the SDK type with no safe fallback value for "AWS omitted the
+            // type of a load balancer that unambiguously exists" — picking
+            // one needs a product decision (deferred: see cast-cleanup ADR).
             type: lb.Type as LoadBalancerType,
             createdTime: lb.CreatedTime ?? new Date(),
             detectedAt: now,
@@ -74,7 +80,7 @@ export class AwsLoadBalancerScanner implements WasteScannerPort {
 
       return Result.ok(entities.filter((lb) => this.policy.evaluate(lb, now).isWaste));
     } catch (err) {
-      return Result.fail(new AwsAdapterError('ELB', err as Error));
+      return Result.fail(new AwsAdapterError('ELB', err));
     } finally {
       client.destroy();
     }

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-log-group.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-log-group.scanner.ts
@@ -67,7 +67,7 @@ export class AwsLogGroupScanner implements WasteScannerPort {
 
       return Result.ok(groups);
     } catch (err) {
-      return Result.fail(new AwsAdapterError('CloudWatchLogs', err as Error));
+      return Result.fail(new AwsAdapterError('CloudWatchLogs', err));
     } finally {
       client.destroy();
     }

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-rds-instance.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-rds-instance.scanner.ts
@@ -65,6 +65,15 @@ export class AwsRdsInstanceScanner implements WasteScannerPort {
             accountId: this.accountId,
             dbInstanceClass: db.DBInstanceClass ?? 'unknown',
             engine: db.Engine ?? 'unknown',
+            // Cast, not narrowed: unlike EC2/EBS/ELB, RDS's `DBInstanceStatus`
+            // is typed by the SDK as a plain open-ended `string`, not a
+            // closed union — AWS documents RDS statuses as free-form rather
+            // than a fixed enum. A real type guard would need to (a) list
+            // every status RdsInstanceStatus actually covers and (b) decide
+            // what happens to a real but unmapped status (currently:
+            // silently mislabeled as whatever `?? 'stopped'` picks) — a
+            // product decision, not a mechanical fix (deferred: see
+            // cast-cleanup ADR).
             dbInstanceStatus: (db.DBInstanceStatus ?? 'stopped') as RdsInstanceStatus,
             allocatedStorageGb,
             storageType,
@@ -80,7 +89,7 @@ export class AwsRdsInstanceScanner implements WasteScannerPort {
 
       return Result.ok(instances);
     } catch (err) {
-      return Result.fail(new AwsAdapterError('RDS', err as Error));
+      return Result.fail(new AwsAdapterError('RDS', err));
     } finally {
       client.destroy();
     }

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-rds-manual-snapshot-old.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-rds-manual-snapshot-old.scanner.ts
@@ -65,7 +65,7 @@ export class AwsRdsManualSnapshotOldScanner implements WasteScannerPort {
 
       return Result.ok(snapshots);
     } catch (err) {
-      return Result.fail(new AwsAdapterError('RDS', err as Error));
+      return Result.fail(new AwsAdapterError('RDS', err));
     } finally {
       client.destroy();
     }

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-s3-multipart-upload-abandoned.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-s3-multipart-upload-abandoned.scanner.ts
@@ -91,7 +91,7 @@ export class AwsS3MultipartUploadAbandonedScanner implements WasteScannerPort {
 
       return Result.ok(results);
     } catch (err) {
-      return Result.fail(new AwsAdapterError('S3', err as Error));
+      return Result.fail(new AwsAdapterError('S3', err));
     } finally {
       s3.destroy();
     }

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-s3-no-lifecycle.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-s3-no-lifecycle.scanner.ts
@@ -90,7 +90,7 @@ export class AwsS3NoLifecycleScanner implements WasteScannerPort {
 
       return Result.ok(buckets);
     } catch (err) {
-      return Result.fail(new AwsAdapterError('S3', err as Error));
+      return Result.fail(new AwsAdapterError('S3', err));
     } finally {
       s3.destroy();
       cw.destroy();
@@ -102,7 +102,7 @@ export class AwsS3NoLifecycleScanner implements WasteScannerPort {
       await client.send(new GetBucketLifecycleConfigurationCommand({ Bucket: bucket }));
       return true;
     } catch (err) {
-      if ((err as Error).name === 'NoSuchLifecycleConfiguration') return false;
+      if (err instanceof Error && err.name === 'NoSuchLifecycleConfiguration') return false;
       throw err;
     }
   }

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-sagemaker-training-orphaned.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-sagemaker-training-orphaned.scanner.ts
@@ -104,7 +104,7 @@ export class AwsSageMakerTrainingOrphanedScanner implements WasteScannerPort {
 
       return Result.ok(entities.filter((model) => this.policy.evaluate(model, now).isWaste));
     } catch (err) {
-      return Result.fail(new AwsAdapterError('SageMaker', err as Error));
+      return Result.fail(new AwsAdapterError('SageMaker', err));
     } finally {
       client.destroy();
     }

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-secretsmanager-unused.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-secretsmanager-unused.scanner.ts
@@ -58,7 +58,7 @@ export class AwsSecretsManagerUnusedScanner implements WasteScannerPort {
 
       return Result.ok(secrets);
     } catch (err) {
-      return Result.fail(new AwsAdapterError('SecretsManager', err as Error));
+      return Result.fail(new AwsAdapterError('SecretsManager', err));
     } finally {
       client.destroy();
     }

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-workspaces-idle.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-workspaces-idle.scanner.ts
@@ -106,7 +106,7 @@ export class AwsWorkspacesIdleScanner implements WasteScannerPort {
 
       return Result.ok(idle);
     } catch (err) {
-      return Result.fail(new AwsAdapterError('WorkSpaces', err as Error));
+      return Result.fail(new AwsAdapterError('WorkSpaces', err));
     } finally {
       workspaces.destroy();
     }

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/cloudwatch-idle.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/cloudwatch-idle.scanner.ts
@@ -55,7 +55,7 @@ export abstract class CloudWatchIdleScanner<TPrimaryClient, TRaw, TMetric, TEnti
 
       return Result.ok(entities);
     } catch (err) {
-      return Result.fail(new AwsAdapterError(this.serviceLabel, err as Error));
+      return Result.fail(new AwsAdapterError(this.serviceLabel, err));
     } finally {
       this.destroyPrimaryClient(primary);
       cw.destroy();

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/utils/paginate.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/utils/paginate.ts
@@ -4,17 +4,24 @@
  * the raw items themselves. Callers that filter/map down to a small subset (e.g.
  * only the wasted resources out of tens of thousands of raw entries) keep memory
  * bounded by the filtered output, not by the total item count across all pages.
- * Defaults to identity, preserving the original "accumulate everything" behavior.
+ * Omitting `select` accumulates the raw items unchanged.
  */
-export async function paginate<TItem, TResult = TItem>(
+export function paginate<TItem>(
   fetchPage: (cursor: string | undefined) => Promise<{ items: TItem[]; cursor: string | undefined }>,
-  select: (items: TItem[]) => TResult[] = (items) => items as unknown as TResult[],
-): Promise<TResult[]> {
-  const all: TResult[] = [];
+): Promise<TItem[]>;
+export function paginate<TItem, TResult>(
+  fetchPage: (cursor: string | undefined) => Promise<{ items: TItem[]; cursor: string | undefined }>,
+  select: (items: TItem[]) => TResult[],
+): Promise<TResult[]>;
+export async function paginate<TItem, TResult>(
+  fetchPage: (cursor: string | undefined) => Promise<{ items: TItem[]; cursor: string | undefined }>,
+  select?: (items: TItem[]) => TResult[],
+): Promise<(TItem | TResult)[]> {
+  const all: (TItem | TResult)[] = [];
   let cursor: string | undefined;
   do {
     const page = await fetchPage(cursor);
-    all.push(...select(page.items));
+    all.push(...(select ? select(page.items) : page.items));
     cursor = page.cursor;
   } while (cursor !== undefined);
   return all;

--- a/libs/cost-analytics/infrastructure/aws-adapter/src/cost-explorer/aws-cost-explorer.adapter.ts
+++ b/libs/cost-analytics/infrastructure/aws-adapter/src/cost-explorer/aws-cost-explorer.adapter.ts
@@ -40,7 +40,7 @@ export class AwsCostExplorerAdapter implements CostExplorerPort {
 
       return Result.ok(results.map(toBucket));
     } catch (err) {
-      return Result.fail(new AwsAdapterError('CostExplorer', err as Error));
+      return Result.fail(new AwsAdapterError('CostExplorer', err));
     } finally {
       client.destroy();
     }

--- a/libs/cost-analytics/infrastructure/aws-adapter/src/cost-explorer/cost-explorer-cache.adapter.ts
+++ b/libs/cost-analytics/infrastructure/aws-adapter/src/cost-explorer/cost-explorer-cache.adapter.ts
@@ -68,7 +68,7 @@ export class CachedCostExplorerAdapter implements CostExplorerPort {
   private async readCache(path: string): Promise<CostPeriodBucket[] | undefined> {
     try {
       const raw = await readFile(path, 'utf8');
-      return JSON.parse(raw) as CostPeriodBucket[];
+      return JSON.parse(raw);
     } catch {
       return undefined;
     }

--- a/libs/cost-analytics/infrastructure/aws-adapter/src/errors/aws-adapter.error.ts
+++ b/libs/cost-analytics/infrastructure/aws-adapter/src/errors/aws-adapter.error.ts
@@ -4,21 +4,28 @@ import { InfrastructureError, createLogger } from 'shared-kernel';
 const logger = createLogger('cloudrift:scanner');
 
 export class AwsAdapterError extends InfrastructureError {
+  override readonly cause: Error;
+
   constructor(
     readonly service: string,
-    override readonly cause: Error,
+    cause: unknown,
   ) {
+    const normalizedCause = cause instanceof Error ? cause : new Error(String(cause));
     super(
       'AWS_ADAPTER_ERROR',
-      `AWS ${service} adapter failed: ${cause.message}`,
+      `AWS ${service} adapter failed: ${normalizedCause.message}`,
     );
+    this.cause = normalizedCause;
     // Diagnostic for the concurrency=12 "socket hang up" investigation
     // (ADR-0063): $metadata.attempts shows whether the SDK's own retries
     // (maxAttempts: 3) were exhausted before surfacing, which distinguishes
     // a transient blip from a sustained connection-level problem.
-    const meta = cause as Error & { $metadata?: { attempts?: number }; code?: string };
+    // Cast, not narrowed: the AWS SDK attaches `$metadata`/`code` to thrown
+    // errors only at runtime — its public `Error` type doesn't declare them,
+    // so there's no structural information to check for.
+    const meta = normalizedCause as Error & { $metadata?: { attempts?: number }; code?: string };
     logger.debug(`${service} adapter error`, {
-      name: cause.name,
+      name: normalizedCause.name,
       code: meta.code,
       attempts: meta.$metadata?.attempts,
     });

--- a/libs/dead-resources/domain/src/group-by-kind.ts
+++ b/libs/dead-resources/domain/src/group-by-kind.ts
@@ -49,6 +49,12 @@ export type DeadFindingsByKind = {
 };
 
 export function groupByKind(findings: readonly DeadResource[]): DeadFindingsByKind {
+  // Casts, not narrowed: same shape as `cloud-cost-domain`'s `groupByKind`
+  // (ADR-0078 deliberate copy) — `Object.fromEntries` discards the per-key
+  // literal types `DeadFindingsByKind` encodes, and `finding.kind` only
+  // proves which union member it is, not that `grouped[finding.kind]` is
+  // that member's array type. Already isolated in this one function; moving
+  // either cast to a caller would just multiply it, not remove it.
   const grouped = Object.fromEntries(
     DEAD_RESOURCE_KINDS.map((kind) => [kind, []]),
   ) as unknown as DeadFindingsByKind;

--- a/libs/dead-resources/infrastructure/aws-adapter/src/errors/aws-adapter.error.ts
+++ b/libs/dead-resources/infrastructure/aws-adapter/src/errors/aws-adapter.error.ts
@@ -5,14 +5,21 @@ const logger = createLogger('cloudrift:scanner');
 
 /** Deliberate copy of `cloud-cost-infrastructure-aws-adapter`'s own `AwsAdapterError` (ADR-0078). */
 export class AwsAdapterError extends InfrastructureError {
+  override readonly cause: Error;
+
   constructor(
     readonly service: string,
-    override readonly cause: Error,
+    cause: unknown,
   ) {
-    super('AWS_ADAPTER_ERROR', `AWS ${service} adapter failed: ${cause.message}`);
-    const meta = cause as Error & { $metadata?: { attempts?: number }; code?: string };
+    const normalizedCause = cause instanceof Error ? cause : new Error(String(cause));
+    super('AWS_ADAPTER_ERROR', `AWS ${service} adapter failed: ${normalizedCause.message}`);
+    this.cause = normalizedCause;
+    // Cast, not narrowed: the AWS SDK attaches `$metadata`/`code` to thrown
+    // errors only at runtime — its public `Error` type doesn't declare them,
+    // so there's no structural information to check for.
+    const meta = normalizedCause as Error & { $metadata?: { attempts?: number }; code?: string };
     logger.debug(`${service} adapter error`, {
-      name: cause.name,
+      name: normalizedCause.name,
       code: meta.code,
       attempts: meta.$metadata?.attempts,
     });

--- a/libs/dead-resources/infrastructure/aws-adapter/src/scanners/aws-acm-certificate-unused.scanner.ts
+++ b/libs/dead-resources/infrastructure/aws-adapter/src/scanners/aws-acm-certificate-unused.scanner.ts
@@ -55,7 +55,7 @@ export class AwsAcmCertificateUnusedScanner implements DeadResourceScannerPort {
 
       return Result.ok(results);
     } catch (err) {
-      return Result.fail(new AwsAdapterError('ACM', err as Error));
+      return Result.fail(new AwsAdapterError('ACM', err));
     } finally {
       client.destroy();
     }

--- a/libs/dead-resources/infrastructure/aws-adapter/src/scanners/aws-cloudformation-stack-stuck.scanner.ts
+++ b/libs/dead-resources/infrastructure/aws-adapter/src/scanners/aws-cloudformation-stack-stuck.scanner.ts
@@ -58,7 +58,7 @@ export class AwsCloudformationStackStuckScanner implements DeadResourceScannerPo
 
       return Result.ok(results);
     } catch (err) {
-      return Result.fail(new AwsAdapterError('CloudFormation', err as Error));
+      return Result.fail(new AwsAdapterError('CloudFormation', err));
     } finally {
       client.destroy();
     }

--- a/libs/dead-resources/infrastructure/aws-adapter/src/scanners/aws-cloudwatch-alarm-orphaned.scanner.ts
+++ b/libs/dead-resources/infrastructure/aws-adapter/src/scanners/aws-cloudwatch-alarm-orphaned.scanner.ts
@@ -56,7 +56,7 @@ export class AwsCloudwatchAlarmOrphanedScanner implements DeadResourceScannerPor
 
       return Result.ok(results);
     } catch (err) {
-      return Result.fail(new AwsAdapterError('CloudWatch', err as Error));
+      return Result.fail(new AwsAdapterError('CloudWatch', err));
     } finally {
       client.destroy();
     }

--- a/libs/dead-resources/infrastructure/aws-adapter/src/scanners/aws-ec2-keypair-unused.scanner.ts
+++ b/libs/dead-resources/infrastructure/aws-adapter/src/scanners/aws-ec2-keypair-unused.scanner.ts
@@ -81,7 +81,7 @@ export class AwsEc2KeyPairUnusedScanner implements DeadResourceScannerPort {
 
       return Result.ok(results);
     } catch (err) {
-      return Result.fail(new AwsAdapterError('EC2', err as Error));
+      return Result.fail(new AwsAdapterError('EC2', err));
     } finally {
       client.destroy();
     }

--- a/libs/dead-resources/infrastructure/aws-adapter/src/scanners/aws-ec2-ri-expiring-soon.scanner.ts
+++ b/libs/dead-resources/infrastructure/aws-adapter/src/scanners/aws-ec2-ri-expiring-soon.scanner.ts
@@ -58,7 +58,7 @@ export class AwsEc2RiExpiringSoonScanner implements DeadResourceScannerPort {
 
       return Result.ok(results);
     } catch (err) {
-      return Result.fail(new AwsAdapterError('EC2', err as Error));
+      return Result.fail(new AwsAdapterError('EC2', err));
     } finally {
       client.destroy();
     }

--- a/libs/dead-resources/infrastructure/aws-adapter/src/scanners/aws-ec2-security-group-unused.scanner.ts
+++ b/libs/dead-resources/infrastructure/aws-adapter/src/scanners/aws-ec2-security-group-unused.scanner.ts
@@ -72,7 +72,7 @@ export class AwsEc2SecurityGroupUnusedScanner implements DeadResourceScannerPort
 
       return Result.ok(results);
     } catch (err) {
-      return Result.fail(new AwsAdapterError('EC2', err as Error));
+      return Result.fail(new AwsAdapterError('EC2', err));
     } finally {
       client.destroy();
     }

--- a/libs/dead-resources/infrastructure/aws-adapter/src/scanners/aws-ecr-repository-empty.scanner.ts
+++ b/libs/dead-resources/infrastructure/aws-adapter/src/scanners/aws-ecr-repository-empty.scanner.ts
@@ -57,7 +57,7 @@ export class AwsEcrRepositoryEmptyScanner implements DeadResourceScannerPort {
             tags: {},
           });
         } catch (err) {
-          logger.debug(`ecr-repository-empty: skipped ${repo.repositoryName}, could not describe images`, { error: (err as Error).message });
+          logger.debug(`ecr-repository-empty: skipped ${repo.repositoryName}, could not describe images`, { error: err instanceof Error ? err.message : String(err) });
           return undefined;
         }
       });
@@ -68,7 +68,7 @@ export class AwsEcrRepositoryEmptyScanner implements DeadResourceScannerPort {
 
       return Result.ok(results);
     } catch (err) {
-      return Result.fail(new AwsAdapterError('ECR', err as Error));
+      return Result.fail(new AwsAdapterError('ECR', err));
     } finally {
       client.destroy();
     }

--- a/libs/dead-resources/infrastructure/aws-adapter/src/scanners/aws-eventbridge-rule-no-targets.scanner.ts
+++ b/libs/dead-resources/infrastructure/aws-adapter/src/scanners/aws-eventbridge-rule-no-targets.scanner.ts
@@ -61,7 +61,7 @@ export class AwsEventbridgeRuleNoTargetsScanner implements DeadResourceScannerPo
 
       return Result.ok(results);
     } catch (err) {
-      return Result.fail(new AwsAdapterError('EventBridge', err as Error));
+      return Result.fail(new AwsAdapterError('EventBridge', err));
     } finally {
       client.destroy();
     }

--- a/libs/dead-resources/infrastructure/aws-adapter/src/scanners/aws-iam-access-key-stale.scanner.ts
+++ b/libs/dead-resources/infrastructure/aws-adapter/src/scanners/aws-iam-access-key-stale.scanner.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-import { IAMClient, ListUsersCommand, ListAccessKeysCommand, type User } from '@aws-sdk/client-iam';
+import { IAMClient, ListUsersCommand, ListAccessKeysCommand, type User, type AccessKeyMetadata } from '@aws-sdk/client-iam';
 import { Result } from 'shared-kernel';
 import type { AwsRegion, DeadResourceScannerPort, DeadResource } from 'dead-resources-domain';
 import { IamAccessKeyStale, IamAccessKeyStalePolicy } from 'dead-resources-domain';
@@ -15,6 +15,7 @@ const IAM_ENDPOINT_REGION = 'us-east-1';
 const ACCESS_KEY_LOOKUP_CONCURRENCY = 5;
 
 type UserWithName = User & { UserName: string };
+type ActiveAccessKey = AccessKeyMetadata & { AccessKeyId: string; CreateDate: Date };
 
 /**
  * Detects **active** IAM access keys not rotated within the policy's age
@@ -46,15 +47,15 @@ export class AwsIamAccessKeyStaleScanner implements DeadResourceScannerPort {
         // AWS caps a user at 2 access keys — one unpaginated call always returns the complete list.
         const r = await client.send(new ListAccessKeysCommand({ UserName: user.UserName }));
         return (r.AccessKeyMetadata ?? [])
-          .filter((k) => !!k.AccessKeyId && !!k.CreateDate && k.Status === 'Active')
+          .filter((k): k is ActiveAccessKey => !!k.AccessKeyId && !!k.CreateDate && k.Status === 'Active')
           .map(
             (k) =>
               new IamAccessKeyStale({
-                accessKeyId: k.AccessKeyId as string,
+                accessKeyId: k.AccessKeyId,
                 userName: user.UserName,
                 status: 'Active',
                 accountId: this.accountId,
-                createdAt: k.CreateDate as Date,
+                createdAt: k.CreateDate,
                 detectedAt: now,
                 tags: {},
               }),
@@ -65,7 +66,7 @@ export class AwsIamAccessKeyStaleScanner implements DeadResourceScannerPort {
 
       return Result.ok(results);
     } catch (err) {
-      return Result.fail(new AwsAdapterError('IAM', err as Error));
+      return Result.fail(new AwsAdapterError('IAM', err));
     } finally {
       client.destroy();
     }

--- a/libs/dead-resources/infrastructure/aws-adapter/src/scanners/aws-iam-instance-profile-unattached.scanner.ts
+++ b/libs/dead-resources/infrastructure/aws-adapter/src/scanners/aws-iam-instance-profile-unattached.scanner.ts
@@ -82,7 +82,7 @@ export class AwsIamInstanceProfileUnattachedScanner implements DeadResourceScann
           }
         } catch (err) {
           // A single unreachable/opted-out region shouldn't fail the whole account-wide check.
-          logger.debug(`iam-instance-profile-unattached: skipped region ${regionCode}`, { error: (err as Error).message });
+          logger.debug(`iam-instance-profile-unattached: skipped region ${regionCode}`, { error: err instanceof Error ? err.message : String(err) });
         } finally {
           client.destroy();
         }
@@ -111,7 +111,7 @@ export class AwsIamInstanceProfileUnattachedScanner implements DeadResourceScann
 
       return Result.ok(results);
     } catch (err) {
-      return Result.fail(new AwsAdapterError('IAM', err as Error));
+      return Result.fail(new AwsAdapterError('IAM', err));
     } finally {
       iamClient.destroy();
       regionDiscoveryClient.destroy();

--- a/libs/dead-resources/infrastructure/aws-adapter/src/scanners/aws-iam-policy-unattached.scanner.ts
+++ b/libs/dead-resources/infrastructure/aws-adapter/src/scanners/aws-iam-policy-unattached.scanner.ts
@@ -59,7 +59,7 @@ export class AwsIamPolicyUnattachedScanner implements DeadResourceScannerPort {
 
       return Result.ok(results);
     } catch (err) {
-      return Result.fail(new AwsAdapterError('IAM', err as Error));
+      return Result.fail(new AwsAdapterError('IAM', err));
     } finally {
       client.destroy();
     }

--- a/libs/dead-resources/infrastructure/aws-adapter/src/scanners/aws-iam-role-unused.scanner.ts
+++ b/libs/dead-resources/infrastructure/aws-adapter/src/scanners/aws-iam-role-unused.scanner.ts
@@ -61,7 +61,7 @@ export class AwsIamRoleUnusedScanner implements DeadResourceScannerPort {
 
       return Result.ok(results);
     } catch (err) {
-      return Result.fail(new AwsAdapterError('IAM', err as Error));
+      return Result.fail(new AwsAdapterError('IAM', err));
     } finally {
       client.destroy();
     }

--- a/libs/dead-resources/infrastructure/aws-adapter/src/scanners/aws-iam-user-inactive.scanner.ts
+++ b/libs/dead-resources/infrastructure/aws-adapter/src/scanners/aws-iam-user-inactive.scanner.ts
@@ -85,7 +85,7 @@ export class AwsIamUserInactiveScanner implements DeadResourceScannerPort {
 
       return Result.ok(results);
     } catch (err) {
-      return Result.fail(new AwsAdapterError('IAM', err as Error));
+      return Result.fail(new AwsAdapterError('IAM', err));
     } finally {
       client.destroy();
     }

--- a/libs/dead-resources/infrastructure/aws-adapter/src/scanners/aws-logs-loggroup-empty.scanner.ts
+++ b/libs/dead-resources/infrastructure/aws-adapter/src/scanners/aws-logs-loggroup-empty.scanner.ts
@@ -54,7 +54,7 @@ export class AwsLogsLogGroupEmptyScanner implements DeadResourceScannerPort {
 
       return Result.ok(results);
     } catch (err) {
-      return Result.fail(new AwsAdapterError('CloudWatchLogs', err as Error));
+      return Result.fail(new AwsAdapterError('CloudWatchLogs', err));
     } finally {
       client.destroy();
     }

--- a/libs/dead-resources/infrastructure/aws-adapter/src/scanners/aws-route53-hostedzone-empty.scanner.ts
+++ b/libs/dead-resources/infrastructure/aws-adapter/src/scanners/aws-route53-hostedzone-empty.scanner.ts
@@ -60,7 +60,7 @@ export class AwsRoute53HostedZoneEmptyScanner implements DeadResourceScannerPort
 
       return Result.ok(results);
     } catch (err) {
-      return Result.fail(new AwsAdapterError('Route53', err as Error));
+      return Result.fail(new AwsAdapterError('Route53', err));
     } finally {
       client.destroy();
     }

--- a/libs/dead-resources/infrastructure/aws-adapter/src/scanners/aws-s3-bucket-empty.scanner.ts
+++ b/libs/dead-resources/infrastructure/aws-adapter/src/scanners/aws-s3-bucket-empty.scanner.ts
@@ -61,7 +61,7 @@ export class AwsS3BucketEmptyScanner implements DeadResourceScannerPort {
             tags: {},
           });
         } catch (err) {
-          logger.debug(`s3-bucket-empty: skipped ${bucket.Name}, could not list objects`, { error: (err as Error).message });
+          logger.debug(`s3-bucket-empty: skipped ${bucket.Name}, could not list objects`, { error: err instanceof Error ? err.message : String(err) });
           return undefined;
         }
       });
@@ -72,7 +72,7 @@ export class AwsS3BucketEmptyScanner implements DeadResourceScannerPort {
 
       return Result.ok(results);
     } catch (err) {
-      return Result.fail(new AwsAdapterError('S3', err as Error));
+      return Result.fail(new AwsAdapterError('S3', err));
     } finally {
       client.destroy();
     }

--- a/libs/dead-resources/infrastructure/aws-adapter/src/scanners/aws-sns-topic-unsubscribed.scanner.ts
+++ b/libs/dead-resources/infrastructure/aws-adapter/src/scanners/aws-sns-topic-unsubscribed.scanner.ts
@@ -61,7 +61,7 @@ export class AwsSnsTopicUnsubscribedScanner implements DeadResourceScannerPort {
 
       return Result.ok(results);
     } catch (err) {
-      return Result.fail(new AwsAdapterError('SNS', err as Error));
+      return Result.fail(new AwsAdapterError('SNS', err));
     } finally {
       client.destroy();
     }

--- a/libs/dead-resources/infrastructure/aws-adapter/src/scanners/aws-stepfunctions-statemachine-unused.scanner.ts
+++ b/libs/dead-resources/infrastructure/aws-adapter/src/scanners/aws-stepfunctions-statemachine-unused.scanner.ts
@@ -61,7 +61,7 @@ export class AwsStepfunctionsStatemachineUnusedScanner implements DeadResourceSc
 
       return Result.ok(results);
     } catch (err) {
-      return Result.fail(new AwsAdapterError('SFN', err as Error));
+      return Result.fail(new AwsAdapterError('SFN', err));
     } finally {
       client.destroy();
     }

--- a/libs/dead-resources/infrastructure/aws-adapter/src/utils/paginate.ts
+++ b/libs/dead-resources/infrastructure/aws-adapter/src/utils/paginate.ts
@@ -7,15 +7,22 @@
  * ~15-line, fully generic utility. Revisit (move to `shared-kernel`) if a
  * third AWS-touching infra lib ever needs it too.
  */
-export async function paginate<TItem, TResult = TItem>(
+export function paginate<TItem>(
   fetchPage: (cursor: string | undefined) => Promise<{ items: TItem[]; cursor: string | undefined }>,
-  select: (items: TItem[]) => TResult[] = (items) => items as unknown as TResult[],
-): Promise<TResult[]> {
-  const all: TResult[] = [];
+): Promise<TItem[]>;
+export function paginate<TItem, TResult>(
+  fetchPage: (cursor: string | undefined) => Promise<{ items: TItem[]; cursor: string | undefined }>,
+  select: (items: TItem[]) => TResult[],
+): Promise<TResult[]>;
+export async function paginate<TItem, TResult>(
+  fetchPage: (cursor: string | undefined) => Promise<{ items: TItem[]; cursor: string | undefined }>,
+  select?: (items: TItem[]) => TResult[],
+): Promise<(TItem | TResult)[]> {
+  const all: (TItem | TResult)[] = [];
   let cursor: string | undefined;
   do {
     const page = await fetchPage(cursor);
-    all.push(...select(page.items));
+    all.push(...(select ? select(page.items) : page.items));
     cursor = page.cursor;
   } while (cursor !== undefined);
   return all;

--- a/libs/resource-security/domain/src/group-by-kind.ts
+++ b/libs/resource-security/domain/src/group-by-kind.ts
@@ -41,6 +41,12 @@ export type SecurityFindingsByKind = {
 };
 
 export function groupByKind(findings: readonly SecurityFinding[]): SecurityFindingsByKind {
+  // Casts, not narrowed: same shape as `cloud-cost-domain`'s `groupByKind`
+  // (ADR-0078 deliberate copy) — `Object.fromEntries` discards the per-key
+  // literal types `SecurityFindingsByKind` encodes, and `finding.kind` only
+  // proves which union member it is, not that `grouped[finding.kind]` is
+  // that member's array type. Already isolated in this one function; moving
+  // either cast to a caller would just multiply it, not remove it.
   const grouped = Object.fromEntries(
     RESOURCE_SECURITY_KINDS.map((kind) => [kind, []]),
   ) as unknown as SecurityFindingsByKind;

--- a/libs/resource-security/infrastructure/aws-adapter/src/errors/aws-adapter.error.ts
+++ b/libs/resource-security/infrastructure/aws-adapter/src/errors/aws-adapter.error.ts
@@ -5,14 +5,21 @@ const logger = createLogger('cloudrift:scanner');
 
 /** Deliberate copy of `dead-resources-infrastructure-aws-adapter`'s own `AwsAdapterError` (ADR-0078). */
 export class AwsAdapterError extends InfrastructureError {
+  override readonly cause: Error;
+
   constructor(
     readonly service: string,
-    override readonly cause: Error,
+    cause: unknown,
   ) {
-    super('AWS_ADAPTER_ERROR', `AWS ${service} adapter failed: ${cause.message}`);
-    const meta = cause as Error & { $metadata?: { attempts?: number }; code?: string };
+    const normalizedCause = cause instanceof Error ? cause : new Error(String(cause));
+    super('AWS_ADAPTER_ERROR', `AWS ${service} adapter failed: ${normalizedCause.message}`);
+    this.cause = normalizedCause;
+    // Cast, not narrowed: the AWS SDK attaches `$metadata`/`code` to thrown
+    // errors only at runtime — its public `Error` type doesn't declare them,
+    // so there's no structural information to check for.
+    const meta = normalizedCause as Error & { $metadata?: { attempts?: number }; code?: string };
     logger.debug(`${service} adapter error`, {
-      name: cause.name,
+      name: normalizedCause.name,
       code: meta.code,
       attempts: meta.$metadata?.attempts,
     });

--- a/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-cloudtrail-not-multiregion.scanner.ts
+++ b/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-cloudtrail-not-multiregion.scanner.ts
@@ -33,7 +33,7 @@ export class AwsCloudtrailNotMultiregionScanner implements ResourceSecurityScann
 
       return Result.ok(this.policy.evaluate(finding, now).flagged ? [finding] : []);
     } catch (err) {
-      return Result.fail(new AwsAdapterError('CloudTrail', err as Error));
+      return Result.fail(new AwsAdapterError('CloudTrail', err));
     } finally {
       client.destroy();
     }

--- a/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-ec2-default-security-group-permissive.scanner.ts
+++ b/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-ec2-default-security-group-permissive.scanner.ts
@@ -55,7 +55,7 @@ export class AwsEc2DefaultSecurityGroupPermissiveScanner implements ResourceSecu
 
       return Result.ok(results);
     } catch (err) {
-      return Result.fail(new AwsAdapterError('EC2', err as Error));
+      return Result.fail(new AwsAdapterError('EC2', err));
     } finally {
       client.destroy();
     }

--- a/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-ec2-security-group-open-ingress.scanner.ts
+++ b/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-ec2-security-group-open-ingress.scanner.ts
@@ -83,7 +83,7 @@ export class AwsEc2SecurityGroupOpenIngressScanner implements ResourceSecuritySc
 
       return Result.ok(results);
     } catch (err) {
-      return Result.fail(new AwsAdapterError('EC2', err as Error));
+      return Result.fail(new AwsAdapterError('EC2', err));
     } finally {
       client.destroy();
     }

--- a/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-ec2-snapshot-public.scanner.ts
+++ b/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-ec2-snapshot-public.scanner.ts
@@ -55,7 +55,7 @@ export class AwsEc2SnapshotPublicScanner implements ResourceSecurityScannerPort 
 
       return Result.ok(results);
     } catch (err) {
-      return Result.fail(new AwsAdapterError('EC2', err as Error));
+      return Result.fail(new AwsAdapterError('EC2', err));
     } finally {
       client.destroy();
     }

--- a/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-ec2-volume-unencrypted.scanner.ts
+++ b/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-ec2-volume-unencrypted.scanner.ts
@@ -45,7 +45,7 @@ export class AwsEc2VolumeUnencryptedScanner implements ResourceSecurityScannerPo
 
       return Result.ok(results);
     } catch (err) {
-      return Result.fail(new AwsAdapterError('EC2', err as Error));
+      return Result.fail(new AwsAdapterError('EC2', err));
     } finally {
       client.destroy();
     }

--- a/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-iam-access-key-rotation-overdue.scanner.ts
+++ b/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-iam-access-key-rotation-overdue.scanner.ts
@@ -59,7 +59,7 @@ export class AwsIamAccessKeyRotationOverdueScanner implements ResourceSecuritySc
 
       return Result.ok(results);
     } catch (err) {
-      return Result.fail(new AwsAdapterError('IAM', err as Error));
+      return Result.fail(new AwsAdapterError('IAM', err));
     } finally {
       client.destroy();
     }

--- a/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-iam-password-policy-weak.scanner.ts
+++ b/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-iam-password-policy-weak.scanner.ts
@@ -42,13 +42,13 @@ export class AwsIamPasswordPolicyWeakScanner implements ResourceSecurityScannerP
           tags: {},
         });
       } catch (err) {
-        if ((err as Error).name !== NO_POLICY_ERROR_NAME) throw err;
+        if (!(err instanceof Error) || err.name !== NO_POLICY_ERROR_NAME) throw err;
         finding = new IamPasswordPolicyWeak({ accountId: this.accountId, exists: false, detectedAt: now, tags: {} });
       }
 
       return Result.ok(this.policy.evaluate(finding, now).flagged ? [finding] : []);
     } catch (err) {
-      return Result.fail(new AwsAdapterError('IAM', err as Error));
+      return Result.fail(new AwsAdapterError('IAM', err));
     } finally {
       client.destroy();
     }

--- a/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-iam-root-access-key-active.scanner.ts
+++ b/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-iam-root-access-key-active.scanner.ts
@@ -32,7 +32,7 @@ export class AwsIamRootAccessKeyActiveScanner implements ResourceSecurityScanner
 
       return Result.ok(this.policy.evaluate(finding, now).flagged ? [finding] : []);
     } catch (err) {
-      return Result.fail(new AwsAdapterError('IAM', err as Error));
+      return Result.fail(new AwsAdapterError('IAM', err));
     } finally {
       client.destroy();
     }

--- a/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-iam-root-mfa-disabled.scanner.ts
+++ b/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-iam-root-mfa-disabled.scanner.ts
@@ -37,7 +37,7 @@ export class AwsIamRootMfaDisabledScanner implements ResourceSecurityScannerPort
 
       return Result.ok(this.policy.evaluate(finding, now).flagged ? [finding] : []);
     } catch (err) {
-      return Result.fail(new AwsAdapterError('IAM', err as Error));
+      return Result.fail(new AwsAdapterError('IAM', err));
     } finally {
       client.destroy();
     }

--- a/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-iam-user-mfa-disabled.scanner.ts
+++ b/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-iam-user-mfa-disabled.scanner.ts
@@ -54,7 +54,7 @@ export class AwsIamUserMfaDisabledScanner implements ResourceSecurityScannerPort
 
       return Result.ok(results);
     } catch (err) {
-      return Result.fail(new AwsAdapterError('IAM', err as Error));
+      return Result.fail(new AwsAdapterError('IAM', err));
     } finally {
       client.destroy();
     }

--- a/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-rds-instance-publicly-accessible.scanner.ts
+++ b/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-rds-instance-publicly-accessible.scanner.ts
@@ -45,7 +45,7 @@ export class AwsRdsInstancePubliclyAccessibleScanner implements ResourceSecurity
 
       return Result.ok(results);
     } catch (err) {
-      return Result.fail(new AwsAdapterError('RDS', err as Error));
+      return Result.fail(new AwsAdapterError('RDS', err));
     } finally {
       client.destroy();
     }

--- a/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-rds-instance-unencrypted.scanner.ts
+++ b/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-rds-instance-unencrypted.scanner.ts
@@ -45,7 +45,7 @@ export class AwsRdsInstanceUnencryptedScanner implements ResourceSecurityScanner
 
       return Result.ok(results);
     } catch (err) {
-      return Result.fail(new AwsAdapterError('RDS', err as Error));
+      return Result.fail(new AwsAdapterError('RDS', err));
     } finally {
       client.destroy();
     }

--- a/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-s3-bucket-encryption-missing.scanner.ts
+++ b/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-s3-bucket-encryption-missing.scanner.ts
@@ -38,8 +38,8 @@ export class AwsS3BucketEncryptionMissingScanner implements ResourceSecurityScan
           await client.send(new GetBucketEncryptionCommand({ Bucket: bucketName }));
           return undefined; // encryption configuration exists
         } catch (err) {
-          if ((err as Error).name !== NO_ENCRYPTION_ERROR_NAME) {
-            logger.debug('s3-bucket-encryption-missing: skipping bucket after error', { bucketName, error: (err as Error).message });
+          if (!(err instanceof Error) || err.name !== NO_ENCRYPTION_ERROR_NAME) {
+            logger.debug('s3-bucket-encryption-missing: skipping bucket after error', { bucketName, error: err instanceof Error ? err.message : String(err) });
             return undefined;
           }
           return new S3BucketEncryptionMissing({ bucketName, accountId: this.accountId, detectedAt: now, tags: {} });
@@ -52,7 +52,7 @@ export class AwsS3BucketEncryptionMissingScanner implements ResourceSecurityScan
 
       return Result.ok(results);
     } catch (err) {
-      return Result.fail(new AwsAdapterError('S3', err as Error));
+      return Result.fail(new AwsAdapterError('S3', err));
     } finally {
       client.destroy();
     }

--- a/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-s3-bucket-public.scanner.ts
+++ b/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-s3-bucket-public.scanner.ts
@@ -27,7 +27,7 @@ async function findPublicVia(client: S3Client, bucketName: string): Promise<stri
     const { PublicAccessBlockConfiguration: cfg } = await client.send(new GetPublicAccessBlockCommand({ Bucket: bucketName }));
     fullyBlocked = !!(cfg?.BlockPublicAcls && cfg?.IgnorePublicAcls && cfg?.BlockPublicPolicy && cfg?.RestrictPublicBuckets);
   } catch (err) {
-    if ((err as Error).name !== 'NoSuchPublicAccessBlockConfiguration') throw err;
+    if (!(err instanceof Error) || err.name !== 'NoSuchPublicAccessBlockConfiguration') throw err;
   }
   // S3 Block Public Access, when fully enabled, overrides both ACLs and bucket policies account/bucket-wide.
   if (fullyBlocked) return [];
@@ -38,7 +38,7 @@ async function findPublicVia(client: S3Client, bucketName: string): Promise<stri
     const { PolicyStatus } = await client.send(new GetBucketPolicyStatusCommand({ Bucket: bucketName }));
     if (PolicyStatus?.IsPublic) reasons.push('bucket policy allows public access');
   } catch (err) {
-    if ((err as Error).name !== 'NoSuchBucketPolicy') throw err;
+    if (!(err instanceof Error) || err.name !== 'NoSuchBucketPolicy') throw err;
   }
 
   const { Grants } = await client.send(new GetBucketAclCommand({ Bucket: bucketName }));
@@ -76,7 +76,7 @@ export class AwsS3BucketPublicScanner implements ResourceSecurityScannerPort {
           return new S3BucketPublic({ bucketName, accountId: this.accountId, publicVia, detectedAt: now, tags: {} });
         } catch (err) {
           // A single unreadable bucket (e.g. a bucket policy denying this principal) shouldn't fail the whole scan.
-          logger.debug('s3-bucket-public: skipping bucket after error', { bucketName, error: (err as Error).message });
+          logger.debug('s3-bucket-public: skipping bucket after error', { bucketName, error: err instanceof Error ? err.message : String(err) });
           return undefined;
         }
       });
@@ -87,7 +87,7 @@ export class AwsS3BucketPublicScanner implements ResourceSecurityScannerPort {
 
       return Result.ok(results);
     } catch (err) {
-      return Result.fail(new AwsAdapterError('S3', err as Error));
+      return Result.fail(new AwsAdapterError('S3', err));
     } finally {
       client.destroy();
     }

--- a/libs/resource-security/infrastructure/aws-adapter/src/utils/paginate.ts
+++ b/libs/resource-security/infrastructure/aws-adapter/src/utils/paginate.ts
@@ -6,15 +6,22 @@
  * infrastructure lib decoupled from that one, at the cost of duplicating a
  * ~15-line, fully generic utility.
  */
-export async function paginate<TItem, TResult = TItem>(
+export function paginate<TItem>(
   fetchPage: (cursor: string | undefined) => Promise<{ items: TItem[]; cursor: string | undefined }>,
-  select: (items: TItem[]) => TResult[] = (items) => items as unknown as TResult[],
-): Promise<TResult[]> {
-  const all: TResult[] = [];
+): Promise<TItem[]>;
+export function paginate<TItem, TResult>(
+  fetchPage: (cursor: string | undefined) => Promise<{ items: TItem[]; cursor: string | undefined }>,
+  select: (items: TItem[]) => TResult[],
+): Promise<TResult[]>;
+export async function paginate<TItem, TResult>(
+  fetchPage: (cursor: string | undefined) => Promise<{ items: TItem[]; cursor: string | undefined }>,
+  select?: (items: TItem[]) => TResult[],
+): Promise<(TItem | TResult)[]> {
+  const all: (TItem | TResult)[] = [];
   let cursor: string | undefined;
   do {
     const page = await fetchPage(cursor);
-    all.push(...select(page.items));
+    all.push(...(select ? select(page.items) : page.items));
     cursor = page.cursor;
   } while (cursor !== undefined);
   return all;

--- a/libs/shared/kernel/src/base/entity.base.ts
+++ b/libs/shared/kernel/src/base/entity.base.ts
@@ -24,8 +24,8 @@ export abstract class Entity<TId> {
       return value;
     }
     Object.freeze(value);
-    for (const key of Object.keys(value as object)) {
-      this.deepFreeze((value as Record<string, unknown>)[key]);
+    for (const nested of Object.values(value)) {
+      this.deepFreeze(nested);
     }
     return value;
   }

--- a/libs/shared/kernel/src/base/value-object.base.ts
+++ b/libs/shared/kernel/src/base/value-object.base.ts
@@ -7,6 +7,10 @@ export abstract class ValueObject<T extends object> {
   }
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
 /**
  * Structural equality, independent of key insertion order (unlike
  * `JSON.stringify` comparison). Handles the shapes VO props actually take:
@@ -14,7 +18,7 @@ export abstract class ValueObject<T extends object> {
  */
 function deepEqual(a: unknown, b: unknown): boolean {
   if (Object.is(a, b)) return true;
-  if (typeof a !== 'object' || typeof b !== 'object' || a === null || b === null) return false;
+  if (!isRecord(a) || !isRecord(b)) return false;
   if (a instanceof Date || b instanceof Date) {
     return a instanceof Date && b instanceof Date && a.getTime() === b.getTime();
   }
@@ -23,12 +27,10 @@ function deepEqual(a: unknown, b: unknown): boolean {
       Array.isArray(a) && Array.isArray(b) && a.length === b.length && a.every((item, i) => deepEqual(item, b[i]))
     );
   }
-  const aObj = a as Record<string, unknown>;
-  const bObj = b as Record<string, unknown>;
-  const aKeys = Object.keys(aObj);
-  const bKeys = Object.keys(bObj);
+  const aKeys = Object.keys(a);
+  const bKeys = Object.keys(b);
   return (
     aKeys.length === bKeys.length &&
-    aKeys.every((key) => Object.prototype.hasOwnProperty.call(bObj, key) && deepEqual(aObj[key], bObj[key]))
+    aKeys.every((key) => Object.prototype.hasOwnProperty.call(b, key) && deepEqual(a[key], b[key]))
   );
 }


### PR DESCRIPTION
Two-pass cleanup applying one heuristic throughout: a cast is only
justified when the compiler genuinely can't derive the info another way;
if the same fact is already checked at runtime via a plain boolean
callback, that's a type predicate away from not needing the cast at all.

First pass (71 casts):
- AwsAdapterError (4 domains) takes `cause: unknown` and normalizes
  internally (`instanceof Error` check), instead of every call site
  casting `err as Error` — 66 call sites simplified, 10 standalone
  `(err as Error).name/.message` sites fixed with `instanceof` guards.
- IAM access-key scanner: type predicate instead of two field casts.
- paginate() (3 domains): split into two overloads (no-select identity /
  select-required mapping) instead of a generic default that faked the
  identity case with `as unknown as TResult[]`.

Second pass (19 more casts, zero behavior change, each verified against
tsc --strict before being applied):
- shared-kernel's ValueObject.equals()/Entity.deepFreeze(): type
  predicate / Object.values() instead of Record<string, unknown> casts.
- 3 CLI --scanners validators + 5 CLI --format validators: Array.every()
  and a named type-predicate instead of casting past a check the code
  already did further down.
- static-price-table.adapter.ts, brand-mark.ts, cost-explorer cache read,
  aws-ec2-instance state field: same pattern, one file at a time.

3 casts intentionally left in place (EBS volume state, load-balancer
type, RDS instance status) — removing them safely needs a product
decision on fallback values for fields AWS's SDK types as optional but
always returns in practice; each now has an inline comment naming the
open question.

11 casts confirmed genuinely legitimate (wizard Option<T>[] distributive
type limitation, AwsAdapterError's SDK-only runtime metadata,
groupByKind's kind-discriminated casts, boxed-String JSON parsing) — now
commented in place instead of silently accepted.

ADR-0084 records the full categorization and reasoning for all three
buckets.


## Test plan
- [x] `nx run-many --target=build --all` — 15/15 projects, 0 errors
- [x] `nx run-many --target=test --all` — 15/15 projects, 1327/1327 tests passing
- [x] `nx run-many --target=lint --all` — 0 errors (4 pre-existing warnings, unrelated
      to this change)
- [x] Every removed cast confirmed compiling without it via an isolated `tsc --strict`
      check before being applied, not assumed from resemblance to an already-fixed case
- [x] `AwsAdapterError` constructor change re-verified per domain (56 constructor call
      sites + 10 standalone `instanceof` sites) after an initial shell-escaping mistake
      wiped the service-name argument — caught, reverted via `git checkout`, redone
      correctly with a Python script, re-verified