### PR TITLE
fix(release): symlink npm-installed binary into bin/ for Homebrew formula

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # cloudrift
 
 [![npm version](https://img.shields.io/npm/v/@cloudrift/cli.svg)](https://www.npmjs.com/package/@cloudrift/cli)
+[![Homebrew](https://img.shields.io/badge/homebrew-tap-fbb040.svg?logo=homebrew)](https://github.com/elleVas/homebrew-cloudrift)
 [![License](https://img.shields.io/npm/l/@cloudrift/cli.svg)](https://github.com/elleVas/cloudrift/blob/main/LICENSE.md)
 [![Coverage](https://img.shields.io/badge/coverage-%E2%89%A580%25%20domain%2Fapp%20%C2%B7%20%E2%89%A560%25%20infra-brightgreen.svg)](https://github.com/elleVas/cloudrift/actions/workflows/ci.yml)
 [![🇮🇹 Italiano](https://img.shields.io/badge/🇮🇹-Italiano-lightgrey.svg)](https://github.com/elleVas/cloudrift/blob/main/docs/it/leggimi.md)
@@ -17,6 +18,8 @@
 npm install -g @cloudrift/cli
 cloudrift
 ```
+
+macOS/Linux via Homebrew: `brew install elleVas/cloudrift/cloudrift`
 
 That's it — no subcommand needed, the interactive wizard walks you through region and scanner selection. Requires **Node.js 20+** and AWS credentials with [read-only IAM permissions](https://github.com/elleVas/cloudrift/blob/main/docs/en/iam-permissions.md) (`aws configure`, or env vars — see [full setup](#full-setup-fresh-aws-credentials-from-source) below if you need that first).
 
@@ -50,6 +53,12 @@ See [docs/en/usage.md](https://github.com/elleVas/cloudrift/blob/main/docs/en/us
 npm install -g @cloudrift/cli
 # or run it once-off, without installing:
 npx @cloudrift/cli analyze
+```
+
+**Or via Homebrew** (macOS/Linux):
+
+```sh
+brew install elleVas/cloudrift/cloudrift
 ```
 
 **From source** (for contributing, or to run unreleased changes):

--- a/docs/en/releasing.md
+++ b/docs/en/releasing.md
@@ -71,7 +71,7 @@ The package targets **Node 20+** (`engines`). The bundle is CommonJS, so every e
 
 ## Homebrew
 
-The tap lives in a **separate** repository, `elleVas/homebrew-cloudrift` (Homebrew's naming convention — a formula cannot live in this repo and be installable via `brew install elleVas/cloudrift/cloudrift`). The formula uses Homebrew's `Language::Node` npm-install pattern: `depends_on "node"`, `def install; system "npm", "install", *std_npm_args; end`, `url` pointing at the published npm tarball (`https://registry.npmjs.org/@cloudrift/cli/-/cli-<version>.tgz`) with its `sha256`.
+The tap lives in a **separate** repository, `elleVas/homebrew-cloudrift` (Homebrew's naming convention — a formula cannot live in this repo and be installable via `brew install elleVas/cloudrift/cloudrift`). The formula uses Homebrew's `Language::Node` npm-install pattern: `depends_on "node"`, `def install; system "npm", "install", *std_npm_args; bin.install_symlink Dir["#{libexec}/bin/*"]; end` (the symlink step is required — `std_npm_args` alone installs into `libexec` but doesn't link the binary into `bin`), `url` pointing at the published npm tarball (`https://registry.npmjs.org/@cloudrift/cli/-/cli-<version>.tgz`) with its `sha256`.
 
 **The tap is bumped automatically.** The last step of `release.yml` ("Bump Homebrew formula") runs `scripts/bump-homebrew-formula.mjs`, which:
 

--- a/docs/it/leggimi.md
+++ b/docs/it/leggimi.md
@@ -15,6 +15,8 @@ npm install -g @cloudrift/cli
 cloudrift
 ```
 
+macOS/Linux via Homebrew: `brew install elleVas/cloudrift/cloudrift`
+
 Tutto qui — nessun sottocomando necessario, il wizard interattivo ti guida nella scelta di regioni e scanner. Richiede **Node.js 20+** e credenziali AWS con [permessi IAM in sola lettura](#permessi-iam-necessari) (`aws configure`, o variabili d'ambiente — vedi [setup completo](#setup-completo-credenziali-aws-da-zero-dai-sorgenti) qui sotto se ti serve prima quello).
 
 Preferisci i flag al wizard (script, CI)? Stesso tool, stesso output:
@@ -60,6 +62,12 @@ Vedi [Utilizzo](#utilizzo) per l'elenco completo dei flag.
 npm install -g @cloudrift/cli
 # oppure eseguilo una tantum, senza installarlo:
 npx @cloudrift/cli analyze
+```
+
+**Oppure via Homebrew** (macOS/Linux):
+
+```sh
+brew install elleVas/cloudrift/cloudrift
 ```
 
 **Dai sorgenti** (per contribuire, o per eseguire modifiche non ancora rilasciate):

--- a/docs/it/rilascio.md
+++ b/docs/it/rilascio.md
@@ -71,7 +71,7 @@ Il pacchetto punta a **Node 20+** (`engines`). Il bundle è CommonJS, quindi ogn
 
 ## Homebrew
 
-Il tap vive in un repository **separato**, `elleVas/homebrew-cloudrift` (convenzione di naming di Homebrew — una formula non può vivere in questo repo ed essere installabile via `brew install elleVas/cloudrift/cloudrift`). La formula usa il pattern npm-install `Language::Node` di Homebrew: `depends_on "node"`, `def install; system "npm", "install", *std_npm_args; end`, `url` che punta al tarball npm pubblicato (`https://registry.npmjs.org/@cloudrift/cli/-/cli-<versione>.tgz`) con il suo `sha256`.
+Il tap vive in un repository **separato**, `elleVas/homebrew-cloudrift` (convenzione di naming di Homebrew — una formula non può vivere in questo repo ed essere installabile via `brew install elleVas/cloudrift/cloudrift`). La formula usa il pattern npm-install `Language::Node` di Homebrew: `depends_on "node"`, `def install; system "npm", "install", *std_npm_args; bin.install_symlink Dir["#{libexec}/bin/*"]; end` (lo step di symlink è necessario — `std_npm_args` da solo installa in `libexec` ma non collega il binario in `bin`), `url` che punta al tarball npm pubblicato (`https://registry.npmjs.org/@cloudrift/cli/-/cli-<versione>.tgz`) con il suo `sha256`.
 
 **Il tap viene aggiornato automaticamente.** L'ultimo step di `release.yml` ("Bump Homebrew formula") esegue `scripts/bump-homebrew-formula.mjs`, che:
 

--- a/scripts/bump-homebrew-formula.mjs
+++ b/scripts/bump-homebrew-formula.mjs
@@ -66,6 +66,7 @@ function renderFormula({ version, tarballUrl, sha256 }) {
 
   def install
     system "npm", "install", *std_npm_args
+    bin.install_symlink Dir["#{libexec}/bin/*"]
   end
 
   test do


### PR DESCRIPTION
## Summary
`std_npm_args` alone installs into `libexec` but never links the binary into `bin/` — every `brew install` produced a formula with no `cloudrift` command reachable. Found by actually running the tap's CI (audit/install/test) for the first time, on the real v0.8.0 release.

- `scripts/bump-homebrew-formula.mjs`: adds `bin.install_symlink Dir["#{libexec}/bin/*"]` to the generated formula's `install` block
- Docs (EN/IT) updated to match

The other two issues found in the same pass (`brew audit` no longer accepting a file path, and the untrusted-tap gate needing `brew trust`) live in the tap's own CI workflow, already fixed directly there (`elleVas/homebrew-cloudrift`), not in this template.

## Test plan
- [x] v0.8.0 tap PR passed `brew audit --strict --online` + `brew install --formula --build-from-source` + `brew test` on a clean macOS GitHub Actions runner with this exact formula shape, then auto-merged