### PR TITLE
feat(cli): CSV output format, PDF quick-wins effort ranking + bar cha…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,8 +89,13 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Run tests
-        run: pnpm nx run-many --target=test --all --parallel
+      # --coverage is what actually makes each project's coverageThreshold
+      # (ADR-0090) get checked — Jest silently skips it without that flag.
+      # Sequential, not --parallel: coverage + parallel workers previously
+      # produced spurious CPU-contention timeouts on the heavier PDF specs
+      # (see ADR-0090's Consequences section).
+      - name: Run tests with coverage
+        run: pnpm nx run-many --target=test --all --coverage
 
   audit:
     name: Dependency audit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,8 +48,14 @@ jobs:
           fi
           echo "Releasing @cloudrift/cli@$PKG_VERSION"
 
-      - name: Lint and test
-        run: pnpm nx run-many -t lint test --all --parallel
+      - name: Lint
+        run: pnpm nx run-many -t lint --all --parallel
+
+      # --coverage is what actually makes each project's coverageThreshold
+      # (ADR-0090) get checked — Jest silently skips it without that flag.
+      # Sequential, not --parallel: see ci.yml for why.
+      - name: Test with coverage
+        run: pnpm nx run-many -t test --all --coverage
 
       - name: Package the CLI for npm
         run: pnpm nx package cli

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ cloudrift dead-resources --scanners iam-user-inactive  # only one check
 | **ECR Repositories (empty)** | Zero images | info | 7-day grace period (`--min-age-days`) |
 | **Step Functions State Machines (never executed)** | STANDARD-type, zero executions (EXPRESS excluded) | info | 7-day grace period (`--min-age-days`) |
 
