### PR TITLE
Phase 0.7: unify CLI exit-code handling, negative-price config test

### DIFF
--- a/apps/cli/src/commands/analyze-waste.command.ts
+++ b/apps/cli/src/commands/analyze-waste.command.ts
@@ -18,6 +18,7 @@ import {
 } from './analyze-waste.composition';
 import { resolveMinAgeDays, resolveExplicitScanners, resolveRegions } from './resolve-options';
 import { writeArtifacts, applyCostGate } from './post-analysis';
+import { reportCliError as fail } from './report-cli-error';
 
 export type { AnalyzeDeps };
 
@@ -43,11 +44,6 @@ export interface AnalyzeWasteOptions {
   silent?: boolean;
   scanners?: string[];
   allServices?: boolean;
-}
-
-function fail(message: string): void {
-  console.error(chalk.red(`\n  Error: ${message}\n`));
-  process.exitCode = 1;
 }
 
 /**

--- a/apps/cli/src/commands/cost.command.ts
+++ b/apps/cli/src/commands/cost.command.ts
@@ -11,6 +11,7 @@ import { confirmCostExplorerCharge } from '../wizard/cost-confirmation.wizard';
 import { startScanSpinner } from '../wizard/scan-spinner';
 import { defaultCostAnalyticsDeps, type CostAnalyticsDeps } from './cost-analytics.composition';
 import { applyCostTrendGate } from './post-analysis';
+import { reportCliError as fail } from './report-cli-error';
 
 const OUTPUT_FORMATS = ['table', 'json'] as const;
 type OutputFormat = (typeof OUTPUT_FORMATS)[number];
@@ -28,11 +29,6 @@ export interface CostCommandOptions {
   silent?: boolean;
   yes?: boolean;
   pdf?: string | boolean;
-}
-
-function fail(message: string): void {
-  console.error(chalk.red(`\n  Error: ${message}\n`));
-  process.exitCode = 1;
 }
 
 /**

--- a/apps/cli/src/commands/dead-resources.command.ts
+++ b/apps/cli/src/commands/dead-resources.command.ts
@@ -10,6 +10,7 @@ import { formatDeadResourcesReportAsJson } from '../formatters/dead-resources-re
 import { generateDeadResourcesReportPdf } from '../formatters/dead-resources-report.pdf-formatter';
 import { startScanSpinner } from '../wizard/scan-spinner';
 import { defaultDeadResourcesDeps, type DeadResourcesDeps } from './dead-resources.composition';
+import { reportCliError as fail } from './report-cli-error';
 
 export type { DeadResourcesDeps };
 
@@ -32,11 +33,6 @@ export interface DeadResourcesCommandOptions {
   scanners?: string[];
   /** Already-validated kind filter — how the wizard's multiselect passes its choice through. `--scanners` wins if both are set. */
   scannerKinds?: DeadResourceKind[];
-}
-
-function fail(message: string): void {
-  console.error(chalk.red(`\n  Error: ${message}\n`));
-  process.exitCode = 1;
 }
 
 function isDeadResourceKind(kind: string): kind is DeadResourceKind {

--- a/apps/cli/src/commands/report-cli-error.ts
+++ b/apps/cli/src/commands/report-cli-error.ts
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+import chalk from 'chalk';
+
+/**
+ * Standard "recoverable" CLI error: print to stderr and set `process.exitCode`
+ * (never call `process.exit()` here) so pending stdout/stderr writes flush and
+ * any in-flight async work finishes before the process exits naturally.
+ * `process.exit()` is reserved for `main.ts`'s top-level catch, where an error
+ * escaped every command's own Result-based handling and continuing is unsafe.
+ */
+export function reportCliError(message: string): void {
+  console.error(chalk.red(`\n  Error: ${message}\n`));
+  process.exitCode = 1;
+}

--- a/apps/cli/src/commands/resource-security.command.ts
+++ b/apps/cli/src/commands/resource-security.command.ts
@@ -10,6 +10,7 @@ import { formatResourceSecurityReportAsJson } from '../formatters/resource-secur
 import { generateResourceSecurityReportPdf } from '../formatters/resource-security-report.pdf-formatter';
 import { startScanSpinner } from '../wizard/scan-spinner';
 import { defaultResourceSecurityDeps, type ResourceSecurityDeps } from './resource-security.composition';
+import { reportCliError as fail } from './report-cli-error';
 
 export type { ResourceSecurityDeps };
 
@@ -31,11 +32,6 @@ export interface ResourceSecurityCommandOptions {
   scanners?: string[];
   /** Already-validated kind filter — how the wizard's multiselect passes its choice through. `--scanners` wins if both are set. */
   scannerKinds?: ResourceSecurityKind[];
-}
-
-function fail(message: string): void {
-  console.error(chalk.red(`\n  Error: ${message}\n`));
-  process.exitCode = 1;
 }
 
 function isResourceSecurityKind(kind: string): kind is ResourceSecurityKind {

--- a/apps/cli/src/commands/trend.command.ts
+++ b/apps/cli/src/commands/trend.command.ts
@@ -11,6 +11,7 @@ import { resolveServiceNames } from '../config/cost-explorer-service-names';
 import { confirmCostExplorerCharge } from '../wizard/cost-confirmation.wizard';
 import { startScanSpinner } from '../wizard/scan-spinner';
 import { defaultCostAnalyticsDeps, type CostAnalyticsDeps } from './cost-analytics.composition';
+import { reportCliError as fail } from './report-cli-error';
 
 const OUTPUT_FORMATS = ['table', 'json'] as const;
 type OutputFormat = (typeof OUTPUT_FORMATS)[number];
@@ -31,11 +32,6 @@ export interface TrendCommandOptions {
   silent?: boolean;
   yes?: boolean;
   pdf?: string | boolean;
-}
-
-function fail(message: string): void {
-  console.error(chalk.red(`\n  Error: ${message}\n`));
-  process.exitCode = 1;
 }
 
 /**

--- a/apps/cli/src/config/cloudrift.config.spec.ts
+++ b/apps/cli/src/config/cloudrift.config.spec.ts
@@ -45,6 +45,12 @@ describe('parseConfig', () => {
     if (!result.ok) expect(result.error.message).toContain('prices');
   });
 
+  it('rejects a negative price value', () => {
+    const result = parseConfig(JSON.stringify({ prices: { 'us-east-1': { 'ebs-gp3': -5 } } }));
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toContain('prices');
+  });
+
   it('parses thresholds.ebsIdleMaxOps', () => {
     const result = parseConfig(JSON.stringify({ thresholds: { ebsIdleMaxOps: 50 } }));
     expect(result.ok).toBe(true);


### PR DESCRIPTION
## Summary
- Extract `apps/cli/src/commands/report-cli-error.ts` (`reportCliError`), replacing 5 identical local `fail()` functions in `cost`/`trend`/`dead-resources`/`analyze-waste`/`resource-security`.command.ts. Doc comment explains the convention: `process.exitCode` for recoverable command errors (lets pending I/O flush), `process.exit()` reserved for `main.ts`'s top-level catch only.
- Left untouched on purpose: `mcp.command.ts`'s disabled-check (different message shape, not duplicated, already correct) and `post-analysis.ts`'s `exitCode = 2` gates (intentionally a distinct code for threshold-exceeded, not an inconsistency).
- Add the one missing edge case in `cloudrift.config.spec.ts`: rejects a negative value inside the `prices` map.