### PR TITLE
chore: bump version to 0.8.0

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudrift/cli",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Detect and report wasted AWS cloud resources — built to run in CI/CD and fail pipelines over a cost threshold.",
   "keywords": [
     "aws",


### PR DESCRIPTION
Version bump for the next release (npm + Homebrew tap automation).