### PR TITLE
docs: document ignoreTag trust boundary, add Makefile and Dependabot …

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      aws-sdk:
+        patterns:
+          - "@aws-sdk/*"
+          - "@smithy/*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,48 @@
+.PHONY: help install build test lint typecheck format format-check verify-aws e2e-localstack e2e-localstack-mcp reset
+
+help:
+	@echo "Common targets:"
+	@echo "  make install             pnpm install"
+	@echo "  make build               nx run-many -t build"
+	@echo "  make test                nx run-many -t test"
+	@echo "  make lint                nx run-many -t lint"
+	@echo "  make typecheck           nx run-many -t typecheck"
+	@echo "  make format              nx format:write"
+	@echo "  make format-check        nx format:check"
+	@echo "  make verify-aws          node scripts/verify-against-aws.mjs"
+	@echo "  make e2e-localstack      nx run cli:e2e-localstack"
+	@echo "  make e2e-localstack-mcp  nx run cli:e2e-localstack-mcp"
+	@echo "  make reset               nx reset (clears the local Nx cache)"
+
+install:
+	pnpm install
+
+build:
+	pnpm run build
+
+test:
+	pnpm run test
+
+lint:
+	pnpm run lint
+
+typecheck:
+	pnpm run typecheck
+
+format:
+	pnpm exec nx format:write
+
+format-check:
+	pnpm exec nx format:check
+
+verify-aws:
+	pnpm run verify:aws
+
+e2e-localstack:
+	pnpm run e2e:localstack
+
+e2e-localstack-mcp:
+	pnpm run e2e:localstack:mcp
+
+reset:
+	pnpm exec nx reset

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Every finding is also tagged `waste` or `optimization`: `waste` is money being s
 **False-positive guards (waste policies):**
 
 - **Grace period** — resources younger than 7 days (configurable via `--min-age-days`) are never reported. For EC2 the stop time is reconstructed from `StateTransitionReason`; for NAT Gateways and Load Balancers the creation time is used.
-- **Exclusion tag** — any resource tagged `cloudrift:ignore` (configurable via `--ignore-tag`) is skipped.
+- **Exclusion tag** — any resource tagged `cloudrift:ignore` (configurable via `--ignore-tag`) is skipped. Caveat: anyone with tag-write access to a resource can apply this tag to hide it from scans — the same trust boundary as any other AWS permission, see [SECURITY.md](./SECURITY.md#tag-based-exclusion-is-a-trust-boundary-not-a-security-control).
 - **AMI-bound snapshots** — orphan snapshots referenced by a registered AMI are not reported (they cannot be deleted anyway).
 
 > Prices vary by region. The tool uses region-specific pricing for: `us-east-1`, `us-west-2`, `eu-west-1`, `eu-central-1`, `ap-southeast-1`, `ap-northeast-1`. Every report states the date the price table was last verified (`prices as of`).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -38,6 +38,10 @@ Out of scope:
 - issues that require an attacker to already have write access to your AWS credentials or local filesystem
 - the IAM permissions you grant to the credentials you run cloudrift with — that's on the user to scope to read-only, as documented in [Required IAM permissions](./docs/en/iam-permissions.md)
 
+### Tag-based exclusion is a trust boundary, not a security control
+
+The `cloudrift:ignore` tag (configurable via `--ignore-tag`) skips a resource during a scan. This is a convenience for known exceptions (e.g. an intentionally idle staging environment), not an access control: anyone with tag-write permission on a resource can apply it to hide that resource from future scans. This is the same trust level as any other AWS permission — if you don't want a principal to be able to suppress findings, don't grant it `TagResource`/`CreateTags` (or equivalent) on the resources cloudrift scans.
+
 ### If you're wrapping cloudrift in another service
 
 `--json`, `--pdf`, and `--config` accept any filesystem path, resolved with the same privileges as the process running the CLI — by design, so you can write reports and load config wherever you choose, the same trust level as any other CLI flag. Reviewed internally 2026-07-13: this isn't a vulnerability for direct, interactive use (whoever can pass CLI flags already has that filesystem access), so cloudrift does not restrict these paths to the working directory.


### PR DESCRIPTION
## Summary
- Document that `cloudrift:ignore` is a trust boundary, not an access control — anyone with tag-write permission can hide a resource from scans. Added to README (linked from the exclusion-tag bullet) and a new SECURITY.md section.
- Add a `Makefile` wrapping the existing `package.json` scripts (build/test/lint/typecheck/format/verify-aws/e2e-localstack) — no new logic, just shorter commands.
- Add `.github/dependabot.yml`: weekly npm + github-actions update checks, with the 30+ `@aws-sdk/*`/`@smithy/*` packages grouped into a single PR to avoid flooding the PR list.

## Test plan
- [x] `make help` runs and lists all targets correctly
- [x] Doc-only + config changes — no source touched, no test/build/lint impact
- [ ] Confirm Dependabot opens its first PR on schedule (nothing to check synchronously)