### PR TITLE
feat(release): automate Homebrew tap bump on npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,3 +83,42 @@ jobs:
         run: |
           gh release create "$GITHUB_REF_NAME" --title "$GITHUB_REF_NAME" --generate-notes
           gh release upload "$GITHUB_REF_NAME" apps/cli/dist/sbom.cyclonedx.json apps/cli/dist/sbom.spdx.json
+
+      # HOMEBREW_TAP_TOKEN is a fine-grained PAT scoped to elleVas/homebrew-cloudrift
+      # (Contents + Pull requests: read & write) — see docs/en/releasing.md#homebrew
+      # for the one-time setup. Skips gracefully (doesn't fail the release) until
+      # that secret exists, so npm publish is never blocked by tap plumbing.
+      - name: Bump Homebrew formula
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::warning::HOMEBREW_TAP_TOKEN not set — skipping Homebrew tap bump (see docs/en/releasing.md#homebrew for one-time setup)"
+            exit 0
+          fi
+
+          TAP_DIR="$(mktemp -d)"
+          git clone "https://x-access-token:${GH_TOKEN}@github.com/elleVas/homebrew-cloudrift.git" "$TAP_DIR"
+          cd "$TAP_DIR"
+
+          BRANCH="bump-${GITHUB_REF_NAME}"
+          git checkout -b "$BRANCH"
+
+          node "$GITHUB_WORKSPACE/scripts/bump-homebrew-formula.mjs" "${GITHUB_REF_NAME#v}" Formula/cloudrift.rb
+
+          if git diff --quiet Formula/cloudrift.rb; then
+            echo "Formula already up to date, nothing to bump."
+            exit 0
+          fi
+
+          git config user.name "cloudrift-release-bot"
+          git config user.email "actions@users.noreply.github.com"
+          git add Formula/cloudrift.rb
+          git commit -m "cloudrift $GITHUB_REF_NAME"
+          git push origin "$BRANCH"
+
+          gh pr create --repo elleVas/homebrew-cloudrift \
+            --title "cloudrift $GITHUB_REF_NAME" \
+            --body "Automated bump from the elleVas/cloudrift release workflow." \
+            --head "$BRANCH" --base main
+          gh pr merge --repo elleVas/homebrew-cloudrift --auto --squash "$BRANCH"

--- a/docs/en/releasing.md
+++ b/docs/en/releasing.md
@@ -69,11 +69,24 @@ The package targets **Node 20+** (`engines`). The bundle is CommonJS, so every e
 
 [`action.yml`](../../action.yml) at the repo root is a composite action that installs `@cloudrift/cli` from npm and runs `cloudrift analyze`, so `uses: elleVas/cloudrift@v<version>` only works once the referenced version is actually published to npm (same gate as everything else in this document). After a release, sanity-check it with a `workflow_dispatch` run in a scratch workflow before pointing real consumers at the new tag — nothing in CI exercises `action.yml` today.
 
-## Homebrew (after the first npm publish)
+## Homebrew
 
-No Homebrew tap exists yet. This is documented ahead of time so Phase B doesn't start from zero, but none of it is built or automated yet:
+The tap lives in a **separate** repository, `elleVas/homebrew-cloudrift` (Homebrew's naming convention — a formula cannot live in this repo and be installable via `brew install elleVas/cloudrift/cloudrift`). The formula uses Homebrew's `Language::Node` npm-install pattern: `depends_on "node"`, `def install; system "npm", "install", *std_npm_args; end`, `url` pointing at the published npm tarball (`https://registry.npmjs.org/@cloudrift/cli/-/cli-<version>.tgz`) with its `sha256`.
 
-1. Homebrew's tap naming convention requires a **separate** GitHub repository named `homebrew-cloudrift` (e.g. `elleVas/homebrew-cloudrift`) — a formula cannot live in this repo and be installable via `brew install elleVas/cloudrift/cloudrift`.
-2. The formula should use Homebrew's `Language::Node` npm-install pattern (the standard approach for npm-published CLIs — no separate build step, `depends_on "node"`, `def install; system "npm", "install", *std_npm_args; end`), pointing `url` at the published npm tarball (`https://registry.npmjs.org/@cloudrift/cli/-/cli-<version>.tgz`) with its `sha256`. The tarball only exists — and its checksum is only knowable — after the corresponding version is actually on npm.
-3. Every release after the first needs the tap formula's `url`/`sha256`/`version` bumped to match — either by hand or with a small follow-up script; not built yet.
-4. Validate locally with `brew audit --strict cloudrift` and `brew test cloudrift` before publishing tap changes.
+**The tap is bumped automatically.** The last step of `release.yml` ("Bump Homebrew formula") runs `scripts/bump-homebrew-formula.mjs`, which:
+
+1. downloads the npm tarball just published (retrying for a few minutes if the registry hasn't propagated it yet — see the note below),
+2. computes its `sha256`,
+3. writes a fresh `Formula/cloudrift.rb`,
+4. pushes it to a branch in the tap repo, opens a PR, and enables auto-merge.
+
+The tap repo's own CI (`.github/workflows/test-formula.yml`) then runs `brew audit --strict --online` + `brew install --build-from-source` + `brew test` on the PR; branch protection on the tap's `main` requires that check to pass before the PR can merge. So one `git push --tags` here ends up publishing to both npm and Homebrew, with the Homebrew side gated on a real `brew install` succeeding first.
+
+### One-time setup (already done for the current tap, kept here for reference)
+
+- The tap repo itself: `gh repo create elleVas/homebrew-cloudrift --public`, `Formula/cloudrift.rb` + `test-formula.yml` scaffolded, `allow_auto_merge` enabled, branch protection on `main` requiring the `audit` check.
+- **`HOMEBREW_TAP_TOKEN`**: a fine-grained GitHub PAT scoped to `elleVas/homebrew-cloudrift` only, with **Contents: Read & write** and **Pull requests: Read & write** permissions, added as a secret named `HOMEBREW_TAP_TOKEN` on **this** repo (`elleVas/cloudrift` → Settings → Secrets and variables → Actions). Without it, the "Bump Homebrew formula" step logs a warning and skips — it never fails the npm release.
+
+### Registry propagation
+
+npm can take a few minutes to make a freshly published tarball fetchable (up to ~6 minutes was observed on the first public release) — `bump-homebrew-formula.mjs` retries every 30s for up to ~10 minutes before giving up, so this is normally invisible.

--- a/docs/it/rilascio.md
+++ b/docs/it/rilascio.md
@@ -69,11 +69,24 @@ Il pacchetto punta a **Node 20+** (`engines`). Il bundle è CommonJS, quindi ogn
 
 [`action.yml`](../../action.yml) nella root del repo è un'azione composita che installa `@cloudrift/cli` da npm ed esegue `cloudrift analyze`, quindi `uses: elleVas/cloudrift@v<versione>` funziona una volta che la versione referenziata è pubblicata su npm. Dopo un rilascio, verificala con un run `workflow_dispatch` in un workflow usa-e-getta prima di puntarci consumer reali — oggi nessuna CI esercita `action.yml`.
 
-## Homebrew (dopo il primo publish npm)
+## Homebrew
 
-Nessun tap Homebrew esiste ancora. Documentato in anticipo così la Fase B non riparte da zero, ma nulla di questo è ancora costruito o automatizzato:
+Il tap vive in un repository **separato**, `elleVas/homebrew-cloudrift` (convenzione di naming di Homebrew — una formula non può vivere in questo repo ed essere installabile via `brew install elleVas/cloudrift/cloudrift`). La formula usa il pattern npm-install `Language::Node` di Homebrew: `depends_on "node"`, `def install; system "npm", "install", *std_npm_args; end`, `url` che punta al tarball npm pubblicato (`https://registry.npmjs.org/@cloudrift/cli/-/cli-<versione>.tgz`) con il suo `sha256`.
 
-1. La convenzione di naming dei tap Homebrew richiede un repository GitHub **separato** chiamato `homebrew-cloudrift` (es. `elleVas/homebrew-cloudrift`) — una formula non può vivere in questo repo ed essere installabile via `brew install elleVas/cloudrift/cloudrift`.
-2. La formula dovrebbe usare il pattern npm-install di `Language::Node` di Homebrew (l'approccio standard per CLI pubblicate su npm — nessun build separato, `depends_on "node"`, `def install; system "npm", "install", *std_npm_args; end`), puntando `url` al tarball npm pubblicato (`https://registry.npmjs.org/@cloudrift/cli/-/cli-<versione>.tgz`) con il suo `sha256`. Il tarball esiste — e il suo checksum è calcolabile — solo dopo che la versione corrispondente è effettivamente su npm.
-3. Ogni rilascio successivo al primo richiede di aggiornare `url`/`sha256`/`version` della formula nel tap — a mano o con un piccolo script di follow-up; non ancora costruito.
-4. Valida in locale con `brew audit --strict cloudrift` e `brew test cloudrift` prima di pubblicare modifiche al tap.
+**Il tap viene aggiornato automaticamente.** L'ultimo step di `release.yml` ("Bump Homebrew formula") esegue `scripts/bump-homebrew-formula.mjs`, che:
+
+1. scarica il tarball npm appena pubblicato (ritentando per qualche minuto se il registry non l'ha ancora propagato — vedi nota sotto),
+2. ne calcola lo `sha256`,
+3. scrive una nuova `Formula/cloudrift.rb`,
+4. la pusha su un branch nel repo del tap, apre una PR e abilita l'auto-merge.
+
+La CI del tap stesso (`.github/workflows/test-formula.yml`) esegue poi `brew audit --strict --online` + `brew install --build-from-source` + `brew test` sulla PR; la branch protection su `main` del tap richiede quel check verde prima di poter mergiare. Quindi un solo `git push --tags` qui pubblica sia su npm sia su Homebrew, con il lato Homebrew condizionato a un `brew install` reale che funziona prima del merge.
+
+### Setup una tantum (già fatto per il tap attuale, tenuto qui come riferimento)
+
+- Il repo del tap stesso: `gh repo create elleVas/homebrew-cloudrift --public`, `Formula/cloudrift.rb` + `test-formula.yml` scaffoldati, `allow_auto_merge` abilitato, branch protection su `main` che richiede il check `audit`.
+- **`HOMEBREW_TAP_TOKEN`**: un PAT GitHub fine-grained con scope limitato a `elleVas/homebrew-cloudrift`, permessi **Contents: Read & write** e **Pull requests: Read & write**, aggiunto come secret con nome `HOMEBREW_TAP_TOKEN` su **questo** repo (`elleVas/cloudrift` → Settings → Secrets and variables → Actions). Senza, lo step "Bump Homebrew formula" logga un warning e salta — non fa mai fallire la release npm.
+
+### Propagazione del registry
+
+npm può impiegare qualche minuto a rendere fetchabile un tarball appena pubblicato (fino a ~6 minuti osservati al primo rilascio pubblico) — `bump-homebrew-formula.mjs` ritenta ogni 30s per un massimo di ~10 minuti prima di arrendersi, quindi normalmente questo è invisibile.

--- a/scripts/bump-homebrew-formula.mjs
+++ b/scripts/bump-homebrew-formula.mjs
@@ -1,0 +1,76 @@
+// Genera Formula/cloudrift.rb per il tap elleVas/homebrew-cloudrift a partire
+// dal tarball npm appena pubblicato di @cloudrift/cli.
+//
+// Il registry npm può impiegare qualche minuto a propagare un pacchetto
+// appena pubblicato (~6 minuti osservati al primo rilascio pubblico, vedi
+// docs/en/releasing.md) — per questo il download del tarball ha un retry
+// con backoff fisso invece di fallire al primo tentativo.
+
+import { createHash } from 'node:crypto';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const PACKAGE_NAME = '@cloudrift/cli';
+const RETRY_DELAY_MS = 30_000;
+const MAX_ATTEMPTS = 20; // ~10 minuti di margine per la propagazione del registry
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const workspaceRoot = resolve(scriptDir, '..');
+
+const [, , versionArg, outputPathArg] = process.argv;
+const outputPath = outputPathArg;
+if (!outputPath) {
+  console.error('Usage: bump-homebrew-formula.mjs <version> <output-formula-path>');
+  process.exit(1);
+}
+const version = versionArg || readWorkspaceVersion();
+
+const tarballUrl = `https://registry.npmjs.org/${PACKAGE_NAME}/-/cli-${version}.tgz`;
+const sha256 = await sha256OfTarball(tarballUrl);
+
+writeFileSync(outputPath, renderFormula({ version, tarballUrl, sha256 }));
+console.log(`Wrote formula for cloudrift@${version} (sha256 ${sha256}) to ${outputPath}`);
+
+function readWorkspaceVersion() {
+  const pkg = JSON.parse(readFileSync(resolve(workspaceRoot, 'apps/cli/package.json'), 'utf8'));
+  return pkg.version;
+}
+
+async function sha256OfTarball(url) {
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    const response = await fetch(url);
+    if (response.ok) {
+      const buffer = Buffer.from(await response.arrayBuffer());
+      return createHash('sha256').update(buffer).digest('hex');
+    }
+    console.log(
+      `Attempt ${attempt}/${MAX_ATTEMPTS}: tarball not ready yet (HTTP ${response.status}), retrying in ${RETRY_DELAY_MS / 1000}s...`,
+    );
+    if (attempt < MAX_ATTEMPTS) {
+      await new Promise((r) => setTimeout(r, RETRY_DELAY_MS));
+    }
+  }
+  throw new Error(`Tarball never became available at ${url} after ${MAX_ATTEMPTS} attempts`);
+}
+
+function renderFormula({ version, tarballUrl, sha256 }) {
+  return `class Cloudrift < Formula
+  desc "Local-only AWS cost & security scanner"
+  homepage "https://github.com/elleVas/cloudrift"
+  url "${tarballUrl}"
+  sha256 "${sha256}"
+  license "Apache-2.0"
+
+  depends_on "node"
+
+  def install
+    system "npm", "install", *std_npm_args
+  end
+
+  test do
+    assert_match "${version}", shell_output("#{bin}/cloudrift --version")
+  end
+end
+`;
+}


### PR DESCRIPTION
## Summary
- Scaffold `elleVas/homebrew-cloudrift` tap repo (Formula/cloudrift.rb, audit/install/test CI, branch protection requiring that check)
- New `scripts/bump-homebrew-formula.mjs`: downloads the just-published npm tarball (retrying for registry propagation), computes sha256, regenerates the formula
- `release.yml`: new final step opens a PR against the tap with the bumped formula and enables auto-merge; skips with a warning (doesn't fail the release) if `HOMEBREW_TAP_TOKEN` isn't configured
- Docs (EN/IT) updated to describe the automated flow and the one-time PAT setup

## Test plan
- [x] `bump-homebrew-formula.mjs` run manually against the live `@cloudrift/cli@0.7.1` tarball — correct sha256, correct formula output
- [x] Tap repo created, scaffold pushed, `allow_auto_merge` + branch protection verified via `gh api`
- [x] `HOMEBREW_TAP_TOKEN` secret confirmed present via `gh secret list`
- [ ] End-to-end: real tag push triggering the full `release.yml` → tap PR → CI → auto-merge chain (not yet exercised)