-**IAM, Route53, and (for this command) S3 are global AWS services**: those seven checks run once per scan regardless of how many `--regions` you pass, never once per region — the other eleven checks are genuinely regional. See [ADR-0078](https://github.com/elleVas/cloudrift/blob/main/docs/adr/0078-dead-resources-parallel-domain.md)/[ADR-0079](https://github.com/elleVas/cloudrift/blob/main/docs/adr/0079-dead-resources-global-scope-scanners.md) for the design behind this split, `--format json`/`--pdf` for machine-readable/shareable output. See [docs/en/usage.md](https://github.com/elleVas/cloudrift/blob/main/docs/en/usage.md#dead-resources--deadunused-resource-hygiene) for the full flag reference.
+**IAM, Route53, and (for this command) S3 are global AWS services**: those seven checks run once per scan regardless of how many `--regions` you pass, never once per region — the other eleven checks are genuinely regional. See [ADR-0078](https://github.com/elleVas/cloudrift/blob/main/docs/adr/0078-dead-resources-parallel-domain.md)/[ADR-0079](https://github.com/elleVas/cloudrift/blob/main/docs/adr/0079-dead-resources-global-scope-scanners.md) for the design behind this split, `--format json`/`csv`/`--pdf` for machine-readable/shareable output. See [docs/en/usage.md](https://github.com/elleVas/cloudrift/blob/main/docs/en/usage.md#dead-resources--deadunused-resource-hygiene) for the full flag reference.
 
 ---
 
@@ -259,7 +259,7 @@ cloudrift resource-security --scanners iam-root-mfa-disabled    # only one check
 | **RDS Instances (publicly accessible)** | Reachable from outside its VPC | critical |
 | **CloudTrail (no multi-region trail)** | No trail with multi-region logging | warning |
 
-**IAM, S3 (bucket listing), and CloudTrail are global for this command**: those eight checks run once per scan regardless of how many `--regions` you pass, never once per region — the other six checks are genuinely regional. `--format json`/`--pdf` for machine-readable/shareable output, no `--min-age-days` (a security misconfiguration is a risk from the moment it exists). See [docs/en/usage.md](https://github.com/elleVas/cloudrift/blob/main/docs/en/usage.md#resource-security--security-posture-scan) for the full flag reference.
+**IAM, S3 (bucket listing), and CloudTrail are global for this command**: those eight checks run once per scan regardless of how many `--regions` you pass, never once per region — the other six checks are genuinely regional. `--format json`/`csv`/`--pdf` for machine-readable/shareable output, no `--min-age-days` (a security misconfiguration is a risk from the moment it exists). See [docs/en/usage.md](https://github.com/elleVas/cloudrift/blob/main/docs/en/usage.md#resource-security--security-posture-scan) for the full flag reference.
 
 ---
 
@@ -295,6 +295,7 @@ The full reference — flags, config file, pricing sources, CI/CD, IAM permissio
 | [docs/en/vertical-scanners.md](https://github.com/elleVas/cloudrift/blob/main/docs/en/vertical-scanners.md) | The Phase 6 vertical scanners (Serverless, Aurora, SageMaker, Dev/PR, EKS) |
 | [docs/en/adding-a-resource.md](https://github.com/elleVas/cloudrift/blob/main/docs/en/adding-a-resource.md) | Step-by-step guide to adding a new resource type        |
 | [docs/en/mcp-server.md](https://github.com/elleVas/cloudrift/blob/main/docs/en/mcp-server.md)               | Connecting Kiro, VS Code Copilot Chat, and Claude Code to `cloudrift mcp` |
+| [docs/en/remediation-effort.md](https://github.com/elleVas/cloudrift/blob/main/docs/en/remediation-effort.md) | The low/medium/high effort rating behind the PDF's "Top quick wins" ranking |
 
 ## License
 

--- a/apps/cli/src/commands/analyze-waste.command.spec.ts
+++ b/apps/cli/src/commands/analyze-waste.command.spec.ts
@@ -130,6 +130,19 @@ describe('analyzeWasteCommand (CLI end-to-end)', () => {
     expect(stdout).not.toContain('Scanning');
   });
 
+  it('csv format: stdout is a CSV with a header row and one row per finding', async () => {
+    await run({ format: 'csv' }, makeDeps({
+      summary: summaryOf([wasteVolume('vol-1', 8)], 8),
+    }));
+    expect(stdout).not.toContain('Scanning');
+    const lines = stdout.trim().split('\n');
+    expect(lines[0]).toBe(
+      'id,kind,category,estimated,region,accountId,detectedAt,wasteReason,description,monthlyCostUsd,tags,userName,consoleUrl',
+    );
+    expect(lines).toHaveLength(2);
+    expect(lines[1]).toContain('vol-1');
+  });
+
   it('exits 2 when waste exceeds the configured threshold', async () => {
     await run({ format: 'json' }, makeDeps({
       config: { costAlertThresholdUsd: 5 },

--- a/apps/cli/src/commands/analyze-waste.command.ts
+++ b/apps/cli/src/commands/analyze-waste.command.ts
@@ -6,7 +6,9 @@ import type { WasteReportMeta } from 'cloud-cost-application';
 import { formatWasteReportAsTable } from '../formatters/waste-report.table-formatter';
 import { formatWasteReportAsJson } from '../formatters/waste-report.json-formatter';
 import { formatWasteReportAsMarkdown } from '../formatters/waste-report.markdown-formatter';
+import { formatWasteReportAsCsv } from '../formatters/waste-report.csv-formatter';
 import { renderBrandMark } from '../brand-mark';
+import { WASTE_OUTPUT_FORMATS, isOutputFormat } from '../output-format';
 import {
   promptScannerSelection,
   shouldPromptScannerSelection,
@@ -24,12 +26,6 @@ export type { AnalyzeDeps };
 
 const DEFAULT_CLOUDWATCH_WINDOW_HOURS = 48;
 const DEFAULT_UTILIZATION_WINDOW_HOURS = 168;
-const OUTPUT_FORMATS = ['table', 'json', 'markdown'] as const;
-type OutputFormat = (typeof OUTPUT_FORMATS)[number];
-
-function isOutputFormat(format: string): format is OutputFormat {
-  return (OUTPUT_FORMATS as readonly string[]).includes(format);
-}
 
 export interface AnalyzeWasteOptions {
   regions: string[];
@@ -59,9 +55,9 @@ export async function analyzeWasteCommand(
   deps: AnalyzeDeps = defaultAnalyzeDeps,
 ): Promise<void> {
   const format = options.format ?? 'table';
-  if (!isOutputFormat(format)) {
+  if (!isOutputFormat(WASTE_OUTPUT_FORMATS, format)) {
     return fail(
-      `--format must be one of: ${OUTPUT_FORMATS.join(', ')}. Got "${options.format}".`,
+      `--format must be one of: ${WASTE_OUTPUT_FORMATS.join(', ')}. Got "${options.format}".`,
     );
   }
 
@@ -185,6 +181,8 @@ export async function analyzeWasteCommand(
       rendered = formatWasteReportAsMarkdown(result.value, meta, {
         costAlertThresholdUsd: config.costAlertThresholdUsd,
       });
+    } else if (format === 'csv') {
+      rendered = formatWasteReportAsCsv(result.value, meta);
     } else {
       rendered = formatWasteReportAsTable(result.value, meta);
     }

--- a/apps/cli/src/commands/cost.command.spec.ts
+++ b/apps/cli/src/commands/cost.command.spec.ts
@@ -94,6 +94,13 @@ describe('costCommand (CLI end-to-end)', () => {
     expect(parsed.previous).toBeDefined();
   });
 
+  it('csv format: stdout is a CSV with a header row and one row per service delta', async () => {
+    const port = dynamicDailyPort((ymd) => (ymd.endsWith('-01') ? 42 : 0));
+    await run({ format: 'csv' }, makeDeps({ port }));
+    const lines = stdout.trim().split('\n');
+    expect(lines[0]).toBe('service,currentUsd,previousUsd,changeUsd,changePercent');
+  });
+
   it('exits 2 via --fail-on-increase when the last two weeks spiked vs. a quiet baseline', async () => {
     const today = new Date();
     const recencyCutoff = new Date(today.getTime() - 15 * 86_400_000).toISOString().slice(0, 10);

--- a/apps/cli/src/commands/cost.command.ts
+++ b/apps/cli/src/commands/cost.command.ts
@@ -6,19 +6,14 @@ import { CompareCostUseCase } from 'cost-analytics-application';
 import type { CostAnalyticsMeta } from 'cost-analytics-application';
 import { formatCostComparisonAsTable } from '../formatters/cost-comparison.table-formatter';
 import { formatCostComparisonAsJson } from '../formatters/cost-comparison.json-formatter';
+import { formatCostComparisonAsCsv } from '../formatters/cost-comparison.csv-formatter';
 import { generateCostComparisonPdf } from '../formatters/cost-comparison.pdf-formatter';
 import { confirmCostExplorerCharge } from '../wizard/cost-confirmation.wizard';
 import { startScanSpinner } from '../wizard/scan-spinner';
 import { defaultCostAnalyticsDeps, type CostAnalyticsDeps } from './cost-analytics.composition';
 import { applyCostTrendGate } from './post-analysis';
 import { reportCliError as fail } from './report-cli-error';
-
-const OUTPUT_FORMATS = ['table', 'json'] as const;
-type OutputFormat = (typeof OUTPUT_FORMATS)[number];
-
-function isOutputFormat(format: string): format is OutputFormat {
-  return (OUTPUT_FORMATS as readonly string[]).includes(format);
-}
+import { OUTPUT_FORMATS, isOutputFormat } from '../output-format';
 
 export interface CostCommandOptions {
   accountId?: string;
@@ -40,7 +35,7 @@ export async function costCommand(
   deps: CostAnalyticsDeps = defaultCostAnalyticsDeps,
 ): Promise<void> {
   const format = options.format ?? 'table';
-  if (!isOutputFormat(format)) {
+  if (!isOutputFormat(OUTPUT_FORMATS, format)) {
     return fail(`--format must be one of: ${OUTPUT_FORMATS.join(', ')}. Got "${options.format}".`);
   }
 
@@ -84,10 +79,14 @@ export async function costCommand(
   const meta: CostAnalyticsMeta = { accountId, generatedAt: new Date() };
 
   if (!silent) {
-    const rendered =
-      format === 'json'
-        ? formatCostComparisonAsJson(result.value, meta)
-        : formatCostComparisonAsTable(result.value);
+    let rendered: string;
+    if (format === 'json') {
+      rendered = formatCostComparisonAsJson(result.value, meta);
+    } else if (format === 'csv') {
+      rendered = formatCostComparisonAsCsv(result.value, meta);
+    } else {
+      rendered = formatCostComparisonAsTable(result.value);
+    }
     console.log(rendered);
   }
 

--- a/apps/cli/src/commands/dead-resources.command.spec.ts
+++ b/apps/cli/src/commands/dead-resources.command.spec.ts
@@ -121,6 +121,23 @@ describe('deadResourcesCommand (CLI end-to-end)', () => {
     expect(parsed.countBySeverity).toEqual({ info: 1, warning: 0, critical: 0 });
   });
 
+  it('csv format: stdout is a CSV with a header row and one row per finding', async () => {
+    await run(
+      { format: 'csv' },
+      makeDeps({
+        summary: {
+          findings: [makeKeyPair('key-3')],
+          countBySeverity: { info: 1, warning: 0, critical: 0 },
+          scanErrors: [],
+        },
+      }),
+    );
+    const lines = stdout.trim().split('\n');
+    expect(lines[0]).toBe('id,kind,region,accountId,detectedAt,tags,hygieneReason,severity,consoleUrl');
+    expect(lines).toHaveLength(2);
+    expect(lines[1]).toContain('key-3');
+  });
+
   it('--silent suppresses stdout entirely', async () => {
     await run({ format: 'table', silent: true }, makeDeps());
     expect(stdout).toBe('');

--- a/apps/cli/src/commands/dead-resources.command.ts
+++ b/apps/cli/src/commands/dead-resources.command.ts
@@ -7,19 +7,14 @@ import type { DeadResourceKind, DeadResourcePolicyOptions } from 'dead-resources
 import { renderBrandMark } from '../brand-mark';
 import { formatDeadResourcesReportAsTable } from '../formatters/dead-resources-report.table-formatter';
 import { formatDeadResourcesReportAsJson } from '../formatters/dead-resources-report.json-formatter';
+import { formatDeadResourcesReportAsCsv } from '../formatters/dead-resources-report.csv-formatter';
 import { generateDeadResourcesReportPdf } from '../formatters/dead-resources-report.pdf-formatter';
 import { startScanSpinner } from '../wizard/scan-spinner';
 import { defaultDeadResourcesDeps, type DeadResourcesDeps } from './dead-resources.composition';
 import { reportCliError as fail } from './report-cli-error';
+import { OUTPUT_FORMATS, isOutputFormat } from '../output-format';
 
 export type { DeadResourcesDeps };
-
-const OUTPUT_FORMATS = ['table', 'json'] as const;
-type OutputFormat = (typeof OUTPUT_FORMATS)[number];
-
-function isOutputFormat(format: string): format is OutputFormat {
-  return (OUTPUT_FORMATS as readonly string[]).includes(format);
-}
 
 export interface DeadResourcesCommandOptions {
   regions: string[];
@@ -59,7 +54,7 @@ export async function deadResourcesCommand(
   deps: DeadResourcesDeps = defaultDeadResourcesDeps,
 ): Promise<void> {
   const format = options.format ?? 'table';
-  if (!isOutputFormat(format)) {
+  if (!isOutputFormat(OUTPUT_FORMATS, format)) {
     return fail(`--format must be one of: ${OUTPUT_FORMATS.join(', ')}. Got "${options.format}".`);
   }
 
@@ -122,8 +117,14 @@ export async function deadResourcesCommand(
   const meta = { accountId, regions: regions.map((r) => r.code), generatedAt: new Date() };
 
   if (!silent) {
-    const rendered =
-      format === 'json' ? formatDeadResourcesReportAsJson(result.value, meta) : formatDeadResourcesReportAsTable(result.value);
+    let rendered: string;
+    if (format === 'json') {
+      rendered = formatDeadResourcesReportAsJson(result.value, meta);
+    } else if (format === 'csv') {
+      rendered = formatDeadResourcesReportAsCsv(result.value, meta);
+    } else {
+      rendered = formatDeadResourcesReportAsTable(result.value);
+    }
     console.log(rendered);
   }
 

--- a/apps/cli/src/commands/resource-security.command.spec.ts
+++ b/apps/cli/src/commands/resource-security.command.spec.ts
@@ -105,6 +105,23 @@ describe('resourceSecurityCommand (CLI end-to-end)', () => {
     expect(parsed.countBySeverity).toEqual({ info: 0, warning: 0, critical: 1 });
   });
 
+  it('csv format: stdout is a CSV with a header row and one row per finding', async () => {
+    await run(
+      { format: 'csv' },
+      makeDeps({
+        summary: {
+          findings: [makeFinding('123456789012')],
+          countBySeverity: { info: 0, warning: 0, critical: 1 },
+          scanErrors: [],
+        },
+      }),
+    );
+    const lines = stdout.trim().split('\n');
+    expect(lines[0]).toBe('id,kind,region,accountId,detectedAt,tags,riskReason,severity,consoleUrl');
+    expect(lines).toHaveLength(2);
+    expect(lines[1]).toContain('123456789012');
+  });
+
   it('--silent suppresses stdout entirely', async () => {
     await run({ format: 'table', silent: true }, makeDeps());
     expect(stdout).toBe('');

--- a/apps/cli/src/commands/resource-security.command.ts
+++ b/apps/cli/src/commands/resource-security.command.ts
@@ -7,19 +7,14 @@ import type { ResourceSecurityKind, ResourceSecurityPolicyOptions } from 'resour
 import { renderBrandMark } from '../brand-mark';
 import { formatResourceSecurityReportAsTable } from '../formatters/resource-security-report.table-formatter';
 import { formatResourceSecurityReportAsJson } from '../formatters/resource-security-report.json-formatter';
+import { formatResourceSecurityReportAsCsv } from '../formatters/resource-security-report.csv-formatter';
 import { generateResourceSecurityReportPdf } from '../formatters/resource-security-report.pdf-formatter';
 import { startScanSpinner } from '../wizard/scan-spinner';
 import { defaultResourceSecurityDeps, type ResourceSecurityDeps } from './resource-security.composition';
 import { reportCliError as fail } from './report-cli-error';
+import { OUTPUT_FORMATS, isOutputFormat } from '../output-format';
 
 export type { ResourceSecurityDeps };
-
-const OUTPUT_FORMATS = ['table', 'json'] as const;
-type OutputFormat = (typeof OUTPUT_FORMATS)[number];
-
-function isOutputFormat(format: string): format is OutputFormat {
-  return (OUTPUT_FORMATS as readonly string[]).includes(format);
-}
 
 export interface ResourceSecurityCommandOptions {
   regions: string[];
@@ -59,7 +54,7 @@ export async function resourceSecurityCommand(
   deps: ResourceSecurityDeps = defaultResourceSecurityDeps,
 ): Promise<void> {
   const format = options.format ?? 'table';
-  if (!isOutputFormat(format)) {
+  if (!isOutputFormat(OUTPUT_FORMATS, format)) {
     return fail(`--format must be one of: ${OUTPUT_FORMATS.join(', ')}. Got "${options.format}".`);
   }
 
@@ -110,8 +105,14 @@ export async function resourceSecurityCommand(
   const meta = { accountId, regions: regions.map((r) => r.code), generatedAt: new Date() };
 
   if (!silent) {
-    const rendered =
-      format === 'json' ? formatResourceSecurityReportAsJson(result.value, meta) : formatResourceSecurityReportAsTable(result.value);
+    let rendered: string;
+    if (format === 'json') {
+      rendered = formatResourceSecurityReportAsJson(result.value, meta);
+    } else if (format === 'csv') {
+      rendered = formatResourceSecurityReportAsCsv(result.value, meta);
+    } else {
+      rendered = formatResourceSecurityReportAsTable(result.value);
+    }
     console.log(rendered);
   }
 

--- a/apps/cli/src/commands/trend.command.spec.ts
+++ b/apps/cli/src/commands/trend.command.spec.ts
@@ -77,6 +77,15 @@ describe('trendCommand (CLI end-to-end)', () => {
     expect(parsed.months[1].final).toBe(false);
   });
 
+  it('csv format: stdout is a CSV with a header row and one row per month', async () => {
+    await run({ format: 'csv' }, makeDeps());
+    const lines = stdout.trim().split('\n');
+    expect(lines[0]).toBe('month,totalUsd,final');
+    expect(lines).toHaveLength(3);
+    expect(lines[1]).toBe('2026-06,100,true');
+    expect(lines[2]).toBe('2026-07,50,false');
+  });
+
   it('passes an unresolved shorthand through unchanged as a literal Cost Explorer name', async () => {
     await run({ format: 'json', services: ['Amazon Custom Service'] }, makeDeps());
     const parsed = JSON.parse(stdout.trim());

--- a/apps/cli/src/commands/trend.command.ts
+++ b/apps/cli/src/commands/trend.command.ts
@@ -6,19 +6,15 @@ import { CostTrendUseCase } from 'cost-analytics-application';
 import type { CostAnalyticsMeta } from 'cost-analytics-application';
 import { formatCostTrendAsChart } from '../formatters/cost-trend.chart-formatter';
 import { formatCostTrendAsJson } from '../formatters/cost-trend.json-formatter';
+import { formatCostTrendAsCsv } from '../formatters/cost-trend.csv-formatter';
 import { generateCostTrendPdf } from '../formatters/cost-trend.pdf-formatter';
 import { resolveServiceNames } from '../config/cost-explorer-service-names';
 import { confirmCostExplorerCharge } from '../wizard/cost-confirmation.wizard';
 import { startScanSpinner } from '../wizard/scan-spinner';
 import { defaultCostAnalyticsDeps, type CostAnalyticsDeps } from './cost-analytics.composition';
 import { reportCliError as fail } from './report-cli-error';
+import { OUTPUT_FORMATS, isOutputFormat } from '../output-format';
 
-const OUTPUT_FORMATS = ['table', 'json'] as const;
-type OutputFormat = (typeof OUTPUT_FORMATS)[number];
-
-function isOutputFormat(format: string): format is OutputFormat {
-  return (OUTPUT_FORMATS as readonly string[]).includes(format);
-}
 const DEFAULT_MONTHS = 6;
 const MAX_MONTHS = 36;
 
@@ -44,7 +40,7 @@ export async function trendCommand(
   deps: CostAnalyticsDeps = defaultCostAnalyticsDeps,
 ): Promise<void> {
   const format = options.format ?? 'table';
-  if (!isOutputFormat(format)) {
+  if (!isOutputFormat(OUTPUT_FORMATS, format)) {
     return fail(`--format must be one of: ${OUTPUT_FORMATS.join(', ')}. Got "${options.format}".`);
   }
 
@@ -87,8 +83,14 @@ export async function trendCommand(
   const meta: CostAnalyticsMeta = { accountId, generatedAt: new Date() };
 
   if (!silent) {
-    const rendered =
-      format === 'json' ? formatCostTrendAsJson(result.value, meta) : formatCostTrendAsChart(result.value);
+    let rendered: string;
+    if (format === 'json') {
+      rendered = formatCostTrendAsJson(result.value, meta);
+    } else if (format === 'csv') {
+      rendered = formatCostTrendAsCsv(result.value, meta);
+    } else {
+      rendered = formatCostTrendAsChart(result.value);
+    }
     console.log(rendered);
   }
 

--- a/apps/cli/src/formatters/cost-comparison.csv-formatter.spec.ts
+++ b/apps/cli/src/formatters/cost-comparison.csv-formatter.spec.ts
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+import type { CostAnalyticsMeta } from 'cost-analytics-application';
+import type { CostComparisonSummary } from 'cost-analytics-domain';
+import { formatCostComparisonAsCsv } from './cost-comparison.csv-formatter';
+
+const meta: CostAnalyticsMeta = { accountId: '123456789012', generatedAt: new Date('2026-06-16') };
+
+const summary: CostComparisonSummary = {
+  current: { start: '2026-06-01', end: '2026-06-16', totalUsd: 120 },
+  previous: { start: '2026-05-01', end: '2026-05-16', totalUsd: 100 },
+  changeUsd: 20,
+  changePercent: 20,
+  byService: [
+    { service: 'EC2', currentUsd: 100, previousUsd: 80, changeUsd: 20, changePercent: 25 },
+    { service: 'S3', currentUsd: 20, previousUsd: 20, changeUsd: 0, changePercent: null },
+  ],
+};
+
+describe('formatCostComparisonAsCsv', () => {
+  it('emits a header row followed by one row per service delta', () => {
+    const csv = formatCostComparisonAsCsv(summary, meta);
+    const lines = csv.split('\n');
+
+    expect(lines[0]).toBe('service,currentUsd,previousUsd,changeUsd,changePercent');
+    expect(lines).toHaveLength(3);
+    expect(lines[1]).toBe('EC2,100,80,20,25');
+    expect(lines[2]).toBe('S3,20,20,0,');
+  });
+});

--- a/apps/cli/src/formatters/cost-comparison.csv-formatter.ts
+++ b/apps/cli/src/formatters/cost-comparison.csv-formatter.ts
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+import { toCostComparisonDto } from 'cost-analytics-application';
+import type { CostAnalyticsMeta } from 'cost-analytics-application';
+import type { CostComparisonSummary } from 'cost-analytics-domain';
+import { toCsv } from './csv-utils';
+
+const HEADERS = ['service', 'currentUsd', 'previousUsd', 'changeUsd', 'changePercent'];
+
+/** One row per service delta — current/previous period totals live in `meta`/table output, not repeated per row here. */
+export function formatCostComparisonAsCsv(summary: CostComparisonSummary, meta: CostAnalyticsMeta): string {
+  const dto = toCostComparisonDto(summary, meta);
+  const rows = dto.byService.map((delta) => [
+    delta.service,
+    delta.currentUsd,
+    delta.previousUsd,
+    delta.changeUsd,
+    delta.changePercent,
+  ]);
+  return toCsv(HEADERS, rows);
+}

--- a/apps/cli/src/formatters/cost-trend.csv-formatter.spec.ts
+++ b/apps/cli/src/formatters/cost-trend.csv-formatter.spec.ts
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+import type { CostAnalyticsMeta } from 'cost-analytics-application';
+import type { CostTrendSummary } from 'cost-analytics-domain';
+import { formatCostTrendAsCsv } from './cost-trend.csv-formatter';
+
+const meta: CostAnalyticsMeta = { accountId: '123456789012', generatedAt: new Date('2026-06-16') };
+
+const summary: CostTrendSummary = {
+  months: [
+    { month: '2026-05', totalUsd: 100, final: true },
+    { month: '2026-06', totalUsd: 50, final: false },
+  ],
+};
+
+describe('formatCostTrendAsCsv', () => {
+  it('emits a header row followed by one row per month', () => {
+    const csv = formatCostTrendAsCsv(summary, meta);
+    expect(csv).toBe('month,totalUsd,final\n2026-05,100,true\n2026-06,50,false');
+  });
+});

--- a/apps/cli/src/formatters/cost-trend.csv-formatter.ts
+++ b/apps/cli/src/formatters/cost-trend.csv-formatter.ts
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+import { toCostTrendDto } from 'cost-analytics-application';
+import type { CostAnalyticsMeta } from 'cost-analytics-application';
+import type { CostTrendSummary } from 'cost-analytics-domain';
+import { toCsv } from './csv-utils';
+
+const HEADERS = ['month', 'totalUsd', 'final'];
+
+/** One row per month. */
+export function formatCostTrendAsCsv(summary: CostTrendSummary, meta: CostAnalyticsMeta): string {
+  const dto = toCostTrendDto(summary, meta);
+  const rows = dto.months.map((month) => [month.month, month.totalUsd, month.final]);
+  return toCsv(HEADERS, rows);
+}

--- a/apps/cli/src/formatters/csv-utils.spec.ts
+++ b/apps/cli/src/formatters/csv-utils.spec.ts
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+import { toCsv } from './csv-utils';
+
+describe('toCsv', () => {
+  it('joins headers and rows with commas and newlines', () => {
+    expect(toCsv(['a', 'b'], [['1', '2'], ['3', '4']])).toBe('a,b\n1,2\n3,4');
+  });
+
+  it('renders null/undefined as an empty field', () => {
+    expect(toCsv(['a'], [[null], [undefined]])).toBe('a\n\n');
+  });
+
+  it('quotes and escapes a field containing a comma', () => {
+    expect(toCsv(['a'], [['1,2']])).toBe('a\n"1,2"');
+  });
+
+  it('quotes and doubles embedded quotes', () => {
+    expect(toCsv(['a'], [['say "hi"']])).toBe('a\n"say ""hi"""');
+  });
+
+  it('quotes a field containing a newline', () => {
+    expect(toCsv(['a'], [['line1\nline2']])).toBe('a\n"line1\nline2"');
+  });
+
+  it('leaves plain numbers and booleans unquoted', () => {
+    expect(toCsv(['a', 'b'], [[42, true]])).toBe('a,b\n42,true');
+  });
+});

--- a/apps/cli/src/formatters/csv-utils.ts
+++ b/apps/cli/src/formatters/csv-utils.ts
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+
+export type CsvValue = string | number | boolean | null | undefined;
+
+function escapeCsvField(value: CsvValue): string {
+  if (value === null || value === undefined) return '';
+  const str = String(value);
+  return /[",\n]/.test(str) ? `"${str.replace(/"/g, '""')}"` : str;
+}
+
+/** Minimal CSV serialization (comma-separated, quote-escaped) — no external dependency needed for this shape. */
+export function toCsv(headers: readonly string[], rows: readonly CsvValue[][]): string {
+  return [headers, ...rows].map((row) => row.map(escapeCsvField).join(',')).join('\n');
+}

--- a/apps/cli/src/formatters/dead-resources-report.csv-formatter.spec.ts
+++ b/apps/cli/src/formatters/dead-resources-report.csv-formatter.spec.ts
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+import { AwsRegion, Ec2SecurityGroupUnused } from 'dead-resources-domain';
+import type { DeadResourcesSummary } from 'dead-resources-domain';
+import type { DeadResourcesReportMeta } from 'dead-resources-application';
+import { formatDeadResourcesReportAsCsv } from './dead-resources-report.csv-formatter';
+
+const region = AwsRegion.create('us-east-1');
+const meta: DeadResourcesReportMeta = {
+  accountId: '123456789012',
+  regions: ['us-east-1'],
+  generatedAt: new Date('2026-06-16'),
+};
+
+function summaryOf(groupId: string): DeadResourcesSummary {
+  const group = new Ec2SecurityGroupUnused({
+    groupId,
+    groupName: 'my-sg',
+    region,
+    accountId: '123456789012',
+    detectedAt: new Date('2026-06-16'),
+    tags: {},
+  });
+  return { findings: [group], countBySeverity: { info: 0, warning: 1, critical: 0 }, scanErrors: [] };
+}
+
+describe('formatDeadResourcesReportAsCsv', () => {
+  it('emits a header row followed by one row per finding, with a consoleUrl column', () => {
+    const csv = formatDeadResourcesReportAsCsv(summaryOf('sg-abc123'), meta);
+    const lines = csv.split('\n');
+
+    expect(lines[0]).toBe('id,kind,region,accountId,detectedAt,tags,hygieneReason,severity,consoleUrl');
+    expect(lines).toHaveLength(2);
+    expect(lines[1]).toContain('sg-abc123');
+    expect(lines[1]).toContain(
+      'https://console.aws.amazon.com/vpc/home?region=us-east-1#SecurityGroups:groupId=sg-abc123',
+    );
+  });
+
+  it('renders a null region (global-scope finding) as an empty field, not the literal "null"', () => {
+    const roleFinding = {
+      id: 'AROAEXAMPLE',
+      kind: 'iam-role-unused',
+      region: undefined,
+      accountId: '123456789012',
+      detectedAt: new Date('2026-06-16'),
+      tags: {},
+      hygieneReason: 'not assumed in 90 days',
+      severity: 'warning' as const,
+    };
+    const summary: DeadResourcesSummary = {
+      findings: [roleFinding],
+      countBySeverity: { info: 0, warning: 1, critical: 0 },
+      scanErrors: [],
+    };
+
+    const csv = formatDeadResourcesReportAsCsv(summary, meta);
+    const lines = csv.split('\n');
+    expect(lines[1]).toBe('AROAEXAMPLE,iam-role-unused,,123456789012,2026-06-16T00:00:00.000Z,{},not assumed in 90 days,warning,');
+  });
+});

--- a/apps/cli/src/formatters/dead-resources-report.csv-formatter.ts
+++ b/apps/cli/src/formatters/dead-resources-report.csv-formatter.ts
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+import type { DeadResourcesSummary } from 'dead-resources-domain';
+import { toDeadResourceReportDto, type DeadResourcesReportMeta } from 'dead-resources-application';
+import { buildConsoleUrl } from '../aws-console-link';
+import { toCsv } from './csv-utils';
+
+const HEADERS = ['id', 'kind', 'region', 'accountId', 'detectedAt', 'tags', 'hygieneReason', 'severity', 'consoleUrl'];
+
+/** One row per finding, raw DTO fields — meant for re-processing (spreadsheets, scripts), not on-screen reading. */
+export function formatDeadResourcesReportAsCsv(summary: DeadResourcesSummary, meta: DeadResourcesReportMeta): string {
+  const dto = toDeadResourceReportDto(summary, meta);
+  const rows = dto.findings.map((finding) => [
+    finding.id,
+    finding.kind,
+    finding.region,
+    finding.accountId,
+    finding.detectedAt,
+    JSON.stringify(finding.tags),
+    finding.hygieneReason,
+    finding.severity,
+    buildConsoleUrl({ ...finding, region: finding.region ?? undefined }),
+  ]);
+  return toCsv(HEADERS, rows);
+}

--- a/apps/cli/src/formatters/pdf-shared.ts
+++ b/apps/cli/src/formatters/pdf-shared.ts
@@ -14,6 +14,7 @@ export const C = {
   primary: '#1d4ed8',
   danger: '#dc2626',
   warning: '#d97706',
+  success: '#16a34a',
   text: '#111827',
   muted: '#6b7280',
   tableHeader: '#f3f4f6',
@@ -359,7 +360,7 @@ export function drawTable(
   contentBottom: number,
   // Parallel to `rows`: when present for a row, an invisible clickable
   // hotspot is layered over that row's *last* column (the visible cell text
-  // is still whatever `rows` put there, e.g. a short "Open ↗" label — this
+  // is still whatever `rows` put there, e.g. a short "Open ->" label — this
   // only adds the link annotation, it doesn't draw anything itself).
   links?: (string | undefined)[],
 ): number {

--- a/apps/cli/src/formatters/resource-security-report.csv-formatter.spec.ts
+++ b/apps/cli/src/formatters/resource-security-report.csv-formatter.spec.ts
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+import { AwsRegion, Ec2SecurityGroupOpenIngress } from 'resource-security-domain';
+import type { ResourceSecuritySummary } from 'resource-security-domain';
+import type { ResourceSecurityReportMeta } from 'resource-security-application';
+import { formatResourceSecurityReportAsCsv } from './resource-security-report.csv-formatter';
+
+const region = AwsRegion.create('us-east-1');
+const meta: ResourceSecurityReportMeta = {
+  accountId: '123456789012',
+  regions: ['us-east-1'],
+  generatedAt: new Date('2026-06-16'),
+};
+
+function summaryOf(groupId: string): ResourceSecuritySummary {
+  const group = new Ec2SecurityGroupOpenIngress({
+    groupId,
+    groupName: 'my-sg',
+    region,
+    accountId: '123456789012',
+    matchedRules: ['22/tcp from 0.0.0.0/0'],
+    detectedAt: new Date('2026-06-16'),
+    tags: {},
+  });
+  return { findings: [group], countBySeverity: { info: 0, warning: 0, critical: 1 }, scanErrors: [] };
+}
+
+describe('formatResourceSecurityReportAsCsv', () => {
+  it('emits a header row followed by one row per finding, with a consoleUrl column', () => {
+    const csv = formatResourceSecurityReportAsCsv(summaryOf('sg-abc123'), meta);
+    const lines = csv.split('\n');
+
+    expect(lines[0]).toBe('id,kind,region,accountId,detectedAt,tags,riskReason,severity,consoleUrl');
+    expect(lines).toHaveLength(2);
+    expect(lines[1]).toContain('sg-abc123');
+    expect(lines[1]).toContain(
+      'https://console.aws.amazon.com/vpc/home?region=us-east-1#SecurityGroups:groupId=sg-abc123',
+    );
+  });
+});

--- a/apps/cli/src/formatters/resource-security-report.csv-formatter.ts
+++ b/apps/cli/src/formatters/resource-security-report.csv-formatter.ts
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+import type { ResourceSecuritySummary } from 'resource-security-domain';
+import { toResourceSecurityReportDto, type ResourceSecurityReportMeta } from 'resource-security-application';
+import { buildConsoleUrl } from '../aws-console-link';
+import { toCsv } from './csv-utils';
+
+const HEADERS = ['id', 'kind', 'region', 'accountId', 'detectedAt', 'tags', 'riskReason', 'severity', 'consoleUrl'];
+
+/** One row per finding, raw DTO fields — meant for re-processing (spreadsheets, scripts), not on-screen reading. */
+export function formatResourceSecurityReportAsCsv(
+  summary: ResourceSecuritySummary,
+  meta: ResourceSecurityReportMeta,
+): string {
+  const dto = toResourceSecurityReportDto(summary, meta);
+  const rows = dto.findings.map((finding) => [
+    finding.id,
+    finding.kind,
+    finding.region,
+    finding.accountId,
+    finding.detectedAt,
+    JSON.stringify(finding.tags),
+    finding.riskReason,
+    finding.severity,
+    buildConsoleUrl({ ...finding, region: finding.region ?? undefined }),
+  ]);
+  return toCsv(HEADERS, rows);
+}

--- a/apps/cli/src/formatters/severity-report.formatter.ts
+++ b/apps/cli/src/formatters/severity-report.formatter.ts
@@ -247,7 +247,9 @@ export abstract class SeverityReportFormatter<
       const rows = findings.map((finding, i) => [
         ...this.rowFor(finding),
         finding.severity,
-        links[i] ? 'Open ↗' : '',
+        // Plain ASCII, not '↗': the base-14 Helvetica font (WinAnsi encoding)
+        // has no glyph for U+2197, which rendered as a broken/missing-glyph box.
+        links[i] ? 'Open ->' : '',
       ]);
       const headers = [...presenter.head, 'Severity', 'Link'];
       const colWidths = computeColumnWidths(doc, headers, rows, CONTENT_W);

--- a/apps/cli/src/formatters/waste-report.csv-formatter.spec.ts
+++ b/apps/cli/src/formatters/waste-report.csv-formatter.spec.ts
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+import { AwsRegion, EbsVolume } from 'cloud-cost-domain';
+import type { WastedResourcesSummary } from 'cloud-cost-domain';
+import type { WasteReportMeta } from 'cloud-cost-application';
+import { formatWasteReportAsCsv } from './waste-report.csv-formatter';
+
+const region = AwsRegion.create('us-east-1');
+const meta: WasteReportMeta = {
+  accountId: '123456789012',
+  regions: ['us-east-1'],
+  generatedAt: new Date('2026-06-16'),
+  pricesAsOf: '2026-06',
+};
+
+function summaryOf(volumeId: string): WastedResourcesSummary {
+  const volume = new EbsVolume({
+    volumeId,
+    region,
+    accountId: '123456789012',
+    sizeGb: 100,
+    volumeType: 'gp3',
+    state: 'available',
+    createTime: new Date('2025-01-01'),
+    detectedAt: new Date('2026-06-16'),
+    tags: { env: 'prod' },
+    monthlyCostUsd: 8,
+  });
+  return { findings: [volume], totalWasteMonthlyUsd: 8, totalOptimizationMonthlyUsd: 0, scanErrors: [] };
+}
+
+describe('formatWasteReportAsCsv', () => {
+  it('emits a header row followed by one row per finding, with a consoleUrl column', () => {
+    const csv = formatWasteReportAsCsv(summaryOf('vol-abc123'), meta);
+    const lines = csv.split('\n');
+
+    expect(lines[0]).toBe(
+      'id,kind,category,estimated,region,accountId,detectedAt,wasteReason,description,monthlyCostUsd,tags,userName,consoleUrl',
+    );
+    expect(lines).toHaveLength(2);
+    expect(lines[1]).toContain('vol-abc123');
+    expect(lines[1]).toContain('https://console.aws.amazon.com/ec2/home?region=us-east-1#Volumes:volumeId=vol-abc123');
+  });
+
+  it('JSON-encodes the tags map into a single quoted field', () => {
+    const csv = formatWasteReportAsCsv(summaryOf('vol-1'), meta);
+    expect(csv).toContain('"{""env"":""prod""}"');
+  });
+});

--- a/apps/cli/src/formatters/waste-report.csv-formatter.ts
+++ b/apps/cli/src/formatters/waste-report.csv-formatter.ts
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+import { toWasteReportDto } from 'cloud-cost-application';
+import type { WasteReportMeta } from 'cloud-cost-application';
+import type { WastedResourcesSummary } from 'cloud-cost-domain';
+import { buildConsoleUrl } from '../aws-console-link';
+import { toCsv } from './csv-utils';
+
+const HEADERS = [
+  'id',
+  'kind',
+  'category',
+  'estimated',
+  'region',
+  'accountId',
+  'detectedAt',
+  'wasteReason',
+  'description',
+  'monthlyCostUsd',
+  'tags',
+  'userName',
+  'consoleUrl',
+];
+
+/** One row per finding, raw DTO fields — meant for re-processing (spreadsheets, scripts), not on-screen reading. */
+export function formatWasteReportAsCsv(summary: WastedResourcesSummary, meta: WasteReportMeta): string {
+  const dto = toWasteReportDto(summary, meta);
+  const rows = dto.findings.map((finding) => [
+    finding.id,
+    finding.kind,
+    finding.category,
+    finding.estimated,
+    finding.region,
+    finding.accountId,
+    finding.detectedAt,
+    finding.wasteReason,
+    finding.description,
+    finding.monthlyCostUsd,
+    JSON.stringify(finding.tags),
+    finding.userName,
+    buildConsoleUrl(finding),
+  ]);
+  return toCsv(HEADERS, rows);
+}

--- a/apps/cli/src/formatters/waste-report.pdf-formatter.ts
+++ b/apps/cli/src/formatters/waste-report.pdf-formatter.ts
@@ -8,6 +8,7 @@ import {
 } from 'cloud-cost-domain';
 import type {
   FindingCategory,
+  RemediationEffort,
   WastedResource,
   WastedResourcesSummary,
 } from 'cloud-cost-domain';
@@ -111,6 +112,17 @@ function drawSummaryPage(
   doc.font('Helvetica-Bold').fontSize(10.5).fillColor(C.text)
     .text('Waste breakdown by resource type', MARGIN, y, { lineBreak: false });
   y += 16;
+
+  // Bar chart first (skim-in-5-seconds view of the biggest offenders), exact
+  // per-kind numbers in the table right below — additive, not a replacement,
+  // so nothing present today is lost.
+  const chartRows = buildCategoryChartRows(summary, 'waste');
+  if (chartRows.length > 0) {
+    y = ensureSpace(doc, y, measureBarChartHeight(doc, chartRows), contentBottom);
+    y = drawBarChart(doc, chartRows, y);
+    y += 14;
+  }
+
   const breakdownRows = buildBreakdownRows(summary, 'waste');
   const breakdownHeaders = ['Resource type', 'Found', 'Est. cost/month'];
   const breakdownColWidths = computeColumnWidths(doc, breakdownHeaders, breakdownRows, CONTENT_W);
@@ -142,7 +154,7 @@ function drawSummaryPage(
     y += 20;
     y = ensureSpace(doc, y, 16 + measureRecommendationsHeight(doc, wins), contentBottom);
     doc.font('Helvetica-Bold').fontSize(10.5).fillColor(C.text)
-      .text('Top recommendations — sorted by monthly impact', MARGIN, y, { lineBreak: false });
+      .text('Top quick wins — savings vs. remediation effort', MARGIN, y, { lineBreak: false });
     y += 16;
     y = drawRecommendations(doc, wins, y, contentBottom);
   }
@@ -189,7 +201,9 @@ function drawDetailPages(
     const rows = findings.map((finding, i) => [
       ...rowFor(finding),
       `$${finding.costEstimate.monthlyCostUsd.toFixed(2)}/mo`,
-      links[i] ? 'Open ↗' : '',
+      // Plain ASCII, not '↗': the base-14 Helvetica font (WinAnsi encoding)
+      // has no glyph for U+2197, which rendered as a broken/missing-glyph box.
+      links[i] ? 'Open ->' : '',
     ]);
     const headers = [...presenter.head, 'Cost/mo', 'Link'];
     const colWidths = computeColumnWidths(doc, headers, rows, CONTENT_W);
@@ -208,7 +222,14 @@ function sectionHeader(doc: PDFKit.PDFDocument, title: string): number {
 interface QuickWin {
   label: string;
   monthlyCostUsd: number;
+  effort: RemediationEffort;
 }
+
+// Divides the $ impact down by how much work remediating it takes (ADR-0093,
+// docs/en/remediation-effort.md), so a cheap-to-fix medium finding can outrank
+// an expensive one that needs a maintenance window — "quick wins" means both
+// savings AND effort, not just the biggest dollar figure.
+const EFFORT_WEIGHT: Record<RemediationEffort, number> = { low: 1, medium: 2, high: 3 };
 
 function buildQuickWins(summary: WastedResourcesSummary): QuickWin[] {
   // Routed through groupByKind (not summary.findings directly) so `finding`
@@ -216,18 +237,26 @@ function buildQuickWins(summary: WastedResourcesSummary): QuickWin[] {
   const grouped = groupByKind(summary.findings);
   const wins: QuickWin[] = [];
   for (const kind of RESOURCE_KINDS) {
+    const { effort } = RESOURCE_KIND_META[kind];
     for (const finding of grouped[kind]) {
-      wins.push({ label: recommendFor(finding), monthlyCostUsd: finding.costEstimate.monthlyCostUsd });
+      wins.push({ label: recommendFor(finding), monthlyCostUsd: finding.costEstimate.monthlyCostUsd, effort });
     }
   }
-  return wins.sort((a, b) => b.monthlyCostUsd - a.monthlyCostUsd).slice(0, 8);
+  return wins
+    .sort((a, b) => b.monthlyCostUsd / EFFORT_WEIGHT[b.effort] - a.monthlyCostUsd / EFFORT_WEIGHT[a.effort])
+    .slice(0, 8);
 }
 
-// Fixed overhead around the label column: 22 (index area) + 74 (gap, monthly
-// cost width and its own gap, all folded into the annual column's x-offset)
-// + 40 (annual cost width) + 8 (right padding, so "/yr" doesn't sit flush
-// against the table border) = 144. labelW must leave exactly this much room.
-const RECOMMENDATION_FIXED_W = 144;
+const EFFORT_BADGE_COLOR: Record<RemediationEffort, string> = { low: C.success, medium: C.warning, high: C.danger };
+const EFFORT_BADGE_LABEL: Record<RemediationEffort, string> = { low: 'LOW', medium: 'MED', high: 'HIGH' };
+const EFFORT_BADGE_W = 32;
+
+// Fixed overhead around the label column: 22 (index area) + 4 (gap) + 32
+// (effort badge) + 74 (gap, monthly cost width and its own gap, all folded
+// into the annual column's x-offset) + 40 (annual cost width) + 8 (right
+// padding, so "/yr" doesn't sit flush against the table border) = 180.
+// labelW must leave exactly this much room.
+const RECOMMENDATION_FIXED_W = 180;
 
 function recommendationLabelWidth(): number {
   return CONTENT_W - RECOMMENDATION_FIXED_W;
@@ -275,7 +304,7 @@ function drawRecommendations(
       segmentH = 0;
     }
 
-    const { monthlyCostUsd } = wins[i];
+    const { monthlyCostUsd, effort } = wins[i];
     const annual = monthlyCostUsd * 12;
     const bg = i % 2 === 0 ? '#ffffff' : C.rowAlt;
 
@@ -291,19 +320,90 @@ function drawRecommendations(
       doc.text(line, MARGIN + 22, y + 6 + li * LINE_H, { width: labelW, lineBreak: false });
     });
 
+    // Effort badge
+    doc.font('Helvetica-Bold').fontSize(7.5).fillColor(EFFORT_BADGE_COLOR[effort])
+      .text(EFFORT_BADGE_LABEL[effort], MARGIN + 22 + labelW + 4, y + 6.5, { width: EFFORT_BADGE_W, align: 'right', lineBreak: false });
+
     // Monthly cost
     doc.font('Helvetica-Bold').fontSize(8.5).fillColor(C.danger)
-      .text(`$${monthlyCostUsd.toFixed(2)}/mo`, MARGIN + 22 + labelW + 4, y + 6, { width: 66, align: 'right', lineBreak: false });
+      .text(`$${monthlyCostUsd.toFixed(2)}/mo`, MARGIN + 22 + labelW + 40, y + 6, { width: 66, align: 'right', lineBreak: false });
 
     // Annual cost
     doc.font('Helvetica').fontSize(8).fillColor(C.muted)
-      .text(`$${annual.toFixed(0)}/yr`, MARGIN + 22 + labelW + 74, y + 6, { width: 40, align: 'right', lineBreak: false });
+      .text(`$${annual.toFixed(0)}/yr`, MARGIN + 22 + labelW + 110, y + 6, { width: 40, align: 'right', lineBreak: false });
 
     y += h;
     segmentH += h;
   }
 
   strokeSegmentBorder();
+  return y;
+}
+
+// ─── Category bar chart ───────────────────────────────────────────────────────
+
+interface BarChartRow {
+  label: string;
+  monthlyCostUsd: number;
+}
+
+const BAR_CHART_LABEL_W = 190;
+const BAR_CHART_VALUE_W = 64;
+const BAR_CHART_MAX_ROWS = 6;
+const BAR_CHART_BAR_H = 8;
+const BAR_CHART_ROW_MIN_H = 16;
+
+/** Top N resource kinds by monthly cost within a category — capped so the
+ * chart stays a skimmable "biggest offenders" view; the exact table right
+ * below it still lists every kind found, capped or not. */
+function buildCategoryChartRows(summary: WastedResourcesSummary, category: FindingCategory): BarChartRow[] {
+  const grouped = groupByKind(summary.findings);
+  return RESOURCE_KINDS
+    .filter((kind) => RESOURCE_KIND_META[kind].category === category && grouped[kind].length > 0)
+    .map((kind) => ({
+      label: RESOURCE_KIND_LABELS[kind],
+      monthlyCostUsd: grouped[kind].reduce((sum, f) => sum + f.costEstimate.monthlyCostUsd, 0),
+    }))
+    .sort((a, b) => b.monthlyCostUsd - a.monthlyCostUsd)
+    .slice(0, BAR_CHART_MAX_ROWS);
+}
+
+function measureBarChartHeight(doc: PDFKit.PDFDocument, rows: BarChartRow[]): number {
+  doc.font('Helvetica').fontSize(8);
+  return rows.reduce(
+    (total, row) => total + Math.max(rowHeightForLines(wrapToLines(doc, row.label, BAR_CHART_LABEL_W).length), BAR_CHART_ROW_MIN_H),
+    0,
+  );
+}
+
+function drawBarChart(doc: PDFKit.PDFDocument, rows: BarChartRow[], startY: number): number {
+  let y = startY;
+  const barAreaX = MARGIN + BAR_CHART_LABEL_W + 8;
+  const barAreaW = CONTENT_W - BAR_CHART_LABEL_W - 8 - BAR_CHART_VALUE_W - 8;
+  const maxCost = Math.max(...rows.map((r) => r.monthlyCostUsd), 0.01);
+
+  for (const row of rows) {
+    doc.font('Helvetica').fontSize(8);
+    const labelLines = wrapToLines(doc, row.label, BAR_CHART_LABEL_W);
+    const rowH = Math.max(rowHeightForLines(labelLines.length), BAR_CHART_ROW_MIN_H);
+
+    doc.fillColor(C.text);
+    labelLines.forEach((line, li) => {
+      doc.text(line, MARGIN, y + li * LINE_H, { width: BAR_CHART_LABEL_W, lineBreak: false });
+    });
+
+    const barW = Math.max((row.monthlyCostUsd / maxCost) * barAreaW, 2);
+    doc.rect(barAreaX, y + (rowH - BAR_CHART_BAR_H) / 2, barW, BAR_CHART_BAR_H).fill(C.primary);
+
+    doc.font('Helvetica-Bold').fontSize(8).fillColor(C.text).text(
+      `$${row.monthlyCostUsd.toFixed(2)}/mo`,
+      barAreaX + barAreaW + 8,
+      y + (rowH - LINE_H) / 2,
+      { width: BAR_CHART_VALUE_W, align: 'right', lineBreak: false },
+    );
+
+    y += rowH;
+  }
   return y;
 }
 

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -55,7 +55,7 @@ program
   )
   .option(
     '--format <format>',
-    'stdout output format: table (default), json, or markdown (for CI / PR comments)',
+    'stdout output format: table (default), json, markdown (for CI / PR comments), or csv',
     'table',
   )
   // [filename] is an optional value: commander only attaches it to --pdf/--json
@@ -84,7 +84,7 @@ program
     '--config <path>',
     'path to a cloudrift config file (defaults to cloudrift.config.json / .cloudriftrc in the cwd)',
   )
-  .option('--format <format>', 'stdout output format: table (default) or json', 'table')
+  .option('--format <format>', 'stdout output format: table (default), json, or csv', 'table')
   .option(
     '--fail-on-increase <pct>',
     'exit with code 2 if spend increased more than this percent vs. the previous period (overrides config)',
@@ -110,7 +110,7 @@ program
     '--services <names...>',
     'restrict totals to these services (shorthand like ec2/s3/rds, or the exact Cost Explorer service name)',
   )
-  .option('--format <format>', 'stdout output format: table (default, ANSI bar chart) or json', 'table')
+  .option('--format <format>', 'stdout output format: table (default, ANSI bar chart), json, or csv', 'table')
   .option('--refresh-cache', 'bypass the local Cost Explorer cache and re-fetch closed periods from AWS')
   .option('-y, --yes', 'skip the interactive "this costs $0.01" confirmation')
   .option('--pdf [filename]', 'Also write a PDF report to disk (optional filename, defaults to reports/cloudrift-trend-YYYY_MM_DD.pdf)')
@@ -138,7 +138,7 @@ program
     '--scanners <kinds...>',
     'only run these checks (space-separated, e.g. ec2-keypair-unused iam-user-inactive)',
   )
-  .option('--format <format>', 'stdout output format: table (default) or json', 'table')
+  .option('--format <format>', 'stdout output format: table (default), json, or csv', 'table')
   // See the `analyze` command's --pdf option above for why [filename] needs
   // to be written as --pdf=./path.pdf when combined with other flags.
   .option(
@@ -165,7 +165,7 @@ program
     '--scanners <kinds...>',
     'only run these checks (space-separated, e.g. iam-root-mfa-disabled s3-bucket-public)',
   )
-  .option('--format <format>', 'stdout output format: table (default) or json', 'table')
+  .option('--format <format>', 'stdout output format: table (default), json, or csv', 'table')
   .option(
     '--pdf [filename]',
     'Also write a PDF report to disk (optional filename, defaults to reports/cloudrift-resource-security-YYYY_MM_DD.pdf)',

--- a/apps/cli/src/output-format.ts
+++ b/apps/cli/src/output-format.ts
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/** Formats every command supports. `analyze` additionally supports 'markdown' — see WASTE_OUTPUT_FORMATS. */
+export const OUTPUT_FORMATS = ['table', 'json', 'csv'] as const;
+export type OutputFormat = (typeof OUTPUT_FORMATS)[number];
+
+export const WASTE_OUTPUT_FORMATS = [...OUTPUT_FORMATS, 'markdown'] as const;
+export type WasteOutputFormat = (typeof WASTE_OUTPUT_FORMATS)[number];
+
+export function isOutputFormat<T extends string>(formats: readonly T[], format: string): format is T {
+  return (formats as readonly string[]).includes(format);
+}

--- a/apps/cli/src/wizard/output-format.wizard.ts
+++ b/apps/cli/src/wizard/output-format.wizard.ts
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
+import type { OutputFormat, WasteOutputFormat } from '../output-format';
 
 export interface WasteOutputChoice {
-  format: 'table' | 'json' | 'markdown';
+  format: WasteOutputFormat;
   savePdf: boolean;
   saveJson: boolean;
 }
@@ -16,6 +17,7 @@ export async function promptWasteOutput(): Promise<WasteOutputChoice | undefined
       { value: 'table', label: 'Table (default)' },
       { value: 'json', label: 'JSON' },
       { value: 'markdown', label: 'Markdown' },
+      { value: 'csv', label: 'CSV' },
     ],
     initialValue: 'table',
   });
@@ -31,11 +33,11 @@ export async function promptWasteOutput(): Promise<WasteOutputChoice | undefined
 }
 
 export interface DeadResourcesOutputChoice {
-  format: 'table' | 'json';
+  format: OutputFormat;
   savePdf: boolean;
 }
 
-/** Output format + optional PDF for the dead-resources wizard flow — table/json only, no markdown (see dead-resources.command.ts). */
+/** Output format + optional PDF for the dead-resources wizard flow — table/json/csv only, no markdown (see dead-resources.command.ts). */
 export async function promptDeadResourcesOutput(): Promise<DeadResourcesOutputChoice | undefined> {
   const { select, confirm, cancel, isCancel } = await import('@clack/prompts');
 
@@ -44,6 +46,7 @@ export async function promptDeadResourcesOutput(): Promise<DeadResourcesOutputCh
     options: [
       { value: 'table', label: 'Table (default)' },
       { value: 'json', label: 'JSON' },
+      { value: 'csv', label: 'CSV' },
     ],
     initialValue: 'table',
   });
@@ -57,20 +60,21 @@ export async function promptDeadResourcesOutput(): Promise<DeadResourcesOutputCh
 
 export type ResourceSecurityOutputChoice = DeadResourcesOutputChoice;
 
-/** Output format + optional PDF for the resource-security wizard flow — table/json only, no markdown, same shape as dead-resources. */
+/** Output format + optional PDF for the resource-security wizard flow — table/json/csv only, no markdown, same shape as dead-resources. */
 export async function promptResourceSecurityOutput(): Promise<ResourceSecurityOutputChoice | undefined> {
   return promptDeadResourcesOutput();
 }
 
 /** Output format for the cost/trend wizard flow — no file artifacts yet, see PDF backlog item. */
-export async function promptSimpleOutput(): Promise<'table' | 'json' | undefined> {
+export async function promptSimpleOutput(): Promise<OutputFormat | undefined> {
   const { select, cancel, isCancel } = await import('@clack/prompts');
 
-  const format = await select<'table' | 'json'>({
+  const format = await select<OutputFormat>({
     message: 'How should the report be shown?',
     options: [
       { value: 'table', label: 'Table / chart (default)' },
       { value: 'json', label: 'JSON' },
+      { value: 'csv', label: 'CSV' },
     ],
     initialValue: 'table',
   });

--- a/docs/adr/0092-csv-output-format.md
+++ b/docs/adr/0092-csv-output-format.md
@@ -1,0 +1,34 @@
+# ADR-0092: `csv` output format, flat DTO schema, `OUTPUT_FORMATS` consolidated
+
+- **Status:** Accepted (2026-07-27)
+
+## Context
+
+CSV was the last real gap on the competitor scorecard: every other report shape (`table`, `json`, and `markdown` for `analyze`) already existed, but nothing let a user pull findings straight into a spreadsheet/pivot-table workflow. The ask was to add `--format csv` across all five commands (`analyze`, `cost`, `trend`, `dead-resources`, `resource-security`) and expose it as a wizard choice everywhere `table`/`json` already are.
+
+Each of the five command files had its own copy-pasted `OUTPUT_FORMATS`/`isOutputFormat` pair (`analyze-waste.command.ts`, `cost.command.ts`, `trend.command.ts`, `dead-resources.command.ts`, `resource-security.command.ts`) — identical except `analyze`'s extra `'markdown'` member. Adding `'csv'` meant touching all five regardless, which is exactly the trigger condition this project's own DRY discipline calls for: fix duplication you're already touching, don't leave it for later out of laziness.
+
+## Decision
+
+**`apps/cli/src/output-format.ts`** is the new single source of truth: `OUTPUT_FORMATS = ['table', 'json', 'csv']`, `WASTE_OUTPUT_FORMATS = [...OUTPUT_FORMATS, 'markdown']`, and one generic `isOutputFormat<T>(formats, format)` type guard. All five commands import from here instead of declaring their own copy; `analyze-waste.command.ts` is the only one using `WASTE_OUTPUT_FORMATS`.
+
+**One `*.csv-formatter.ts` file per domain**, sibling to the existing `*.json-formatter.ts` (`waste-report.csv-formatter.ts`, `dead-resources-report.csv-formatter.ts`, `resource-security-report.csv-formatter.ts`, `cost-comparison.csv-formatter.ts`, `cost-trend.csv-formatter.ts`) — same file-per-format-per-domain convention the codebase already uses for table/json/pdf/markdown. Each one calls the *same* `toXxxReportDto()`/`toCostComparisonDto()`/`toCostTrendDto()` function its JSON sibling already calls, then flattens `dto.findings` (or `dto.byService`/`dto.months`) into rows — so CSV and JSON are guaranteed to describe the same data, just serialized differently. The findings-domain formatters also add `consoleUrl` via `buildConsoleUrl()`, matching [ADR-0091](0091-aws-console-deep-links-in-reports.md)'s placement (CLI-layer presentation concern, not the DTO).
+
+**Row schema: flat, raw DTO fields — not the presenter's per-kind columns.** `resource-presenters.ts`/`dead-resource-presenters.ts`/`resource-security-presenters.ts` give every finding *kind* its own header/row shape (e.g. `['Volume ID', 'Name', 'Region', 'Size', 'Type', 'Created']` for `ebs-volume`) for the table/PDF output, where a human reads one kind's section at a time. A single CSV file mixing kinds needs one column set for every row, so CSV formatters bypass the presenter layer entirely and use the DTO's already-uniform per-domain shape instead (`id, kind, category, estimated, region, accountId, detectedAt, wasteReason, description, monthlyCostUsd, tags, userName, consoleUrl` for waste; `id, kind, region, accountId, detectedAt, tags, hygieneReason/riskReason, severity, consoleUrl` for dead-resources/resource-security). `tags` (a `Record<string, string>`) is JSON-encoded into a single quoted field rather than flattened into dynamic columns, since the tag keys aren't fixed across findings.
+
+**`apps/cli/src/formatters/csv-utils.ts`**: an ~8-line `toCsv(headers, rows)` with its own comma/quote/newline escaping, no new dependency. The format is simple enough (no multi-line cells beyond what `JSON.stringify(tags)` might produce, no BOM/encoding concerns) that pulling in `csv-stringify` or similar would be pure overhead for what a dozen lines already cover correctly.
+
+**Wizard:** `output-format.wizard.ts`'s three prompt functions (`promptWasteOutput`, `promptDeadResourcesOutput`/`promptResourceSecurityOutput`, `promptSimpleOutput`) each gained a `{ value: 'csv', label: 'CSV' }` option, and their choice types now reuse `OutputFormat`/`WasteOutputFormat` from the new shared module instead of their own inline unions.
+
+**No new `--csv [filename]` file-artifact flag.** Only `--format csv` (stdout) was in scope — `--pdf`/`--json` file-writing flags exist inconsistently today (only `analyze` has both; `dead-resources`/`resource-security`/`cost`/`trend` only have `--pdf`), and adding a sixth flag combination wasn't asked for. A CSV file on disk is `--format csv > file.csv`, already scriptable without new code.
+
+## Alternatives Considered
+
+- **Leave `OUTPUT_FORMATS` duplicated, add `'csv'` to each of the five copies independently.** Rejected: the five files were being edited anyway to add the csv branch, so the marginal cost of consolidating was near zero, and leaving it would have grown the duplication from 5x to 5x-plus-drift-risk (a future format added to one copy and forgotten in another).
+- **Add `toCsv()` to `SeverityReportFormatter`** ([ADR-0088](0088-severity-report-template-method.md)), mirroring how it already hosts `toTable()`/`toPdf()`. Rejected: that base class is presenter/kind-grouping machinery, and CSV's row-per-finding-flat-schema doesn't need kind grouping at all — `formatXxxReportAsJson()` already proves this by skipping the base class entirely and working off the DTO directly. Adding `toCsv()` there would have meant re-deriving a flat DTO-shaped view from inside a class built around per-kind presenters, more code than just following the JSON formatter's existing pattern.
+- **CSV rows shaped like the presenter's per-kind table columns** (`Volume ID`, `Size`, `Type`, ... for `ebs-volume`; different columns for `elastic-ip`, etc.). Rejected: a single CSV file needs one column set for every row it contains; per-kind columns would force either separate CSV files per kind (unrequested scope increase) or padding every row to the union of all kinds' columns (mostly-empty, unreadable). The flat DTO schema is uniform across every kind in a domain by construction.
+- **A CSV library dependency (`csv-stringify`, `papaparse`, ...).** Rejected: the escaping surface needed (comma, quote-doubling, embedded newline) is small and stable; a project convention already avoids dependencies where a short, tested, first-party function suffices (e.g. [ADR-0047](0047-minimal-namespaced-debug-logger.md)'s no-dependency logger).
+
+## Consequences
+
+Five new formatter files plus `csv-utils.ts` and `output-format.ts`, one new test file per formatter plus `csv-utils.spec.ts`, and a `csv format` test added to each of the five command specs. `docs/en/usage.md`'s five `--format` flag-reference rows and the `--format` help strings in `main.ts` were updated to list `csv` alongside `table`/`json`(/`markdown`). Any format added in the future only needs `OUTPUT_FORMATS`/`WASTE_OUTPUT_FORMATS` updated once, not five times.

--- a/docs/adr/0093-quick-wins-effort-and-category-bar-chart.md
+++ b/docs/adr/0093-quick-wins-effort-and-category-bar-chart.md
@@ -1,0 +1,27 @@
+# ADR-0093: Quick-wins ranked by savings/effort, category bar chart in the waste PDF
+
+- **Status:** Accepted (2026-07-27)
+
+## Context
+
+A pasted external code review flagged the waste PDF as "a report, not a consulting one-pager": the "Top recommendations" list was sorted by raw monthly cost only (no sense of how hard a fix is), and the category breakdown was a text table with no visual. Verifying the review against the actual code showed most of its other claims were already addressed or stale (see the triage kept in project memory), but these two were real: `buildQuickWins()` in `waste-report.pdf-formatter.ts` sorted strictly by `monthlyCostUsd`, and `drawSummaryPage()`'s "Waste breakdown by resource type" section was table-only.
+
+## Decision
+
+**Per-kind `effort: 'low' | 'medium' | 'high'`** added to `ResourceKindMeta` (`libs/cloud-cost/domain/src/wasted-resource.ts`), classified for all 44 `ResourceKind`s using an explicit three-tier criterion (pure delete/detach with no dependents = low; needs verification or an in-place config change with a secondary effect = medium; needs downtime, migration, or cross-team coordination = high) — see `docs/en/remediation-effort.md`/`docs/it/livello-sforzo.md` for the full per-kind table and rationale, which the user reviewed and approved before it was wired into code. `effortOf(kind)` is the accessor, mirroring `categoryOf()`/`isEstimated()`.
+
+**Quick-wins re-ranked by a cost/effort score, not raw cost.** `buildQuickWins()` now sorts by `monthlyCostUsd / EFFORT_WEIGHT[effort]` descending (`EFFORT_WEIGHT = { low: 1, medium: 2, high: 3 }`), so a cheap-to-fix medium-cost finding can outrank an expensive one that needs a maintenance window. Each recommendation row in the PDF gained a color-coded effort badge (`LOW`/`MED`/`HIGH`, green/amber/red via a new `C.success` in the shared PDF palette) between the label and the monthly-cost column. The section heading changed from "Top recommendations — sorted by monthly impact" to "Top quick wins — savings vs. remediation effort" to match.
+
+**Category breakdown gets a bar chart, drawn with native pdfkit rectangles — additive, not a replacement for the table.** `buildCategoryChartRows()`/`drawBarChart()` render the top 6 waste kinds by monthly cost as horizontal bars (`C.primary`, proportional width, `$X/mo` right-aligned) directly above the existing "Waste breakdown by resource type" table. The table is untouched — same headers, same full kind list, same numbers — so nothing already on the summary page is lost; the chart is a five-second skim layer on top of it.
+
+## Alternatives Considered
+
+- **Pie chart per category** (the review's literal suggestion, and the option originally on the table). Rejected in favor of a bar chart: a pie chart needs manual arc/wedge trigonometry and label-collision handling in pdfkit (no chart primitives beyond paths/rects), and becomes illegible past 5-6 slices — exactly the range this report regularly hits once several scanners fire. A bar chart uses only rectangles, degrades gracefully at any row count, and needed a fraction of the code.
+- **Chart rendered as an image via a charting library** (e.g. `chartjs-node-canvas`) embedded with `doc.image()`. Rejected: adds a dependency with native canvas bindings — a platform-specific install for every npm consumer of `@cloudrift/cli` — to draw six rectangles, which the project's existing no-unnecessary-dependency convention (see the CSV-formatter [ADR-0092](0092-csv-output-format.md), the debug logger [ADR-0047](0047-minimal-namespaced-debug-logger.md)) already argues against.
+- **Replacing the breakdown table with the chart** instead of adding the chart alongside it. Rejected: the table is the only place on the summary page carrying the exact `Found`/`$` figures for every kind (the chart caps at 6, sorted by cost); dropping it would regress information a reader might specifically want to `Ctrl+F` or quote verbatim.
+- **Deriving "effort" from existing fields** (`category`, `estimated`) instead of adding a new one. Rejected in the options discussion: neither field measures effort — `category` is waste-vs-optimization, `estimated` is pricing-confidence — reusing them would silently misrepresent what "effort" means.
+- **Keep $-only ranking, just label the effort tier without re-sorting** (the more conservative of the two options presented to the user). Not chosen: the user picked the full re-ranked version as the "final result" directly, skipping the incremental step.
+
+## Consequences
+
+`RemediationEffort` is exported from `cloud-cost-domain`'s public index alongside `ResourceKindMeta`. `docs/en/remediation-effort.md` / `docs/it/livello-sforzo.md` are the source of truth for *why* each kind has the rating it does — update them first if a rating changes, the code comment in `wasted-resource.ts` points there rather than repeating the rationale inline. Any new `ResourceKind` added in the future (see `docs/en/adding-a-resource.md`) must set `effort` on `RESOURCE_KIND_META` or the object literal fails to type-check against `Record<ResourceKind, ResourceKindMeta>` — the same exhaustiveness guarantee `category`/`estimated` already had.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -118,6 +118,8 @@ Each entry follows: Context → Decision → Alternatives Considered → Consequ
 | [0076](0076-resource-name-column-alongside-opaque-ids.md) | A `Name`/`User` column alongside opaque AWS-generated IDs, never replacing them | Accepted |
 | [0088](0088-severity-report-template-method.md) | `SeverityReportFormatter` template method for the severity-based reports | Accepted |
 | [0091](0091-aws-console-deep-links-in-reports.md) | AWS console deep links in JSON/PDF findings, partial coverage by design | Accepted |
+| [0092](0092-csv-output-format.md) | `csv` output format, flat DTO schema, `OUTPUT_FORMATS` consolidated | Accepted |
+| [0093](0093-quick-wins-effort-and-category-bar-chart.md) | Quick-wins ranked by savings/effort, category bar chart in the waste PDF | Accepted |
 
 ## Testing
 

--- a/docs/en/remediation-effort.md
+++ b/docs/en/remediation-effort.md
@@ -1,0 +1,58 @@
+# Remediation effort per resource kind
+
+> 🇮🇹 [Versione italiana](../it/livello-sforzo.md)
+
+Every waste `ResourceKind` carries an `effort` rating (`low` / `medium` / `high`) alongside its `category`/`estimated` metadata. It feeds the PDF report's "Top quick wins" ranking — sorted by a cost-vs-effort score, not raw monthly cost alone — so the first items a reader sees are cheap-to-fix, not just expensive.
+
+**Criteria:**
+
+- **low** — pure delete/detach of a resource nothing else references, no dependents by construction, reversible or near-zero risk.
+- **medium** — needs verification before acting (the scan's "idle"/"unused" call could be wrong) or is an in-place config change with no downtime but some secondary effect.
+- **high** — needs downtime, data migration, or coordination with another team/service that may depend on the resource silently.
+
+| Kind | Effort | Why |
+|---|---|---|
+| `ebs-volume` | low | Volume already unattached, zero dependents |
+| `elastic-ip` | low | IP already unassociated |
+| `rds-instance` | **high** | Database: data risk, needs a snapshot + verification + coordination |
+| `load-balancer` | medium | Verify no client still points at the DNS name |
+| `ec2-instance` | medium | Verify before terminating; reversible via an AMI |
+| `ebs-snapshot` | low | Old/redundant snapshot |
+| `nat-gateway` | medium | Affects a whole subnet's egress path if misclassified |
+| `ebs-gp2-upgrade` | low | In-place volume-type change, zero downtime |
+| `ebs-idle` | low | Same reasoning as `ebs-volume` |
+| `ec2-underutilized` | medium | Resize needs a stop/start, brief downtime |
+| `rds-underutilized` | **high** | Resizing RDS usually needs a maintenance window |
+| `log-group` | low | No runtime impact |
+| `eni-orphaned` | low | Network interface already unattached |
+| `s3-no-lifecycle` | low | Adding a lifecycle rule is config-only, zero downtime |
+| `lambda-underutilized` | low | Memory change is config-only, zero downtime |
+| `efs-unused` | medium | Verify no intermittent mounts before deleting |
+| `dynamodb-overprovisioned` | low | Online throughput change, zero downtime |
+| `elasticache-idle` | medium | Cache clusters are often silently shared by other apps |
+| `redshift-idle-cluster` | **high** | Data warehouse — verify no BI tool depends on it |
+| `opensearch-idle-domain` | medium | Verify dependent apps; reversible via snapshot |
+| `msk-idle-cluster` | **high** | Messaging infra often has hidden consumers |
+| `fsx-idle-filesystem` | medium | Verify mounts before deleting |
+| `documentdb-idle-instance` | **high** | Database, same reasoning as `rds-instance` |
+| `neptune-idle-instance` | **high** | Graph database, same reasoning |
+| `mq-idle-broker` | medium | Verify apps depending on the queue |
+| `workspaces-idle` | low | Low per-user blast radius, re-provisionable |
+| `vpn-connection-idle` | medium | Network connectivity, needs the network team's input |
+| `transit-gateway-idle-attachment` | medium | Network routing, needs verification |
+| `kinesis-provisioned-idle-stream` | medium | Verify producers/consumers before deleting |
+| `sqs-dlq-abandoned` | low | $0 queue, pure hygiene |
+| `lambda-loggroup-orphaned` | low | No runtime impact |
+| `aurora-serverless-overprovisioned` | medium | Min ACU change is online but affects the scaling floor |
+| `sagemaker-notebook-idle` | low | Isolated single-user dev notebook |
+| `sagemaker-endpoint-idle` | **high** | A serving endpoint — if misclassified, breaks a production ML integration |
+| `sagemaker-training-orphaned` | low | Model with no active endpoint, zero risk |
+| `environment-ghost` | medium | Multiple resources at once, but already inactive by definition |
+| `eks-node-overprovisioned` | **high** | Affects the whole cluster's scheduling capacity |
+| `eks-orphan-pvc` | low | No pod references it by construction |
+| `ami-unused` | low | Unused AMI, zero dependents |
+| `ecr-image-untagged` | low | No deployment references untagged digests |
+| `s3-multipart-upload-abandoned` | low | Pure cleanup, zero risk |
+| `rds-manual-snapshot-old` | low | Old snapshot, same reasoning as `ebs-snapshot` |
+| `secretsmanager-unused` | medium | A secret can have indirect dependents that are hard to verify |
+| `codepipeline-pipeline-stale` | low | No runtime impact, re-creatable from source |

--- a/docs/en/usage.md
+++ b/docs/en/usage.md
@@ -15,7 +15,7 @@ node apps/cli/dist/main.js analyze [options]
 | Option                       | Description                                                                                                    | Default            |
 | ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ |
 | `-r, --regions <regions...>` | AWS regions to scan                                                                                            | `us-east-1`        |
-| `--format <format>`          | stdout output format: `table`, `json`, or `markdown` (for CI / PR comments)                                   | `table`            |
+| `--format <format>`          | stdout output format: `table`, `json`, `markdown` (for CI / PR comments), or `csv`                            | `table`            |
 | `--config <path>`            | Path to a config file (defaults to `cloudrift.config.json` / `.cloudriftrc` in the cwd)                       | auto-discovered    |
 | `--live-pricing`             | Fetch current list prices from the AWS Pricing API (falls back to the static table; config prices still win)  | off (static table) |
 | `--scanners <kinds...>`      | Only run these services (space-separated resource kinds, e.g. `ebs-volume elastic-ip`); skips the interactive picker | — |
@@ -28,7 +28,7 @@ node apps/cli/dist/main.js analyze [options]
 | `--silent`                   | Suppress all stdout output (banner, report, confirmations) — use with `--pdf`/`--json` for file-only output    | off                |
 | `-h, --help`                 | Show help                                                                                                      | —                  |
 
-> **stdout vs. file artifacts:** `--format` controls what goes to **stdout** (the report itself). `--json` / `--pdf` write **additional files** to disk and are independent of `--format` — by default the chosen `--format` still prints to stdout *in addition to* writing those files (so e.g. `--pdf` alone still shows the table by default). Add `--silent` for file-only output with nothing printed to the terminal. In machine-readable formats (`json`, `markdown`) all human messages are routed to stderr, so stdout carries only the report — ideal for piping. Errors and the cost-gate alert always surface on stderr, even with `--silent`.
+> **stdout vs. file artifacts:** `--format` controls what goes to **stdout** (the report itself). `--json` / `--pdf` write **additional files** to disk and are independent of `--format` — by default the chosen `--format` still prints to stdout *in addition to* writing those files (so e.g. `--pdf` alone still shows the table by default). Add `--silent` for file-only output with nothing printed to the terminal. In machine-readable formats (`json`, `markdown`, `csv`) all human messages are routed to stderr, so stdout carries only the report — ideal for piping. Errors and the cost-gate alert always surface on stderr, even with `--silent`.
 >
 > **Flag order with `--pdf`/`--json`:** their filename is an *optional* value (`--pdf [filename]`), so it's only picked up if it immediately follows the flag — `--pdf --silent ./report.pdf` fails ("too many arguments") because `--silent` blocks `--pdf` from seeing the filename, leaving `./report.pdf` with nothing to attach to. Either keep the filename right after the flag (`--pdf ./report.pdf --silent`), or use `=` to make order irrelevant: `--pdf=./report.pdf --silent --format json`.
 >
@@ -120,7 +120,7 @@ node apps/cli/dist/main.js trend [options]
 | --- | --- | --- |
 | `--account-id <id>` | AWS account ID override (auto-detected via STS when omitted) | auto-detected |
 | `--config <path>` | Path to a config file | auto-discovered |
-| `--format <format>` | stdout format: `table` or `json` | `table` |
+| `--format <format>` | stdout format: `table`, `json`, or `csv` | `table` |
 | `--fail-on-increase <pct>` | Exit with code 2 if spend increased more than this percent vs. the previous period (overrides `config.costIncreaseAlertPercent`) | off |
 | `--refresh-cache` | Bypass the local Cost Explorer cache and re-fetch closed periods from AWS | off |
 | `-y, --yes` | Skip the "this costs $0.01" confirmation | — |
@@ -135,7 +135,7 @@ node apps/cli/dist/main.js trend [options]
 | `--config <path>` | Path to a config file | auto-discovered |
 | `--months <n>` | Number of calendar months to show (1–36) | `6` |
 | `--services <names...>` | Restrict to these services (shorthand like `ec2 s3 rds`, or the exact Cost Explorer service name) | all services |
-| `--format <format>` | stdout format: `table` (ANSI bar chart) or `json` | `table` |
+| `--format <format>` | stdout format: `table` (ANSI bar chart), `json`, or `csv` | `table` |
 | `--refresh-cache` | Bypass the local Cost Explorer cache | off |
 | `-y, --yes` | Skip the billing confirmation | — |
 | `--pdf [filename]` | Also write a PDF report (defaults to `reports/cloudrift-trend-YYYY_MM_DD.pdf`) | — |
@@ -174,7 +174,7 @@ node apps/cli/dist/main.js dead-resources [options]
 | `--min-age-days <days>`      | Grace period: resources younger than this many days are not reported (`ec2-ri-expiring-soon` doesn't use this — see below) | `7`     |
 | `--ignore-tag <tag>`         | Resources carrying this tag are excluded from the report                                                       | `cloudrift:ignore` |
 | `--scanners <kinds...>`      | Only run these checks (space-separated, e.g. `ec2-keypair-unused iam-user-inactive`)                           | all checks          |
-| `--format <format>`          | stdout output format: `table` or `json`                                                                        | `table`            |
+| `--format <format>`          | stdout output format: `table`, `json`, or `csv`                                                                | `table`            |
 | `--pdf [filename]`           | Also write a PDF report to disk (defaults to `reports/cloudrift-dead-resources-YYYY_MM_DD.pdf`)                | —                  |
 | `--silent`                   | Suppress all stdout output (banner, report). Errors still surface.                                              | off                |
 | `-h, --help`                 | Show help                                                                                                       | —                  |
@@ -236,7 +236,7 @@ node apps/cli/dist/main.js resource-security [options]
 | `--account-id <id>`          | AWS account ID override (auto-detected via `sts:GetCallerIdentity` when omitted)                               | auto-detected      |
 | `--ignore-tag <tag>`         | Resources carrying this tag are excluded from the report                                                       | `cloudrift:ignore` |
 | `--scanners <kinds...>`      | Only run these checks (space-separated, e.g. `iam-root-mfa-disabled s3-bucket-public`)                         | all checks          |
-| `--format <format>`          | stdout output format: `table` or `json`                                                                        | `table`            |
+| `--format <format>`          | stdout output format: `table`, `json`, or `csv`                                                                | `table`            |
 | `--pdf [filename]`           | Also write a PDF report to disk (defaults to `reports/cloudrift-resource-security-YYYY_MM_DD.pdf`)             | —                  |
 | `--silent`                   | Suppress all stdout output (banner, report). Errors still surface.                                              | off                |
 | `-h, --help`                 | Show help                                                                                                       | —                  |

--- a/docs/it/livello-sforzo.md
+++ b/docs/it/livello-sforzo.md
@@ -1,0 +1,58 @@
+# Livello di sforzo per tipo di risorsa
+
+> 🇬🇧 [English version](../en/remediation-effort.md)
+
+Ogni `ResourceKind` di spreco ha un valore `effort` (`low` / `medium` / `high`) accanto ai metadati `category`/`estimated`. Alimenta la classifica "Top quick wins" del report PDF — ordinata per un punteggio costo/sforzo, non per il solo costo mensile — così le prime voci che il lettore vede sono quelle economiche da risolvere, non semplicemente le più costose.
+
+**Criterio:**
+
+- **low** — cancellazione o scollegamento puro di una risorsa non referenziata da nulla, zero dipendenti per costruzione, reversibile o a rischio quasi nullo.
+- **medium** — richiede una verifica prima di agire (la classificazione "inattiva"/"non usata" dello scan potrebbe essere sbagliata), oppure è una modifica di configurazione senza downtime ma con qualche effetto secondario.
+- **high** — richiede downtime, migrazione dei dati, o coordinamento con un altro team/servizio che potrebbe dipendere silenziosamente dalla risorsa.
+
+| Kind | Effort | Perché |
+|---|---|---|
+| `ebs-volume` | low | Volume già scollegato, zero dipendenti |
+| `elastic-ip` | low | IP già non associato |
+| `rds-instance` | **high** | Database: rischio di perdita dati, richiede snapshot, verifica e coordinamento |
+| `load-balancer` | medium | Verificare che nessun client punti ancora al nome DNS |
+| `ec2-instance` | medium | Verificare prima di terminare l'istanza; reversibile tramite un'AMI |
+| `ebs-snapshot` | low | Snapshot vecchio o ridondante |
+| `nat-gateway` | medium | Se mal classificato, impatta il percorso di rete di un'intera subnet |
+| `ebs-gp2-upgrade` | low | Modifica del tipo di volume in-place, zero downtime |
+| `ebs-idle` | low | Stesso ragionamento di `ebs-volume` |
+| `ec2-underutilized` | medium | Il ridimensionamento richiede uno stop/start, breve downtime |
+| `rds-underutilized` | **high** | Il ridimensionamento di RDS di solito richiede una finestra di manutenzione |
+| `log-group` | low | Nessun impatto sul funzionamento in produzione |
+| `eni-orphaned` | low | Interfaccia di rete già scollegata |
+| `s3-no-lifecycle` | low | Aggiungere una regola di lifecycle è solo configurazione, zero downtime |
+| `lambda-underutilized` | low | La modifica della memoria è configurazione, zero downtime |
+| `efs-unused` | medium | Verificare eventuali mount intermittenti prima di cancellare |
+| `dynamodb-overprovisioned` | low | Modifica del throughput online, zero downtime |
+| `elasticache-idle` | medium | Le cache sono spesso condivise silenziosamente da altre applicazioni |
+| `redshift-idle-cluster` | **high** | Data warehouse — verificare che nessuno strumento di BI ne dipenda |
+| `opensearch-idle-domain` | medium | Verificare le applicazioni dipendenti; reversibile tramite snapshot |
+| `msk-idle-cluster` | **high** | L'infrastruttura di messaggistica ha spesso consumer nascosti |
+| `fsx-idle-filesystem` | medium | Verificare i mount prima di cancellare |
+| `documentdb-idle-instance` | **high** | Database, stesso ragionamento di `rds-instance` |
+| `neptune-idle-instance` | **high** | Database a grafo, stesso ragionamento |
+| `mq-idle-broker` | medium | Verificare le applicazioni dipendenti dalla coda |
+| `workspaces-idle` | low | Impatto basso per singolo utente, facilmente ri-approvvigionabile |
+| `vpn-connection-idle` | medium | Connettività di rete, richiede il parere del team di rete |
+| `transit-gateway-idle-attachment` | medium | Instradamento di rete, richiede verifica |
+| `kinesis-provisioned-idle-stream` | medium | Verificare produttori e consumatori prima di cancellare |
+| `sqs-dlq-abandoned` | low | Coda a costo zero, pura pulizia |
+| `lambda-loggroup-orphaned` | low | Nessun impatto sul funzionamento in produzione |
+| `aurora-serverless-overprovisioned` | medium | La modifica del Min ACU è online ma incide sulla soglia minima di scaling |
+| `sagemaker-notebook-idle` | low | Notebook di sviluppo isolato, a uso di un solo utente |
+| `sagemaker-endpoint-idle` | **high** | Endpoint di serving — se mal classificato, interrompe un'integrazione ML in produzione |
+| `sagemaker-training-orphaned` | low | Modello senza endpoint attivo, rischio nullo |
+| `environment-ghost` | medium | Più risorse insieme, ma già inattivo per definizione |
+| `eks-node-overprovisioned` | **high** | Incide sulla capacità di scheduling dell'intero cluster |
+| `eks-orphan-pvc` | low | Nessun pod lo referenzia per costruzione |
+| `ami-unused` | low | AMI non usata, zero dipendenti |
+| `ecr-image-untagged` | low | Nessun deployment referenzia digest senza tag |
+| `s3-multipart-upload-abandoned` | low | Pulizia pura, rischio nullo |
+| `rds-manual-snapshot-old` | low | Snapshot vecchio, stesso ragionamento di `ebs-snapshot` |
+| `secretsmanager-unused` | medium | Un secret può avere dipendenti indiretti difficili da verificare |
+| `codepipeline-pipeline-stale` | low | Nessun impatto sul funzionamento in produzione, ricreabile dal codice sorgente |

--- a/libs/cloud-cost/domain/src/index.ts
+++ b/libs/cloud-cost/domain/src/index.ts
@@ -6,12 +6,14 @@ export {
   RESOURCE_KIND_META,
   categoryOf,
   isEstimated,
+  effortOf,
 } from './wasted-resource';
 export type {
   ResourceKind,
   WastedResource,
   FindingCategory,
   ResourceKindMeta,
+  RemediationEffort,
 } from './wasted-resource';
 export { groupByKind } from './group-by-kind';
 export type { ResourceKindMap, FindingsByKind } from './group-by-kind';

--- a/libs/cloud-cost/domain/src/wasted-resource.spec.ts
+++ b/libs/cloud-cost/domain/src/wasted-resource.spec.ts
@@ -1,5 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
-import { RESOURCE_KINDS, RESOURCE_KIND_META, RESOURCE_KIND_LABELS, categoryOf, isEstimated } from './wasted-resource';
+import {
+  RESOURCE_KINDS,
+  RESOURCE_KIND_META,
+  RESOURCE_KIND_LABELS,
+  categoryOf,
+  isEstimated,
+  effortOf,
+} from './wasted-resource';
 
 describe('RESOURCE_KIND_META', () => {
   it('has a metadata entry for every declared resource kind', () => {
@@ -8,6 +15,7 @@ describe('RESOURCE_KIND_META', () => {
       expect(typeof RESOURCE_KIND_META[kind].label).toBe('string');
       expect(['waste', 'optimization']).toContain(RESOURCE_KIND_META[kind].category);
       expect(typeof RESOURCE_KIND_META[kind].estimated).toBe('boolean');
+      expect(['low', 'medium', 'high']).toContain(RESOURCE_KIND_META[kind].effort);
     }
   });
 });
@@ -37,5 +45,15 @@ describe('isEstimated', () => {
 
   it('returns true for a kind with a heuristic cost estimate', () => {
     expect(isEstimated('ec2-underutilized')).toBe(true);
+  });
+});
+
+describe('effortOf', () => {
+  it('returns "low" for a pure delete/detach kind', () => {
+    expect(effortOf('ebs-volume')).toBe('low');
+  });
+
+  it('returns "high" for a kind needing downtime/coordination', () => {
+    expect(effortOf('rds-instance')).toBe('high');
   });
 });

--- a/libs/cloud-cost/domain/src/wasted-resource.ts
+++ b/libs/cloud-cost/domain/src/wasted-resource.ts
@@ -60,70 +60,117 @@ export type ResourceKind = (typeof RESOURCE_KINDS)[number];
  */
 export type FindingCategory = 'waste' | 'optimization';
 
+/**
+ * How much work remediating a finding of this kind takes, independent of its
+ * dollar cost — see docs/en/remediation-effort.md for the full per-kind
+ * rationale. Feeds the PDF "quick wins" ranking (ADR-0093): a cheap-to-fix
+ * finding should outrank an expensive one that needs a maintenance window.
+ * - `low`: pure delete/detach of a resource nothing else references, no
+ *   dependents by construction, reversible or near-zero risk.
+ * - `medium`: needs verification before acting (the scan's "idle"/"unused"
+ *   call could be wrong), or is an in-place config change with no downtime
+ *   but some secondary effect.
+ * - `high`: needs downtime, data migration, or coordination with another
+ *   team/service that may depend on the resource silently.
+ */
+export type RemediationEffort = 'low' | 'medium' | 'high';
+
 export interface ResourceKindMeta {
   label: string;
   category: FindingCategory;
   /** The saving is a heuristic estimate (rightsizing) rather than a definite value. */
   estimated: boolean;
+  effort: RemediationEffort;
 }
 
 export const RESOURCE_KIND_META: Record<ResourceKind, ResourceKindMeta> = {
-  'ebs-volume': { label: 'EBS Volumes', category: 'waste', estimated: false },
-  'elastic-ip': { label: 'Elastic IPs', category: 'waste', estimated: false },
-  'rds-instance': { label: 'RDS Instances', category: 'waste', estimated: false },
-  'load-balancer': { label: 'Load Balancers', category: 'waste', estimated: false },
-  'ec2-instance': { label: 'EC2 Instances', category: 'waste', estimated: false },
-  'ebs-snapshot': { label: 'EBS Snapshots', category: 'waste', estimated: false },
-  'nat-gateway': { label: 'NAT Gateways', category: 'waste', estimated: false },
-  'ebs-gp2-upgrade': { label: 'EBS gp2→gp3 Upgrades', category: 'optimization', estimated: false },
-  'ebs-idle': { label: 'EBS Volumes (idle)', category: 'waste', estimated: false },
+  'ebs-volume': { label: 'EBS Volumes', category: 'waste', estimated: false, effort: 'low' },
+  'elastic-ip': { label: 'Elastic IPs', category: 'waste', estimated: false, effort: 'low' },
+  'rds-instance': { label: 'RDS Instances', category: 'waste', estimated: false, effort: 'high' },
+  'load-balancer': { label: 'Load Balancers', category: 'waste', estimated: false, effort: 'medium' },
+  'ec2-instance': { label: 'EC2 Instances', category: 'waste', estimated: false, effort: 'medium' },
+  'ebs-snapshot': { label: 'EBS Snapshots', category: 'waste', estimated: false, effort: 'low' },
+  'nat-gateway': { label: 'NAT Gateways', category: 'waste', estimated: false, effort: 'medium' },
+  'ebs-gp2-upgrade': { label: 'EBS gp2→gp3 Upgrades', category: 'optimization', estimated: false, effort: 'low' },
+  'ebs-idle': { label: 'EBS Volumes (idle)', category: 'waste', estimated: false, effort: 'low' },
   'ec2-underutilized': {
     label: 'EC2 Instances (underutilized)',
     category: 'optimization',
     estimated: true,
+    effort: 'medium',
   },
   'rds-underutilized': {
     label: 'RDS Instances (underutilized)',
     category: 'optimization',
     estimated: true,
+    effort: 'high',
   },
-  'log-group': { label: 'CloudWatch Log Groups', category: 'waste', estimated: false },
-  'eni-orphaned': { label: 'Orphaned ENIs', category: 'waste', estimated: false },
-  's3-no-lifecycle': { label: 'S3 Buckets (no lifecycle)', category: 'optimization', estimated: true },
-  'lambda-underutilized': { label: 'Lambda Functions (underutilized)', category: 'optimization', estimated: false },
-  'efs-unused': { label: 'EFS File Systems (unused)', category: 'waste', estimated: false },
+  'log-group': { label: 'CloudWatch Log Groups', category: 'waste', estimated: false, effort: 'low' },
+  'eni-orphaned': { label: 'Orphaned ENIs', category: 'waste', estimated: false, effort: 'low' },
+  's3-no-lifecycle': { label: 'S3 Buckets (no lifecycle)', category: 'optimization', estimated: true, effort: 'low' },
+  'lambda-underutilized': {
+    label: 'Lambda Functions (underutilized)',
+    category: 'optimization',
+    estimated: false,
+    effort: 'low',
+  },
+  'efs-unused': { label: 'EFS File Systems (unused)', category: 'waste', estimated: false, effort: 'medium' },
   'dynamodb-overprovisioned': {
     label: 'DynamoDB Tables (overprovisioned)',
     category: 'optimization',
     estimated: true,
+    effort: 'low',
   },
-  'elasticache-idle': { label: 'ElastiCache Clusters (idle)', category: 'waste', estimated: false },
-  'redshift-idle-cluster': { label: 'Redshift Clusters (idle)', category: 'waste', estimated: false },
-  'opensearch-idle-domain': { label: 'OpenSearch Domains (idle)', category: 'waste', estimated: false },
-  'msk-idle-cluster': { label: 'MSK Clusters (idle)', category: 'waste', estimated: false },
-  'fsx-idle-filesystem': { label: 'FSx File Systems (idle)', category: 'waste', estimated: false },
-  'documentdb-idle-instance': { label: 'DocumentDB Instances (idle)', category: 'waste', estimated: false },
-  'neptune-idle-instance': { label: 'Neptune Instances (idle)', category: 'waste', estimated: false },
-  'mq-idle-broker': { label: 'Amazon MQ Brokers (idle)', category: 'waste', estimated: false },
-  'workspaces-idle': { label: 'WorkSpaces (idle, AlwaysOn)', category: 'waste', estimated: false },
-  'vpn-connection-idle': { label: 'Site-to-Site VPN Connections (idle)', category: 'waste', estimated: false },
+  'elasticache-idle': { label: 'ElastiCache Clusters (idle)', category: 'waste', estimated: false, effort: 'medium' },
+  'redshift-idle-cluster': { label: 'Redshift Clusters (idle)', category: 'waste', estimated: false, effort: 'high' },
+  'opensearch-idle-domain': {
+    label: 'OpenSearch Domains (idle)',
+    category: 'waste',
+    estimated: false,
+    effort: 'medium',
+  },
+  'msk-idle-cluster': { label: 'MSK Clusters (idle)', category: 'waste', estimated: false, effort: 'high' },
+  'fsx-idle-filesystem': { label: 'FSx File Systems (idle)', category: 'waste', estimated: false, effort: 'medium' },
+  'documentdb-idle-instance': {
+    label: 'DocumentDB Instances (idle)',
+    category: 'waste',
+    estimated: false,
+    effort: 'high',
+  },
+  'neptune-idle-instance': { label: 'Neptune Instances (idle)', category: 'waste', estimated: false, effort: 'high' },
+  'mq-idle-broker': { label: 'Amazon MQ Brokers (idle)', category: 'waste', estimated: false, effort: 'medium' },
+  'workspaces-idle': { label: 'WorkSpaces (idle, AlwaysOn)', category: 'waste', estimated: false, effort: 'low' },
+  'vpn-connection-idle': {
+    label: 'Site-to-Site VPN Connections (idle)',
+    category: 'waste',
+    estimated: false,
+    effort: 'medium',
+  },
   'transit-gateway-idle-attachment': {
     label: 'Transit Gateway Attachments (idle)',
     category: 'waste',
     estimated: false,
+    effort: 'medium',
   },
   'kinesis-provisioned-idle-stream': {
     label: 'Kinesis Streams (idle, Provisioned mode)',
     category: 'waste',
     estimated: false,
+    effort: 'medium',
   },
   // Phase 6.1 (ADR-0065): serverless orphans vertical. $0 hygiene flag, same
   // rationale as 'eni-orphaned' — no direct AWS cost, but signals ignored errors.
-  'sqs-dlq-abandoned': { label: 'SQS Dead Letter Queues (abandoned)', category: 'waste', estimated: false },
+  'sqs-dlq-abandoned': {
+    label: 'SQS Dead Letter Queues (abandoned)',
+    category: 'waste',
+    estimated: false,
+    effort: 'low',
+  },
   'lambda-loggroup-orphaned': {
     label: 'CloudWatch Log Groups (orphaned Lambda)',
     category: 'waste',
     estimated: false,
+    effort: 'low',
   },
   // Phase 6.2: Aurora Serverless v2 vertical. The Min ACU floor is always
   // billed (730h/mo); lowering it is a definite saving, but the recommended
@@ -132,16 +179,28 @@ export const RESOURCE_KIND_META: Record<ResourceKind, ResourceKindMeta> = {
     label: 'Aurora Serverless v2 (overprovisioned Min ACU)',
     category: 'optimization',
     estimated: true,
+    effort: 'medium',
   },
   // Phase 6.3 (ADR-0065): SageMaker vertical. Notebook/endpoint costs are
   // per-instance-type (requires --live-pricing); training-orphaned is a
   // namespace-hygiene flag priced via the static S3 storage estimate.
-  'sagemaker-notebook-idle': { label: 'SageMaker Notebook Instances (idle)', category: 'waste', estimated: false },
-  'sagemaker-endpoint-idle': { label: 'SageMaker Endpoints (idle)', category: 'waste', estimated: false },
+  'sagemaker-notebook-idle': {
+    label: 'SageMaker Notebook Instances (idle)',
+    category: 'waste',
+    estimated: false,
+    effort: 'low',
+  },
+  'sagemaker-endpoint-idle': {
+    label: 'SageMaker Endpoints (idle)',
+    category: 'waste',
+    estimated: false,
+    effort: 'high',
+  },
   'sagemaker-training-orphaned': {
     label: 'SageMaker Models (orphaned, no endpoint)',
     category: 'optimization',
     estimated: true,
+    effort: 'low',
   },
   // Phase 6.4 (ADR-0065): Dev/PR ghost environments. $0 hygiene flag, same
   // rationale as 'eni-orphaned'/'sqs-dlq-abandoned' — no direct AWS cost,
@@ -150,6 +209,7 @@ export const RESOURCE_KIND_META: Record<ResourceKind, ResourceKindMeta> = {
     label: 'Dev/PR Environments (ghost, all resources inactive)',
     category: 'waste',
     estimated: false,
+    effort: 'medium',
   },
   // Phase 6.5 (ADR-0065/ADR-0066): EKS cost visibility vertical. Per-instance-
   // type pricing (requires --live-pricing); the suggested node count is a
@@ -158,29 +218,52 @@ export const RESOURCE_KIND_META: Record<ResourceKind, ResourceKindMeta> = {
     label: 'EKS Node Groups (overprovisioned)',
     category: 'optimization',
     estimated: true,
+    effort: 'high',
   },
   // Phase 6.5 (ADR-0065/ADR-0066): EBS pricing is static, no --live-pricing gate.
   'eks-orphan-pvc': {
     label: 'EKS Orphaned PVC Volumes',
     category: 'waste',
     estimated: false,
+    effort: 'low',
   },
   // Added 2026-07-22: all fixed at-rest cost, always-on like the rest of
   // the EC2/S3/RDS scanners above.
-  'ami-unused': { label: 'AMIs (unused, backing snapshots still billed)', category: 'waste', estimated: false },
-  'ecr-image-untagged': { label: 'ECR Images (untagged)', category: 'waste', estimated: false },
+  'ami-unused': {
+    label: 'AMIs (unused, backing snapshots still billed)',
+    category: 'waste',
+    estimated: false,
+    effort: 'low',
+  },
+  'ecr-image-untagged': { label: 'ECR Images (untagged)', category: 'waste', estimated: false, effort: 'low' },
   's3-multipart-upload-abandoned': {
     label: 'S3 Multipart Uploads (abandoned)',
     category: 'waste',
     estimated: false,
+    effort: 'low',
   },
-  'rds-manual-snapshot-old': { label: 'RDS Manual Snapshots (old)', category: 'waste', estimated: false },
-  'secretsmanager-unused': { label: 'Secrets Manager Secrets (unused)', category: 'waste', estimated: false },
+  'rds-manual-snapshot-old': {
+    label: 'RDS Manual Snapshots (old)',
+    category: 'waste',
+    estimated: false,
+    effort: 'low',
+  },
+  'secretsmanager-unused': {
+    label: 'Secrets Manager Secrets (unused)',
+    category: 'waste',
+    estimated: false,
+    effort: 'medium',
+  },
   // Added 2026-07-23: moved here from the dead-resources candidate list —
   // CodePipeline's flat $1/mo-per-pipeline fee is a real fixed at-rest cost
   // (ADR-0037 criteria), not a $0 hygiene flag, so it belongs with the rest
   // of the WastedResource scanners, always-on like ebs-snapshot.
-  'codepipeline-pipeline-stale': { label: 'CodePipeline Pipelines (stale)', category: 'waste', estimated: false },
+  'codepipeline-pipeline-stale': {
+    label: 'CodePipeline Pipelines (stale)',
+    category: 'waste',
+    estimated: false,
+    effort: 'low',
+  },
 };
 
 // Cast, not narrowed: `Object.fromEntries` always returns a plain
@@ -198,6 +281,10 @@ export function categoryOf(kind: ResourceKind): FindingCategory {
 
 export function isEstimated(kind: ResourceKind): boolean {
   return RESOURCE_KIND_META[kind].estimated;
+}
+
+export function effortOf(kind: ResourceKind): RemediationEffort {
+  return RESOURCE_KIND_META[kind].effort;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add --format csv across all 5 commands (analyze/cost/trend/dead-resources/resource-security) and the interactive wizard; consolidate the 5 duplicated OUTPUT_FORMATS/isOutputFormat copies into apps/cli/src/output-format.ts (ADR-0092)
- Waste PDF: rank "Top quick wins" by a cost/effort score instead of raw $, backed by a new per-kind RemediationEffort classification on all 44 ResourceKinds (docs/en/remediation-effort.md, docs/it/livello-sforzo.md); add a category bar chart above the existing breakdown table; fix the PDF console-link icon rendering as a broken glyph (base-14 Helvetica has no glyph for the Unicode arrow) (ADR-0093)
- CI/release: actually enforce the configured coverage thresholds by running tests with --coverage (sequential, not --parallel, per ADR-0090) — the thresholds were configured but silently never checked before this

## Test plan
- [x] nx run-many -t build — all 16 projects
- [x] nx run-many -t typecheck — all 16 projects
- [x] nx run cli:lint
- [x] nx run-many --target=test --all --coverage (sequential) — all 16 projects, coverage thresholds hold
- [x] Manual: regenerated a waste PDF and confirmed the fixed link icon + bar chart + effort badges render correctly
