### PR TITLE
feat(cli): warn when the built-in AWS price list is stale

### DIFF
--- a/apps/cli/src/commands/analyze-waste.command.spec.ts
+++ b/apps/cli/src/commands/analyze-waste.command.spec.ts
@@ -137,7 +137,7 @@ describe('analyzeWasteCommand (CLI end-to-end)', () => {
     expect(stdout).not.toContain('Scanning');
     const lines = stdout.trim().split('\n');
     expect(lines[0]).toBe(
-      'id,kind,category,estimated,region,accountId,detectedAt,wasteReason,description,monthlyCostUsd,tags,userName,consoleUrl',
+      'id,kind,category,estimated,region,accountId,detectedAt,wasteReason,description,monthlyCostUsd,tags,userName,consoleUrl,pricesAsOf,pricesStale',
     );
     expect(lines).toHaveLength(2);
     expect(lines[1]).toContain('vol-1');

--- a/apps/cli/src/formatters/waste-report.csv-formatter.spec.ts
+++ b/apps/cli/src/formatters/waste-report.csv-formatter.spec.ts
@@ -34,11 +34,24 @@ describe('formatWasteReportAsCsv', () => {
     const lines = csv.split('\n');
 
     expect(lines[0]).toBe(
-      'id,kind,category,estimated,region,accountId,detectedAt,wasteReason,description,monthlyCostUsd,tags,userName,consoleUrl',
+      'id,kind,category,estimated,region,accountId,detectedAt,wasteReason,description,monthlyCostUsd,tags,userName,consoleUrl,pricesAsOf,pricesStale',
     );
     expect(lines).toHaveLength(2);
     expect(lines[1]).toContain('vol-abc123');
     expect(lines[1]).toContain('https://console.aws.amazon.com/ec2/home?region=us-east-1#Volumes:volumeId=vol-abc123');
+  });
+
+  it('repeats pricesAsOf/pricesStale on every row', () => {
+    const csv = formatWasteReportAsCsv(summaryOf('vol-abc123'), meta);
+    const lines = csv.split('\n');
+    expect(lines[1]).toContain('2026-06,false');
+  });
+
+  it('flags pricesStale true when the price list is over 100 days old', () => {
+    const staleMeta: WasteReportMeta = { ...meta, pricesAsOf: '2025-06' };
+    const csv = formatWasteReportAsCsv(summaryOf('vol-abc123'), staleMeta);
+    const lines = csv.split('\n');
+    expect(lines[1]).toContain('2025-06,true');
   });
 
   it('JSON-encodes the tags map into a single quoted field', () => {

--- a/apps/cli/src/formatters/waste-report.csv-formatter.ts
+++ b/apps/cli/src/formatters/waste-report.csv-formatter.ts
@@ -19,9 +19,15 @@ const HEADERS = [
   'tags',
   'userName',
   'consoleUrl',
+  'pricesAsOf',
+  'pricesStale',
 ];
 
-/** One row per finding, raw DTO fields — meant for re-processing (spreadsheets, scripts), not on-screen reading. */
+/**
+ * One row per finding, raw DTO fields — meant for re-processing (spreadsheets, scripts), not
+ * on-screen reading. `pricesAsOf`/`pricesStale` repeat the report-level meta on every row (same
+ * pattern as `accountId`) so a script consuming just this CSV can still judge estimate freshness.
+ */
 export function formatWasteReportAsCsv(summary: WastedResourcesSummary, meta: WasteReportMeta): string {
   const dto = toWasteReportDto(summary, meta);
   const rows = dto.findings.map((finding) => [
@@ -38,6 +44,8 @@ export function formatWasteReportAsCsv(summary: WastedResourcesSummary, meta: Wa
     JSON.stringify(finding.tags),
     finding.userName,
     buildConsoleUrl(finding),
+    dto.meta.pricesAsOf,
+    dto.meta.pricesStale,
   ]);
   return toCsv(HEADERS, rows);
 }

--- a/apps/cli/src/formatters/waste-report.markdown-formatter.spec.ts
+++ b/apps/cli/src/formatters/waste-report.markdown-formatter.spec.ts
@@ -58,6 +58,33 @@ describe('formatWasteReportAsMarkdown', () => {
     expect(md).toContain('raffaelevasini@gmail.com');
   });
 
+  it('warns when the price list is over 100 days old', () => {
+    const summary: WastedResourcesSummary = {
+      findings: [],
+      totalWasteMonthlyUsd: 0,
+      totalOptimizationMonthlyUsd: 0,
+      scanErrors: [],
+    };
+
+    const md = formatWasteReportAsMarkdown(summary, meta);
+
+    expect(md).toContain('Price list is over 100 days old');
+    expect(md).toContain('--live-pricing');
+  });
+
+  it('does not warn when the price list is fresh', () => {
+    const summary: WastedResourcesSummary = {
+      findings: [],
+      totalWasteMonthlyUsd: 0,
+      totalOptimizationMonthlyUsd: 0,
+      scanErrors: [],
+    };
+
+    const md = formatWasteReportAsMarkdown(summary, { ...meta, pricesAsOf: '2026-06' });
+
+    expect(md).not.toContain('Price list is over');
+  });
+
   it('renders headline (waste), breakdown, details and recommendations', () => {
     const summary: WastedResourcesSummary = {
       findings: [makeVolume('vol-aaa', 8), makeVolume('vol-bbb', 4)],

--- a/apps/cli/src/formatters/waste-report.markdown-formatter.ts
+++ b/apps/cli/src/formatters/waste-report.markdown-formatter.ts
@@ -9,7 +9,7 @@ import type {
   FindingCategory,
   WastedResourcesSummary,
 } from 'cloud-cost-domain';
-import { REPORT_CONTACT, REPORT_DISCLAIMER } from 'cloud-cost-application';
+import { REPORT_CONTACT, REPORT_DISCLAIMER, isPricesStale, PRICES_STALE_AFTER_DAYS } from 'cloud-cost-application';
 import { presenterFor, rowFor, recommendFor } from './resource-presenters';
 
 export interface MarkdownReportOptions {
@@ -31,10 +31,14 @@ function esc(cell: string): string {
     .replace(/\\/g, '\\\\');
 }
 
-function footer(meta: { pricesAsOf: string }): string {
+function footer(meta: { pricesAsOf: string; generatedAt: Date }): string {
+  const staleWarning = isPricesStale(meta.pricesAsOf, meta.generatedAt)
+    ? `\n> ⚠️ Price list is over ${PRICES_STALE_AFTER_DAYS} days old — consider running with \`--live-pricing\` for fresher estimates.\n`
+    : '';
   return (
-    `---\n<sub>Estimates use AWS list prices as of ${meta.pricesAsOf}; actual billing may differ.</sub>\n\n` +
-    `<sub>${REPORT_DISCLAIMER}</sub>\n\n` +
+    `---\n<sub>Estimates use AWS list prices as of ${meta.pricesAsOf}; actual billing may differ.</sub>\n` +
+    staleWarning +
+    `\n<sub>${REPORT_DISCLAIMER}</sub>\n\n` +
     `<sub>Contact: ${REPORT_CONTACT.email} · ` +
       `<a href="${REPORT_CONTACT.github}" target="_blank" rel="noopener noreferrer">GitHub</a> · ` +
       `<a href="${REPORT_CONTACT.linkedin}" target="_blank" rel="noopener noreferrer">LinkedIn</a></sub>`

--- a/apps/cli/src/formatters/waste-report.pdf-formatter.ts
+++ b/apps/cli/src/formatters/waste-report.pdf-formatter.ts
@@ -13,7 +13,7 @@ import type {
   WastedResourcesSummary,
 } from 'cloud-cost-domain';
 import type { WasteReportMeta } from 'cloud-cost-application';
-import { REPORT_DISCLAIMER } from 'cloud-cost-application';
+import { REPORT_DISCLAIMER, isPricesStale, PRICES_STALE_AFTER_DAYS } from 'cloud-cost-application';
 import { presenterFor, rowFor, recommendFor } from './resource-presenters';
 import { buildConsoleUrl } from '../aws-console-link';
 import {
@@ -86,9 +86,21 @@ function drawSummaryPage(
   metaParts.push(`Prices as of: ${meta.pricesAsOf}`);
   doc.font('Helvetica').fontSize(8.5).fillColor(C.muted)
     .text(metaParts.join('   ·   '), MARGIN, y, { lineBreak: false });
+  y += 12;
+
+  if (isPricesStale(meta.pricesAsOf, meta.generatedAt)) {
+    doc.font('Helvetica-Bold').fontSize(8.5).fillColor(C.warning)
+      .text(
+        `⚠ Price list is over ${PRICES_STALE_AFTER_DAYS} days old — consider running with --live-pricing for fresher estimates.`,
+        MARGIN,
+        y,
+        { lineBreak: false },
+      );
+    y += 12;
+  }
 
   // Divider
-  y += 18;
+  y += 6;
   doc.moveTo(MARGIN, y).lineTo(MARGIN + CONTENT_W, y).lineWidth(0.5).strokeColor(C.border).stroke();
 
   // Metric boxes

--- a/apps/cli/src/formatters/waste-report.table-formatter.spec.ts
+++ b/apps/cli/src/formatters/waste-report.table-formatter.spec.ts
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+import { AwsRegion, EbsVolume } from 'cloud-cost-domain';
+import type { WastedResourcesSummary } from 'cloud-cost-domain';
+import type { WasteReportMeta } from 'cloud-cost-application';
+import { formatWasteReportAsTable } from './waste-report.table-formatter';
+
+const region = AwsRegion.create('us-east-1');
+
+function summaryOf(volumeId: string): WastedResourcesSummary {
+  const volume = new EbsVolume({
+    volumeId,
+    region,
+    accountId: '123456789012',
+    sizeGb: 100,
+    volumeType: 'gp3',
+    state: 'available',
+    createTime: new Date('2025-01-01'),
+    detectedAt: new Date('2026-06-16'),
+    tags: {},
+    monthlyCostUsd: 8,
+  });
+  return { findings: [volume], totalWasteMonthlyUsd: 8, totalOptimizationMonthlyUsd: 0, scanErrors: [] };
+}
+
+describe('formatWasteReportAsTable', () => {
+  it('warns when the price list is over 100 days old', () => {
+    const meta: WasteReportMeta = {
+      accountId: '123456789012',
+      regions: ['us-east-1'],
+      generatedAt: new Date('2026-06-16'),
+      pricesAsOf: '2025-06',
+    };
+
+    const table = formatWasteReportAsTable(summaryOf('vol-abc123'), meta);
+
+    expect(table).toContain('Price list is over 100 days old');
+    expect(table).toContain('--live-pricing');
+  });
+
+  it('does not warn when the price list is fresh', () => {
+    const meta: WasteReportMeta = {
+      accountId: '123456789012',
+      regions: ['us-east-1'],
+      generatedAt: new Date('2026-06-16'),
+      pricesAsOf: '2026-06',
+    };
+
+    const table = formatWasteReportAsTable(summaryOf('vol-abc123'), meta);
+
+    expect(table).not.toContain('Price list is over');
+  });
+});

--- a/apps/cli/src/formatters/waste-report.table-formatter.ts
+++ b/apps/cli/src/formatters/waste-report.table-formatter.ts
@@ -8,11 +8,12 @@ import {
   groupByKind,
 } from 'cloud-cost-domain';
 import type { FindingCategory, WastedResourcesSummary } from 'cloud-cost-domain';
-import { REPORT_CONTACT } from 'cloud-cost-application';
+import { REPORT_CONTACT, isPricesStale, PRICES_STALE_AFTER_DAYS } from 'cloud-cost-application';
 import { presenterFor, rowFor } from './resource-presenters';
 
 export interface TableReportMeta {
   pricesAsOf: string;
+  generatedAt: Date;
 }
 
 export function formatWasteReportAsTable(
@@ -94,6 +95,13 @@ export function formatWasteReportAsTable(
       `  Estimates based on AWS list prices as of ${meta.pricesAsOf}; actual billing may differ.`,
     ),
   );
+  if (isPricesStale(meta.pricesAsOf, meta.generatedAt)) {
+    lines.push(
+      chalk.yellow(
+        `  ⚠ Price list is over ${PRICES_STALE_AFTER_DAYS} days old — consider running with --live-pricing for fresher estimates.`,
+      ),
+    );
+  }
   lines.push(
     chalk.dim(
       `  Contact: ${REPORT_CONTACT.email} · ${REPORT_CONTACT.github} · ${REPORT_CONTACT.linkedin}\n`,

--- a/libs/cloud-cost/application/src/dto/waste-report.dto.spec.ts
+++ b/libs/cloud-cost/application/src/dto/waste-report.dto.spec.ts
@@ -58,6 +58,7 @@ describe('toWasteReportDto', () => {
       regions: ['us-east-1'],
       generatedAt: '2026-06-12T10:00:00.000Z',
       pricesAsOf: '2025-06',
+      pricesStale: true,
     });
     expect(dto.disclaimer).toBe(REPORT_DISCLAIMER);
     expect(dto.contact).toEqual(REPORT_CONTACT);
@@ -138,6 +139,11 @@ describe('toWasteReportDto', () => {
 
     expect(dto.findings.find((f) => f.id === 'ws-1')?.userName).toBe('jdoe');
     expect(dto.findings.find((f) => f.id === 'vol-1')?.userName).toBeUndefined();
+  });
+
+  it('flags pricesStale false when pricesAsOf is recent', () => {
+    const dto = toWasteReportDto(summary, { ...meta, pricesAsOf: '2026-06' });
+    expect(dto.meta.pricesStale).toBe(false);
   });
 
   it('maps scan errors to plain messages', () => {

--- a/libs/cloud-cost/application/src/dto/waste-report.dto.ts
+++ b/libs/cloud-cost/application/src/dto/waste-report.dto.ts
@@ -8,6 +8,7 @@ import type {
   Workspace,
 } from 'cloud-cost-domain';
 import { REPORT_CONTACT, REPORT_DISCLAIMER } from '../constants/report-disclaimer';
+import { isPricesStale } from '../pricing-staleness';
 
 /**
  * Serializable (JSON-safe) projection of the summary: it's the data contract
@@ -24,6 +25,7 @@ export interface WasteReportDto {
     regions: string[];
     generatedAt: string;
     pricesAsOf: string;
+    pricesStale: boolean;
   };
   disclaimer: string;
   contact: { email: string; linkedin: string };
@@ -107,6 +109,7 @@ export function toWasteReportDto(
       regions: meta.regions,
       generatedAt: meta.generatedAt.toISOString(),
       pricesAsOf: meta.pricesAsOf,
+      pricesStale: isPricesStale(meta.pricesAsOf, meta.generatedAt),
     },
     disclaimer: REPORT_DISCLAIMER,
     contact: REPORT_CONTACT,

--- a/libs/cloud-cost/application/src/index.ts
+++ b/libs/cloud-cost/application/src/index.ts
@@ -3,3 +3,4 @@ export { AnalyzeCloudWasteUseCase } from './use-cases/analyze-cloud-waste.use-ca
 export { toWasteReportDto } from './dto/waste-report.dto';
 export type { WasteReportDto, WasteReportMeta } from './dto/waste-report.dto';
 export { REPORT_DISCLAIMER, REPORT_CONTACT } from './constants/report-disclaimer';
+export { isPricesStale, PRICES_STALE_AFTER_DAYS } from './pricing-staleness';

--- a/libs/cloud-cost/application/src/pricing-staleness.spec.ts
+++ b/libs/cloud-cost/application/src/pricing-staleness.spec.ts
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+import { isPricesStale, PRICES_STALE_AFTER_DAYS } from './pricing-staleness';
+
+describe('isPricesStale', () => {
+  it('is false right at the start of the pricesAsOf month', () => {
+    expect(isPricesStale('2026-06', new Date('2026-06-01T00:00:00Z'))).toBe(false);
+  });
+
+  it(`is false within ${PRICES_STALE_AFTER_DAYS} days of the pricesAsOf month`, () => {
+    expect(isPricesStale('2026-06', new Date('2026-06-25T00:00:00Z'))).toBe(false);
+  });
+
+  it(`is true past ${PRICES_STALE_AFTER_DAYS} days since the pricesAsOf month`, () => {
+    expect(isPricesStale('2026-06', new Date('2026-10-15T00:00:00Z'))).toBe(true);
+  });
+
+  it('parses the leading year-month when custom overrides are appended', () => {
+    expect(isPricesStale('2025-06 + custom overrides', new Date('2026-06-12T10:00:00Z'))).toBe(true);
+    expect(isPricesStale('2026-06 + custom overrides', new Date('2026-06-12T10:00:00Z'))).toBe(false);
+  });
+
+  it('is false for an unparseable pricesAsOf value', () => {
+    expect(isPricesStale('unknown', new Date('2026-06-12T10:00:00Z'))).toBe(false);
+  });
+});

--- a/libs/cloud-cost/application/src/pricing-staleness.ts
+++ b/libs/cloud-cost/application/src/pricing-staleness.ts
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Past this many days since `pricesAsOf`, the report flags the estimate as stale.
+ * Set above the ~90-day quarterly built-in price refresh cadence (see the
+ * `cloudrift: monthly AWS pricing refresh` routines) so the warning only fires
+ * when a refresh cycle is actually late, not during the normal gap between them.
+ */
+export const PRICES_STALE_AFTER_DAYS = 100;
+
+const YEAR_MONTH = /^(\d{4})-(\d{2})/;
+
+/**
+ * `pricesAsOf` is a "YYYY-MM" tag (see `prices.json`), optionally suffixed
+ * with " + custom overrides" once user overrides are layered on top (see
+ * `pricing.factory.ts`) — judge staleness against the leading year-month only.
+ * Live-pricing runs set `pricesAsOf` to the current month, so this is always
+ * `false` for them by construction.
+ */
+export function isPricesStale(pricesAsOf: string, generatedAt: Date): boolean {
+  const match = YEAR_MONTH.exec(pricesAsOf);
+  if (!match) return false;
+  const [, year, month] = match;
+  const asOfDate = new Date(Date.UTC(Number(year), Number(month) - 1, 1));
+  const ageDays = (generatedAt.getTime() - asOfDate.getTime()) / (1000 * 60 * 60 * 24);
+  return ageDays > PRICES_STALE_AFTER_DAYS;
+}


### PR DESCRIPTION
## Summary
- `isPricesStale(pricesAsOf, generatedAt)` in `cloud-cost-application`, threshold `PRICES_STALE_AFTER_DAYS = 100` — set above the ~90-day quarterly built-in price refresh cadence so the warning only fires when a refresh cycle is genuinely late, not during the normal gap between refreshes
- `WasteReportDto.meta.pricesStale` computed once in `toWasteReportDto`, flows to JSON automatically
- Table/Markdown/PDF: warning line rendered when stale
- CSV: two new trailing columns `pricesAsOf,pricesStale`, repeated per finding row (same pattern as `accountId`) — keeps the file strictly tabular for scripted consumption
- `--live-pricing` runs are never flagged, by construction (they set `pricesAsOf` to the current month)

## Test plan
- [x] `nx run cloud-cost-application:test` — 22/22 passing (new `pricing-staleness.spec.ts`, updated `waste-report.dto.spec.ts`)
- [x] `nx run cli:test` — 237/237 passing (new `waste-report.table-formatter.spec.ts`, updated csv/markdown/analyze-waste specs)
- [x] `nx run cli:lint` / `cloud-cost-application:lint` clean
- [x] `nx run cli:build` green
