### PR TITLE
chore: unify CLI version string in a single place

### DIFF
--- a/apps/cli/src/cli-version.ts
+++ b/apps/cli/src/cli-version.ts
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * A plain `require` call, not an `import`: a static JSON `import` makes
+ * TypeScript's project-reference resolver add package.json to this
+ * project's file list, which trips the esbuild executor's embedded
+ * type-check (TS6307) under this workspace's `composite: true` setup —
+ * `tsc --build` alone accepts it, but Nx's esbuild wrapper always forces
+ * that check on for composite projects, so the build fails regardless. A
+ * `require` call isn't tracked as a module dependency by the type checker,
+ * so it sidesteps that check, while esbuild still resolves and inlines it
+ * as a build-time literal (same as it would a JSON `import`).
+ */
+const packageJson = require('../package.json') as { version: string };
+
+export const cliVersion = packageJson.version;

--- a/apps/cli/src/commands/mcp.command.ts
+++ b/apps/cli/src/commands/mcp.command.ts
@@ -9,8 +9,9 @@ import { DEAD_RESOURCE_KINDS, DEAD_RESOURCE_KIND_META } from 'dead-resources-dom
 import { RESOURCE_SECURITY_KINDS, RESOURCE_SECURITY_KIND_META } from 'resource-security-domain';
 import { PDF_LOGO_PNG_BASE64 } from '../pdf-logo-data';
 import { defaultMcpDeps, type McpDeps } from './mcp.composition';
+import { cliVersion } from '../cli-version';
 
-const SERVER_VERSION = '0.7.0';
+const SERVER_VERSION = cliVersion;
 
 /**
  * Global kill switch, independent of any project/`cloudrift.config.json`

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -9,11 +9,12 @@ import { resourceSecurityCommand } from './commands/resource-security.command';
 import { mcpCommand } from './commands/mcp.command';
 import { runEntryWizard } from './wizard/entry.wizard';
 import { isInteractiveTty } from './wizard/tty';
+import { cliVersion } from './cli-version';
 
 program
   .name('cloudrift')
   .description('Detect and report wasted AWS cloud resources')
-  .version('0.7.0');
+  .version(cliVersion);
 
 program
   .command('analyze')


### PR DESCRIPTION
## Summary
- Phase 4 of the code-review-2026-07-25 follow-up plan: unify the hardcoded `0.7.0` version string (previously duplicated in `main.ts` and `mcp.command.ts`) into a single `cli-version.ts`, sourced from `apps/cli/package.json`.
- Uses a plain `require()` instead of a JSON `import` — the esbuild executor's embedded type-check forces `declaration: true` for composite-project builds and raises a TS6307 false positive on the JSON import, which `tsc --build` alone doesn't. `require()` isn't tracked as a module dependency by the type checker, and esbuild still inlines it as a build-time literal.

## Test plan
- [x] `nx run-many -t typecheck,lint,test --all` green across all 16 projects
- [x] `nx run cli:build` succeeds; `node dist/main.js --version` prints `0.7.0`
- [x] Confirmed `0.7.0` is inlined as a literal in the bundle (no runtime `require` of package.json left), so behavior is identical between the source tree and the published package layout
- [x] `nx run cli:package` output diffed identical to the pre-change baseline