### PR TITLE
feat(pdf): vector arrow link icon; refactor: unify scan use-cases via ScanCoordinatorUseCase

### DIFF
--- a/apps/cli/jest.config.cjs
+++ b/apps/cli/jest.config.cjs
@@ -20,6 +20,8 @@ module.exports = {
     '^shared-kernel/(.*)$': '<rootDir>/../../libs/shared/kernel/src/$1',
     '^shared-aws-infra-utils$': '<rootDir>/../../libs/shared/aws-infra-utils/src/index.ts',
     '^shared-aws-infra-utils/(.*)$': '<rootDir>/../../libs/shared/aws-infra-utils/src/$1',
+    '^shared-scan-coordination$': '<rootDir>/../../libs/shared/scan-coordination/src/index.ts',
+    '^shared-scan-coordination/(.*)$': '<rootDir>/../../libs/shared/scan-coordination/src/$1',
     '^cloud-cost-domain$': '<rootDir>/../../libs/cloud-cost/domain/src/index.ts',
     '^cloud-cost-domain/(.*)$': '<rootDir>/../../libs/cloud-cost/domain/src/$1',
     '^cloud-cost-application$': '<rootDir>/../../libs/cloud-cost/application/src/index.ts',

--- a/apps/cli/src/commands/analyze-waste.command.spec.ts
+++ b/apps/cli/src/commands/analyze-waste.command.spec.ts
@@ -196,6 +196,23 @@ describe('analyzeWasteCommand (CLI end-to-end)', () => {
     }
   });
 
+  it('writes a CSV artifact to disk with --csv <file>', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'cloudrift-cli-'));
+    const file = join(dir, 'out.csv');
+    try {
+      await run({ format: 'table', csv: file }, makeDeps({
+        summary: summaryOf([wasteVolume('vol-1', 8)], 8),
+      }));
+      const lines = (await readFile(file, 'utf8')).trim().split('\n');
+      expect(lines[0]).toBe(
+        'id,kind,category,estimated,region,accountId,detectedAt,wasteReason,description,monthlyCostUsd,tags,userName,consoleUrl,pricesAsOf,pricesStale',
+      );
+      expect(lines[1]).toContain('vol-1');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it('writes a PDF artifact to disk with --pdf <file>', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'cloudrift-cli-'));
     const file = join(dir, 'out.pdf');

--- a/apps/cli/src/commands/analyze-waste.command.ts
+++ b/apps/cli/src/commands/analyze-waste.command.ts
@@ -35,6 +35,7 @@ export interface AnalyzeWasteOptions {
   livePricing?: boolean;
   pdf?: string | boolean;
   json?: string | boolean;
+  csv?: string | boolean;
   minAgeDays?: string;
   ignoreTag?: string;
   silent?: boolean;

--- a/apps/cli/src/commands/cost.command.spec.ts
+++ b/apps/cli/src/commands/cost.command.spec.ts
@@ -1,4 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
+import { readFile, mkdtemp, rm } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
 import { Result } from 'shared-kernel';
 import type { CostExplorerPort, CostPeriodBucket } from 'cost-analytics-domain';
 import type { CloudriftConfig } from '../config/cloudrift.config';
@@ -127,5 +130,18 @@ describe('costCommand (CLI end-to-end)', () => {
   it('--silent suppresses stdout entirely', async () => {
     await run({ format: 'table', silent: true }, makeDeps());
     expect(stdout).toBe('');
+  });
+
+  it('writes a CSV artifact to disk with --csv <file>', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'cloudrift-cli-'));
+    const file = join(dir, 'out.csv');
+    try {
+      const port = dynamicDailyPort((ymd) => (ymd.endsWith('-01') ? 42 : 0));
+      await run({ format: 'table', csv: file }, makeDeps({ port }));
+      const lines = (await readFile(file, 'utf8')).trim().split('\n');
+      expect(lines[0]).toBe('service,currentUsd,previousUsd,changeUsd,changePercent');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/apps/cli/src/commands/cost.command.ts
+++ b/apps/cli/src/commands/cost.command.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import chalk from 'chalk';
 import { dirname, resolve } from 'path';
-import { mkdir } from 'fs/promises';
+import { mkdir, writeFile } from 'fs/promises';
 import { CompareCostUseCase } from 'cost-analytics-application';
 import type { CostAnalyticsMeta } from 'cost-analytics-application';
 import { formatCostComparisonAsTable } from '../formatters/cost-comparison.table-formatter';
@@ -24,6 +24,7 @@ export interface CostCommandOptions {
   silent?: boolean;
   yes?: boolean;
   pdf?: string | boolean;
+  csv?: string | boolean;
 }
 
 /**
@@ -90,8 +91,19 @@ export async function costCommand(
     console.log(rendered);
   }
 
+  const day = meta.generatedAt.toISOString().split('T')[0].replaceAll('-', '_');
+
+  if (options.csv !== undefined && options.csv !== false) {
+    const csvPath =
+      typeof options.csv === 'string'
+        ? resolve(process.cwd(), options.csv)
+        : resolve(process.cwd(), 'reports', `cloudrift-cost-${day}.csv`);
+    await mkdir(dirname(csvPath), { recursive: true });
+    await writeFile(csvPath, formatCostComparisonAsCsv(result.value, meta));
+    info(chalk.green(`  CSV report saved to ${csvPath}`));
+  }
+
   if (options.pdf !== undefined && options.pdf !== false) {
-    const day = meta.generatedAt.toISOString().split('T')[0].replaceAll('-', '_');
     const outputPath =
       typeof options.pdf === 'string'
         ? resolve(process.cwd(), options.pdf)

--- a/apps/cli/src/commands/dead-resources.command.spec.ts
+++ b/apps/cli/src/commands/dead-resources.command.spec.ts
@@ -167,6 +167,28 @@ describe('deadResourcesCommand (CLI end-to-end)', () => {
     expect(received?.scannerKinds).toEqual(['iam-user-inactive']);
   });
 
+  it('writes a CSV artifact to disk with --csv <file>', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'cloudrift-cli-'));
+    const file = join(dir, 'out.csv');
+    try {
+      await run(
+        { format: 'table', csv: file },
+        makeDeps({
+          summary: {
+            findings: [makeKeyPair('key-1')],
+            countBySeverity: { info: 1, warning: 0, critical: 0 },
+            scanErrors: [],
+          },
+        }),
+      );
+      const lines = (await readFile(file, 'utf8')).trim().split('\n');
+      expect(lines[0]).toBe('id,kind,region,accountId,detectedAt,tags,hygieneReason,severity,consoleUrl');
+      expect(lines[1]).toContain('key-1');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it('writes a PDF artifact to disk with --pdf <file>', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'cloudrift-cli-'));
     const file = join(dir, 'out.pdf');

--- a/apps/cli/src/commands/dead-resources.command.ts
+++ b/apps/cli/src/commands/dead-resources.command.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import chalk from 'chalk';
 import { dirname, resolve } from 'path';
-import { mkdir } from 'fs/promises';
+import { mkdir, writeFile } from 'fs/promises';
 import { AwsRegion, DEAD_RESOURCE_KINDS, DEFAULT_IGNORE_TAG } from 'dead-resources-domain';
 import type { DeadResourceKind, DeadResourcePolicyOptions } from 'dead-resources-domain';
 import { renderBrandMark } from '../brand-mark';
@@ -24,6 +24,7 @@ export interface DeadResourcesCommandOptions {
   ignoreTag?: string;
   silent?: boolean;
   pdf?: string | boolean;
+  csv?: string | boolean;
   /** Raw `--scanners` CLI input, validated against `DEAD_RESOURCE_KINDS` below. */
   scanners?: string[];
   /** Already-validated kind filter — how the wizard's multiselect passes its choice through. `--scanners` wins if both are set. */
@@ -128,8 +129,19 @@ export async function deadResourcesCommand(
     console.log(rendered);
   }
 
+  const day = meta.generatedAt.toISOString().split('T')[0].replaceAll('-', '_');
+
+  if (options.csv !== undefined && options.csv !== false) {
+    const csvPath =
+      typeof options.csv === 'string'
+        ? resolve(process.cwd(), options.csv)
+        : resolve(process.cwd(), 'reports', `cloudrift-dead-resources-${day}.csv`);
+    await mkdir(dirname(csvPath), { recursive: true });
+    await writeFile(csvPath, formatDeadResourcesReportAsCsv(result.value, meta));
+    info(chalk.green(`  CSV report saved to ${csvPath}`));
+  }
+
   if (options.pdf !== undefined && options.pdf !== false) {
-    const day = meta.generatedAt.toISOString().split('T')[0].replaceAll('-', '_');
     const outputPath =
       typeof options.pdf === 'string'
         ? resolve(process.cwd(), options.pdf)

--- a/apps/cli/src/commands/post-analysis.ts
+++ b/apps/cli/src/commands/post-analysis.ts
@@ -7,10 +7,11 @@ import type { WasteReportMeta } from 'cloud-cost-application';
 import type { CostComparisonSummary } from 'cost-analytics-domain';
 import type { CloudriftConfig } from '../config/cloudrift.config';
 import { formatWasteReportAsJson } from '../formatters/waste-report.json-formatter';
+import { formatWasteReportAsCsv } from '../formatters/waste-report.csv-formatter';
 import { generateWasteReportPdf } from '../formatters/waste-report.pdf-formatter';
 import type { AnalyzeWasteOptions } from './analyze-waste.command';
 
-/** --json / --pdf are file artifacts, independent of the stdout format. */
+/** --json / --csv / --pdf are file artifacts, independent of the stdout format. */
 export async function writeArtifacts(
   result: WastedResourcesSummary,
   meta: WasteReportMeta,
@@ -27,6 +28,16 @@ export async function writeArtifacts(
     await mkdir(dirname(jsonPath), { recursive: true });
     await writeFile(jsonPath, formatWasteReportAsJson(result, meta));
     info(chalk.green(`  JSON report saved to ${jsonPath}`));
+  }
+
+  if (options.csv !== undefined && options.csv !== false) {
+    const csvPath =
+      typeof options.csv === 'string'
+        ? resolve(process.cwd(), options.csv)
+        : resolve(process.cwd(), 'reports', `AWS_report_${day}.csv`);
+    await mkdir(dirname(csvPath), { recursive: true });
+    await writeFile(csvPath, formatWasteReportAsCsv(result, meta));
+    info(chalk.green(`  CSV report saved to ${csvPath}`));
   }
 
   if (options.pdf !== undefined && options.pdf !== false) {

--- a/apps/cli/src/commands/resource-security.command.spec.ts
+++ b/apps/cli/src/commands/resource-security.command.spec.ts
@@ -151,6 +151,28 @@ describe('resourceSecurityCommand (CLI end-to-end)', () => {
     expect(received?.scannerKinds).toEqual(['s3-bucket-public']);
   });
 
+  it('writes a CSV artifact to disk with --csv <file>', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'cloudrift-cli-'));
+    const file = join(dir, 'out.csv');
+    try {
+      await run(
+        { format: 'table', csv: file },
+        makeDeps({
+          summary: {
+            findings: [makeFinding('123456789012')],
+            countBySeverity: { info: 0, warning: 0, critical: 1 },
+            scanErrors: [],
+          },
+        }),
+      );
+      const lines = (await readFile(file, 'utf8')).trim().split('\n');
+      expect(lines[0]).toBe('id,kind,region,accountId,detectedAt,tags,riskReason,severity,consoleUrl');
+      expect(lines[1]).toContain('123456789012');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it('writes a PDF artifact to disk with --pdf <file>', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'cloudrift-cli-'));
     const file = join(dir, 'out.pdf');

--- a/apps/cli/src/commands/resource-security.command.ts
+++ b/apps/cli/src/commands/resource-security.command.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import chalk from 'chalk';
 import { dirname, resolve } from 'path';
-import { mkdir } from 'fs/promises';
+import { mkdir, writeFile } from 'fs/promises';
 import { AwsRegion, RESOURCE_SECURITY_KINDS, DEFAULT_IGNORE_TAG } from 'resource-security-domain';
 import type { ResourceSecurityKind, ResourceSecurityPolicyOptions } from 'resource-security-domain';
 import { renderBrandMark } from '../brand-mark';
@@ -23,6 +23,7 @@ export interface ResourceSecurityCommandOptions {
   ignoreTag?: string;
   silent?: boolean;
   pdf?: string | boolean;
+  csv?: string | boolean;
   /** Raw `--scanners` CLI input, validated against `RESOURCE_SECURITY_KINDS` below. */
   scanners?: string[];
   /** Already-validated kind filter — how the wizard's multiselect passes its choice through. `--scanners` wins if both are set. */
@@ -116,8 +117,19 @@ export async function resourceSecurityCommand(
     console.log(rendered);
   }
 
+  const day = meta.generatedAt.toISOString().split('T')[0].replaceAll('-', '_');
+
+  if (options.csv !== undefined && options.csv !== false) {
+    const csvPath =
+      typeof options.csv === 'string'
+        ? resolve(process.cwd(), options.csv)
+        : resolve(process.cwd(), 'reports', `cloudrift-resource-security-${day}.csv`);
+    await mkdir(dirname(csvPath), { recursive: true });
+    await writeFile(csvPath, formatResourceSecurityReportAsCsv(result.value, meta));
+    info(chalk.green(`  CSV report saved to ${csvPath}`));
+  }
+
   if (options.pdf !== undefined && options.pdf !== false) {
-    const day = meta.generatedAt.toISOString().split('T')[0].replaceAll('-', '_');
     const outputPath =
       typeof options.pdf === 'string'
         ? resolve(process.cwd(), options.pdf)

--- a/apps/cli/src/commands/trend.command.spec.ts
+++ b/apps/cli/src/commands/trend.command.spec.ts
@@ -1,4 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
+import { readFile, mkdtemp, rm } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
 import { Result } from 'shared-kernel';
 import type { CostExplorerPort, CostPeriodBucket } from 'cost-analytics-domain';
 import type { CloudriftConfig } from '../config/cloudrift.config';
@@ -101,5 +104,19 @@ describe('trendCommand (CLI end-to-end)', () => {
   it('--silent suppresses stdout entirely', async () => {
     await run({ format: 'table', silent: true }, makeDeps());
     expect(stdout).toBe('');
+  });
+
+  it('writes a CSV artifact to disk with --csv <file>', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'cloudrift-cli-'));
+    const file = join(dir, 'out.csv');
+    try {
+      await run({ format: 'table', csv: file }, makeDeps());
+      const lines = (await readFile(file, 'utf8')).trim().split('\n');
+      expect(lines[0]).toBe('month,totalUsd,final');
+      expect(lines[1]).toBe('2026-06,100,true');
+      expect(lines[2]).toBe('2026-07,50,false');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/apps/cli/src/commands/trend.command.ts
+++ b/apps/cli/src/commands/trend.command.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import chalk from 'chalk';
 import { dirname, resolve } from 'path';
-import { mkdir } from 'fs/promises';
+import { mkdir, writeFile } from 'fs/promises';
 import { CostTrendUseCase } from 'cost-analytics-application';
 import type { CostAnalyticsMeta } from 'cost-analytics-application';
 import { formatCostTrendAsChart } from '../formatters/cost-trend.chart-formatter';
@@ -28,6 +28,7 @@ export interface TrendCommandOptions {
   silent?: boolean;
   yes?: boolean;
   pdf?: string | boolean;
+  csv?: string | boolean;
 }
 
 /**
@@ -94,8 +95,19 @@ export async function trendCommand(
     console.log(rendered);
   }
 
+  const day = meta.generatedAt.toISOString().split('T')[0].replaceAll('-', '_');
+
+  if (options.csv !== undefined && options.csv !== false) {
+    const csvPath =
+      typeof options.csv === 'string'
+        ? resolve(process.cwd(), options.csv)
+        : resolve(process.cwd(), 'reports', `cloudrift-trend-${day}.csv`);
+    await mkdir(dirname(csvPath), { recursive: true });
+    await writeFile(csvPath, formatCostTrendAsCsv(result.value, meta));
+    info(chalk.green(`  CSV report saved to ${csvPath}`));
+  }
+
   if (options.pdf !== undefined && options.pdf !== false) {
-    const day = meta.generatedAt.toISOString().split('T')[0].replaceAll('-', '_');
     const outputPath =
       typeof options.pdf === 'string'
         ? resolve(process.cwd(), options.pdf)

--- a/apps/cli/src/formatters/pdf-shared.ts
+++ b/apps/cli/src/formatters/pdf-shared.ts
@@ -351,6 +351,23 @@ export function measureTableHeight(
   return total;
 }
 
+/** Small diagonal "external link" arrow (↗), drawn as vector paths centered
+ * on (cx, cy) — pdfkit's base-14 Helvetica (WinAnsi encoding) has no glyph
+ * for U+2197, so a real unicode/text arrow isn't an option here. */
+function drawLinkIcon(doc: PDFKit.PDFDocument, cx: number, cy: number): void {
+  const r = 4;
+  const x0 = cx - r, y0 = cy + r;
+  const x1 = cx + r, y1 = cy - r;
+  doc.save()
+    .lineWidth(1.1)
+    .strokeColor(C.primary)
+    .lineCap('round')
+    .moveTo(x0, y0).lineTo(x1, y1)
+    .moveTo(x1 - 3.5, y1).lineTo(x1, y1).lineTo(x1, y1 + 3.5)
+    .stroke()
+    .restore();
+}
+
 export function drawTable(
   doc: PDFKit.PDFDocument,
   headers: string[],
@@ -359,9 +376,8 @@ export function drawTable(
   startY: number,
   contentBottom: number,
   // Parallel to `rows`: when present for a row, an invisible clickable
-  // hotspot is layered over that row's *last* column (the visible cell text
-  // is still whatever `rows` put there, e.g. a short "Open ->" label — this
-  // only adds the link annotation, it doesn't draw anything itself).
+  // hotspot plus a small arrow icon are drawn over that row's *last*
+  // column — callers leave that cell's text empty (see drawLinkIcon).
   links?: (string | undefined)[],
 ): number {
   const totalW = colWidths.reduce((a, b) => a + b, 0);
@@ -403,7 +419,10 @@ export function drawTable(
     doc.rect(MARGIN, y, totalW, h).fill(i % 2 === 0 ? '#ffffff' : C.rowAlt);
     renderWrappedRow(doc, wrapped, colWidths, y, false);
     const link = links?.[i];
-    if (link) doc.link(lastColX, y, lastColW, h, link);
+    if (link) {
+      doc.link(lastColX, y, lastColW, h, link);
+      drawLinkIcon(doc, lastColX + lastColW / 2, y + h / 2);
+    }
     y += h;
     segmentH += h;
   }

--- a/apps/cli/src/formatters/severity-report.formatter.ts
+++ b/apps/cli/src/formatters/severity-report.formatter.ts
@@ -244,12 +244,10 @@ export abstract class SeverityReportFormatter<
       const links = findings.map((finding) =>
         buildConsoleUrl({ kind: finding.kind, id: finding.id, region: finding.region?.code }),
       );
-      const rows = findings.map((finding, i) => [
+      const rows = findings.map((finding) => [
         ...this.rowFor(finding),
         finding.severity,
-        // Plain ASCII, not '↗': the base-14 Helvetica font (WinAnsi encoding)
-        // has no glyph for U+2197, which rendered as a broken/missing-glyph box.
-        links[i] ? 'Open ->' : '',
+        '',
       ]);
       const headers = [...presenter.head, 'Severity', 'Link'];
       const colWidths = computeColumnWidths(doc, headers, rows, CONTENT_W);

--- a/apps/cli/src/formatters/waste-report.pdf-formatter.ts
+++ b/apps/cli/src/formatters/waste-report.pdf-formatter.ts
@@ -210,12 +210,10 @@ function drawDetailPages(
     const links = findings.map((finding) =>
       buildConsoleUrl({ kind: finding.kind, id: finding.id, region: finding.region.code }),
     );
-    const rows = findings.map((finding, i) => [
+    const rows = findings.map((finding) => [
       ...rowFor(finding),
       `$${finding.costEstimate.monthlyCostUsd.toFixed(2)}/mo`,
-      // Plain ASCII, not '↗': the base-14 Helvetica font (WinAnsi encoding)
-      // has no glyph for U+2197, which rendered as a broken/missing-glyph box.
-      links[i] ? 'Open ->' : '',
+      '',
     ]);
     const headers = [...presenter.head, 'Cost/mo', 'Link'];
     const colWidths = computeColumnWidths(doc, headers, rows, CONTENT_W);

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -71,8 +71,12 @@ program
     'Also write a JSON report to disk (optional filename, defaults to reports/AWS_report_YYYY_MM_DD.json)',
   )
   .option(
+    '--csv [filename]',
+    'Also write a CSV report to disk (optional filename, defaults to reports/AWS_report_YYYY_MM_DD.csv)',
+  )
+  .option(
     '--silent',
-    'suppress all stdout output (banner, report, confirmations) — use with --pdf/--json for file-only output. Errors and the cost-gate alert still surface.',
+    'suppress all stdout output (banner, report, confirmations) — use with --pdf/--json/--csv for file-only output. Errors and the cost-gate alert still surface.',
   )
   .action((options) => analyzeWasteCommand(options));
 
@@ -94,6 +98,7 @@ program
   // See the `analyze` command's --pdf option above for why [filename] needs
   // to be written as --pdf=./path.pdf when combined with other flags.
   .option('--pdf [filename]', 'Also write a PDF report to disk (optional filename, defaults to reports/cloudrift-cost-YYYY_MM_DD.pdf)')
+  .option('--csv [filename]', 'Also write a CSV report to disk (optional filename, defaults to reports/cloudrift-cost-YYYY_MM_DD.csv)')
   .option('--silent', 'suppress all stdout output. Errors and the increase-gate alert still surface.')
   .action((options) => costCommand(options));
 
@@ -114,6 +119,7 @@ program
   .option('--refresh-cache', 'bypass the local Cost Explorer cache and re-fetch closed periods from AWS')
   .option('-y, --yes', 'skip the interactive "this costs $0.01" confirmation')
   .option('--pdf [filename]', 'Also write a PDF report to disk (optional filename, defaults to reports/cloudrift-trend-YYYY_MM_DD.pdf)')
+  .option('--csv [filename]', 'Also write a CSV report to disk (optional filename, defaults to reports/cloudrift-trend-YYYY_MM_DD.csv)')
   .option('--silent', 'suppress all stdout output.')
   .action((options) => trendCommand(options));
 
@@ -145,6 +151,10 @@ program
     '--pdf [filename]',
     'Also write a PDF report to disk (optional filename, defaults to reports/cloudrift-dead-resources-YYYY_MM_DD.pdf)',
   )
+  .option(
+    '--csv [filename]',
+    'Also write a CSV report to disk (optional filename, defaults to reports/cloudrift-dead-resources-YYYY_MM_DD.csv)',
+  )
   .option('--silent', 'suppress all stdout output (banner, report). Errors still surface.')
   .action((options) => deadResourcesCommand(options));
 
@@ -169,6 +179,10 @@ program
   .option(
     '--pdf [filename]',
     'Also write a PDF report to disk (optional filename, defaults to reports/cloudrift-resource-security-YYYY_MM_DD.pdf)',
+  )
+  .option(
+    '--csv [filename]',
+    'Also write a CSV report to disk (optional filename, defaults to reports/cloudrift-resource-security-YYYY_MM_DD.csv)',
   )
   .option('--silent', 'suppress all stdout output (banner, report). Errors still surface.')
   .action((options) => resourceSecurityCommand(options));

--- a/apps/cli/src/wizard/entry.wizard.ts
+++ b/apps/cli/src/wizard/entry.wizard.ts
@@ -46,6 +46,7 @@ export async function runEntryWizard(): Promise<void> {
       format: output.format,
       pdf: output.savePdf ? true : undefined,
       json: output.saveJson ? true : undefined,
+      csv: output.saveCsv ? true : undefined,
     });
     return;
   }
@@ -66,6 +67,7 @@ export async function runEntryWizard(): Promise<void> {
       scannerKinds,
       format: output.format,
       pdf: output.savePdf ? true : undefined,
+      csv: output.saveCsv ? true : undefined,
     });
     return;
   }
@@ -86,6 +88,7 @@ export async function runEntryWizard(): Promise<void> {
       scannerKinds,
       format: output.format,
       pdf: output.savePdf ? true : undefined,
+      csv: output.saveCsv ? true : undefined,
     });
     return;
   }

--- a/apps/cli/src/wizard/entry.wizard.ts
+++ b/apps/cli/src/wizard/entry.wizard.ts
@@ -10,7 +10,7 @@ import { promptRegions } from './region-input.wizard';
 import { promptScannerSelection } from './scanner-selection.wizard';
 import { promptDeadResourceSelection } from './dead-resource-selection.wizard';
 import { promptResourceSecuritySelection } from './resource-security-selection.wizard';
-import { promptWasteOutput, promptDeadResourcesOutput, promptResourceSecurityOutput, promptSimpleOutput } from './output-format.wizard';
+import { promptWasteOutput, promptDeadResourcesOutput, promptResourceSecurityOutput, promptCostTrendOutput } from './output-format.wizard';
 
 /**
  * The interactive entry point: shown when `cloudrift` is run with no
@@ -93,13 +93,21 @@ export async function runEntryWizard(): Promise<void> {
     return;
   }
 
-  const format = await promptSimpleOutput();
-  if (format === undefined) return;
+  const output = await promptCostTrendOutput();
+  if (output === undefined) return;
 
   outro('Fetching from AWS Cost Explorer...');
   if (mode === 'cost') {
-    await costCommand({ format });
+    await costCommand({
+      format: output.format,
+      pdf: output.savePdf ? true : undefined,
+      csv: output.saveCsv ? true : undefined,
+    });
   } else {
-    await trendCommand({ format });
+    await trendCommand({
+      format: output.format,
+      pdf: output.savePdf ? true : undefined,
+      csv: output.saveCsv ? true : undefined,
+    });
   }
 }

--- a/apps/cli/src/wizard/output-format.wizard.ts
+++ b/apps/cli/src/wizard/output-format.wizard.ts
@@ -5,6 +5,7 @@ export interface WasteOutputChoice {
   format: WasteOutputFormat;
   savePdf: boolean;
   saveJson: boolean;
+  saveCsv: boolean;
 }
 
 /** Output format + optional file artifacts for the waste-scan wizard flow. */
@@ -29,12 +30,16 @@ export async function promptWasteOutput(): Promise<WasteOutputChoice | undefined
   const saveJson = await confirm({ message: 'Also save a JSON report to disk?', initialValue: false });
   if (isCancel(saveJson)) return bail(cancel);
 
-  return { format, savePdf, saveJson };
+  const saveCsv = await confirm({ message: 'Also save a CSV report to disk?', initialValue: false });
+  if (isCancel(saveCsv)) return bail(cancel);
+
+  return { format, savePdf, saveJson, saveCsv };
 }
 
 export interface DeadResourcesOutputChoice {
   format: OutputFormat;
   savePdf: boolean;
+  saveCsv: boolean;
 }
 
 /** Output format + optional PDF for the dead-resources wizard flow — table/json/csv only, no markdown (see dead-resources.command.ts). */
@@ -55,7 +60,10 @@ export async function promptDeadResourcesOutput(): Promise<DeadResourcesOutputCh
   const savePdf = await confirm({ message: 'Also save a PDF report to disk?', initialValue: false });
   if (isCancel(savePdf)) return bail(cancel);
 
-  return { format, savePdf };
+  const saveCsv = await confirm({ message: 'Also save a CSV report to disk?', initialValue: false });
+  if (isCancel(saveCsv)) return bail(cancel);
+
+  return { format, savePdf, saveCsv };
 }
 
 export type ResourceSecurityOutputChoice = DeadResourcesOutputChoice;

--- a/apps/cli/src/wizard/output-format.wizard.ts
+++ b/apps/cli/src/wizard/output-format.wizard.ts
@@ -18,7 +18,6 @@ export async function promptWasteOutput(): Promise<WasteOutputChoice | undefined
       { value: 'table', label: 'Table (default)' },
       { value: 'json', label: 'JSON' },
       { value: 'markdown', label: 'Markdown' },
-      { value: 'csv', label: 'CSV' },
     ],
     initialValue: 'table',
   });
@@ -42,7 +41,7 @@ export interface DeadResourcesOutputChoice {
   saveCsv: boolean;
 }
 
-/** Output format + optional PDF for the dead-resources wizard flow — table/json/csv only, no markdown (see dead-resources.command.ts). */
+/** Output format + optional PDF for the dead-resources wizard flow — table/json only, no markdown (see dead-resources.command.ts). */
 export async function promptDeadResourcesOutput(): Promise<DeadResourcesOutputChoice | undefined> {
   const { select, confirm, cancel, isCancel } = await import('@clack/prompts');
 
@@ -51,7 +50,6 @@ export async function promptDeadResourcesOutput(): Promise<DeadResourcesOutputCh
     options: [
       { value: 'table', label: 'Table (default)' },
       { value: 'json', label: 'JSON' },
-      { value: 'csv', label: 'CSV' },
     ],
     initialValue: 'table',
   });
@@ -68,27 +66,38 @@ export async function promptDeadResourcesOutput(): Promise<DeadResourcesOutputCh
 
 export type ResourceSecurityOutputChoice = DeadResourcesOutputChoice;
 
-/** Output format + optional PDF for the resource-security wizard flow — table/json/csv only, no markdown, same shape as dead-resources. */
+/** Output format + optional PDF for the resource-security wizard flow — table/json only, no markdown, same shape as dead-resources. */
 export async function promptResourceSecurityOutput(): Promise<ResourceSecurityOutputChoice | undefined> {
   return promptDeadResourcesOutput();
 }
 
-/** Output format for the cost/trend wizard flow — no file artifacts yet, see PDF backlog item. */
-export async function promptSimpleOutput(): Promise<OutputFormat | undefined> {
-  const { select, cancel, isCancel } = await import('@clack/prompts');
+export interface CostTrendOutputChoice {
+  format: OutputFormat;
+  savePdf: boolean;
+  saveCsv: boolean;
+}
+
+/** Output format + optional file artifacts for the cost/trend wizard flow. */
+export async function promptCostTrendOutput(): Promise<CostTrendOutputChoice | undefined> {
+  const { select, confirm, cancel, isCancel } = await import('@clack/prompts');
 
   const format = await select<OutputFormat>({
     message: 'How should the report be shown?',
     options: [
       { value: 'table', label: 'Table / chart (default)' },
       { value: 'json', label: 'JSON' },
-      { value: 'csv', label: 'CSV' },
     ],
     initialValue: 'table',
   });
   if (isCancel(format)) return bail(cancel);
 
-  return format;
+  const savePdf = await confirm({ message: 'Also save a PDF report to disk?', initialValue: false });
+  if (isCancel(savePdf)) return bail(cancel);
+
+  const saveCsv = await confirm({ message: 'Also save a CSV report to disk?', initialValue: false });
+  if (isCancel(saveCsv)) return bail(cancel);
+
+  return { format, savePdf, saveCsv };
 }
 
 function bail(cancelFn: (message?: string) => void): undefined {

--- a/apps/cli/src/wizard/region-input.wizard.ts
+++ b/apps/cli/src/wizard/region-input.wizard.ts
@@ -19,10 +19,15 @@ export async function promptRegions(): Promise<string[] | undefined> {
   // resolved shape (same reasoning as `scanner-selection.wizard.ts`).
   const options = AWS_REGION_CODES.map((code) => ({ value: code, label: code })) as Option<string>[];
   const selected = await autocompleteMultiselect<string>({
-    message: 'Which AWS regions do you want to scan? (type to search, space to toggle, enter to confirm)',
+    // Space only toggles the focused option after an arrow key has moved the
+    // cursor at least once — clack's autocomplete prompt otherwise treats a
+    // bare space as a character typed into the search box (no public option
+    // to change this, see @clack/core's AutocompletePrompt#isNavigating).
+    // Tab always toggles regardless, so it's called out as the reliable key.
+    message: 'Which AWS regions do you want to scan? (type to search, tab to toggle, enter to confirm)',
     options,
     initialValues: [],
-    placeholder: 'Type to search, e.g. "eu-w"...',
+    placeholder: 'Type to search, e.g. "eu-w"... (press an arrow key first if space doesn\'t toggle)',
     required: true,
   });
 

--- a/docs/adr/0095-scan-coordinator-use-case-shared-base-class.md
+++ b/docs/adr/0095-scan-coordinator-use-case-shared-base-class.md
@@ -1,0 +1,74 @@
+# ADR-0095: `ScanCoordinatorUseCase` — shared base class for scan orchestration
+
+- **Status:** Accepted. Refines [ADR-0052](0052-global-scan-worker-pool.md)'s worker-pool design (now centralized, not duplicated) and supersedes the "deliberately not shared" rationale informally recorded in `FindDeadResourcesUseCase`/`FindResourceSecurityFindingsUseCase`'s doc comments (which cited [ADR-0078](0078-dead-resources-parallel-domain.md) by analogy — that ADR itself never analyzed use-case-level duplication, only domain-model and infrastructure-utility duplication).
+
+## Context
+
+`AnalyzeCloudWasteUseCase` (`cloud-cost-application`), `FindDeadResourcesUseCase` (`dead-resources-application`), and `FindResourceSecurityFindingsUseCase` (`resource-security-application`) each independently implemented the same orchestration: build one job per (scanner, region) pair (with a global-scope special case added when `dead-resources` and `resource-security` were built), run them through a hand-rolled worker pool bounded by `scanConcurrency` (default 12, [ADR-0063](0063-scan-concurrency-env-configurable-default-restored-to-12.md)), collect per-(scanner, region) errors without aborting other jobs, and wrap the result in `Result.ok(...)`. A direct diff showed `FindDeadResourcesUseCase` and `FindResourceSecurityFindingsUseCase` were identical modulo type names; `AnalyzeCloudWasteUseCase` shared ~75-80% of the same shape (cloud-cost has no global-scope scanners, so it lacks that branch).
+
+Two things changed since the duplication was last deliberately accepted:
+
+1. `mapWithConcurrency` (`shared-aws-infra-utils`) already implements the exact same worker-pool algorithm as the hand-rolled loop, but ADR-0052 explicitly ruled out using it: *"the application layer cannot import `mapWithConcurrency` from the infrastructure lib."* That constraint assumed the only shared-code seam available was `scope:infrastructure`. It does not account for a new `scope:shared` library, which `scope:application` is allowed to depend on under the existing Nx `depConstraints` ([ADR-0075](0075-nx-dep-constraints-layer-enforcement.md)).
+2. `resource-security-application` became the second consumer of the exact same pattern `dead-resources-application` introduced — at which point copy-pasting a third near-identical coordinator stopped being "proving the pattern once" ([ADR-0078](0078-dead-resources-parallel-domain.md)'s stated posture for its first slice) and started being straightforward triplication.
+
+## Decision
+
+New library `shared-scan-coordination` (`scope:shared`, alongside `shared-kernel` and `shared-aws-infra-utils`), exporting one abstract class:
+
+```typescript
+export abstract class ScanCoordinatorUseCase<TKind extends string, TRegion extends ScannableRegion, TFinding, TSummary> {
+  constructor(
+    private readonly scanners: readonly ScannableScanner<TKind, TRegion, TFinding>[],
+    private readonly scanConcurrency: number = DEFAULT_SCAN_CONCURRENCY,
+  ) {}
+
+  protected abstract buildSummary(findings: TFinding[], scanErrors: ScanCoordinatorError<TKind>[]): TSummary;
+
+  async execute(request: ScanCoordinatorRequest<TRegion>): Promise<Result<TSummary>> {
+    // job construction (incl. global-scope special case), mapWithConcurrency-based
+    // worker pool, per-job error collection — identical to the three duplicated
+    // implementations, now written once.
+  }
+}
+```
+
+Each domain's use case shrinks to a subclass supplying only its own aggregation:
+
+```typescript
+export class AnalyzeCloudWasteUseCase
+  extends ScanCoordinatorUseCase<ResourceKind, AwsRegion, WastedResource, WastedResourcesSummary>
+  implements FindWastedResourcesUseCasePort
+{
+  protected override buildSummary(findings, scanErrors): WastedResourcesSummary {
+    // dollar-total split by category — the only part that actually differs
+  }
+}
+```
+
+`FindDeadResourcesUseCase`/`FindResourceSecurityFindingsUseCase` follow the same shape, aggregating `countBySeverity` instead.
+
+**Design choices, and why:**
+
+- **Base class + template method, not a free function or an injected collaborator.** Matches this codebase's stated preference (base class/injected collaborator over free-function utility modules) and keeps each concrete use case a single cohesive object satisfying its own domain port, rather than a use case that merely delegates to an internal helper it also has to construct and store.
+- **`buildSummary` returns the complete `TSummary`, not a spread-plus-cast.** Letting the base class assemble `{ ...partial, findings, scanErrors } as TSummary` would need an `as` cast the compiler can't verify — exactly the pattern this codebase's `as`-cast heuristic ([ADR-0084](0084-typescript-as-cast-cleanup.md)) rejects. Requiring subclasses to return the whole typed object keeps every field compiler-checked.
+- **`kind` flows through as a real generic parameter (`ScanCoordinatorError<TKind>`), not widened to `string`.** Because `TKind` is inferred from the scanner array passed to the constructor, `{ kind: scanner.kind, region, error }` built inside the base class's `execute()` is already exactly typed per domain (e.g. `ScanCoordinatorError<ResourceKind>`) — no cast needed to satisfy each domain's existing `ResourceScanError`/`DeadResourceScanError`/`ResourceSecurityScanError` port types, which stay untouched.
+- **`TRegion` is bounded by a minimal structural `{ readonly code: string }` interface, not `AwsRegion` directly.** `scope:shared` cannot depend on `scope:domain` ([ADR-0075](0075-nx-dep-constraints-layer-enforcement.md)); genericizing the region type avoids needing to import the concrete domain type at all, while `AwsRegion` still satisfies the constraint structurally with zero changes to its own definition.
+- **The three domains' `*UseCasePort` interfaces are untouched.** `AggregateAnalysisUseCase` (`mcp-server-application`) depends on those port interfaces, not on the use cases' internal implementation — this refactor is invisible to it.
+
+**Test split:** coordinator mechanics (concurrency bound, global-scope single-job behavior, per-job error collection, partial-failure isolation) are now tested once in `shared-scan-coordination`'s own spec, against a fake domain. Each of the three application-layer specs keeps only its own aggregation tests (dollar totals / category split / severity counts) plus one smoke test confirming a real domain `kind` flows correctly through the generic base class.
+
+**Jest resolution gotcha (recorded for the next new `scope:shared` lib):** this monorepo's tests resolve workspace packages via each project's `moduleNameMapper` mapping the package name straight to its `src/index.ts` (bypassing the built `dist/`, which is ESM and can't be `require()`-d by Jest's CJS runtime). That mapping is maintained by hand per consuming project, not generated — every `jest.config.cjs` that (transitively) imports a new shared lib needs its own two-line mapper entry added, including the new shared lib's own `jest.config.cjs` for its own dependencies (here: `shared-kernel`, `shared-aws-infra-utils`).
+
+## Alternatives Considered
+
+- **Free function `runScanCoordinator(scanners, regions, concurrency, aggregate)`.** Rejected per this codebase's standing preference for a base class/injected collaborator over free-function utilities when removing duplication.
+- **Injected `ScanOrchestrator` collaborator**, each use case keeping its own `execute()` and calling `orchestrator.run(...)`. More explicit about what each use case does, but adds a constructor-injected dependency three call sites now have to wire identically for no behavioral difference from the template-method version — rejected in favor of the simpler inheritance shape given there is exactly one working orchestration algorithm, not a family of interchangeable ones.
+- **Leave the three duplicated, only replace each hand-rolled worker loop with `mapWithConcurrency`.** Removes the smallest slice of duplication (the loop itself, ~20 lines) while leaving job-construction, error-collection, and the per-domain `DEFAULT_SCAN_CONCURRENCY` constant duplicated three times. Rejected as an incomplete fix once a `scope:shared` seam exists to do the whole thing properly.
+- **Fold the new library into `shared-kernel` or `shared-aws-infra-utils`.** Rejected: `shared-kernel` is DDD primitives (`Result`, `Entity`, `ValueObject`) with no orchestration concerns; `shared-aws-infra-utils` is AWS-adapter-facing infrastructure utilities, not an application-layer abstraction. A dedicated library keeps each existing shared lib's charter unambiguous.
+
+## Consequences
+
+- `AnalyzeCloudWasteUseCase`/`FindDeadResourcesUseCase`/`FindResourceSecurityFindingsUseCase` drop from 71-107 lines each to ~20-30, containing only their own aggregation logic.
+- `cloud-cost-application`, `dead-resources-application`, and `resource-security-application` gain a new `scope:shared` dependency (`shared-scan-coordination`); `dead-resources-application` and `resource-security-application` additionally gain `shared-aws-infra-utils` as a transitive-through-source jest mapping (already an existing dependency of the new shared lib, not of these packages directly).
+- Future scan domains (if any) get the coordinator for free — only `buildSummary` needs writing.
+- Verified: `nx run-many --target={build,lint,typecheck,test} --all` green across all 17 projects, including `apps/cli` and `mcp-server-application` (unaffected — it depends only on the three domains' ports, not their application-layer implementations).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -77,6 +77,7 @@ Each entry follows: Context → Decision → Alternatives Considered → Consequ
 | [0084](0084-typescript-as-cast-cleanup.md) | TypeScript `as` cast cleanup: mechanical fixes, deferred fallback decisions, legitimate exceptions | Accepted |
 | [0086](0086-mcp-tool-handlers-error-boundary.md) | MCP tool handlers wrapped in a shared error boundary | Accepted |
 | [0094](0094-wastereason-derived-from-policy-verdict.md) | `wasteReason` derived from the policy's `WasteVerdict`, not hardcoded on the entity | Accepted |
+| [0095](0095-scan-coordinator-use-case-shared-base-class.md) | `ScanCoordinatorUseCase` — shared base class for scan orchestration across cloud-cost/dead-resources/resource-security | Accepted |
 
 ## Stack
 

--- a/libs/cloud-cost/application/jest.config.cjs
+++ b/libs/cloud-cost/application/jest.config.cjs
@@ -18,8 +18,12 @@ module.exports = {
   moduleNameMapper: {
     '^shared-kernel$': '<rootDir>/../../shared/kernel/src/index.ts',
     '^shared-kernel/(.*)$': '<rootDir>/../../shared/kernel/src/$1',
+    '^shared-aws-infra-utils$': '<rootDir>/../../shared/aws-infra-utils/src/index.ts',
+    '^shared-aws-infra-utils/(.*)$': '<rootDir>/../../shared/aws-infra-utils/src/$1',
     '^cloud-cost-domain$': '<rootDir>/../domain/src/index.ts',
     '^cloud-cost-domain/(.*)$': '<rootDir>/../domain/src/$1',
+    '^shared-scan-coordination$': '<rootDir>/../../shared/scan-coordination/src/index.ts',
+    '^shared-scan-coordination/(.*)$': '<rootDir>/../../shared/scan-coordination/src/$1',
     '^(\\.{1,2}/.*)\\.js$': '$1',
   },
 };

--- a/libs/cloud-cost/application/package.json
+++ b/libs/cloud-cost/application/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "cloud-cost-domain": "workspace:*",
     "shared-kernel": "workspace:*",
+    "shared-scan-coordination": "workspace:*",
     "tslib": "^2.8.1"
   }
 }

--- a/libs/cloud-cost/application/src/use-cases/analyze-cloud-waste.use-case.spec.ts
+++ b/libs/cloud-cost/application/src/use-cases/analyze-cloud-waste.use-case.spec.ts
@@ -1,16 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 import { AnalyzeCloudWasteUseCase } from './analyze-cloud-waste.use-case';
-import {
-  AwsRegion,
-  EbsVolume,
-  ElasticIp,
-  Gp2Volume,
-} from 'cloud-cost-domain';
+import { AwsRegion, EbsVolume, ElasticIp, Gp2Volume } from 'cloud-cost-domain';
 import type { ResourceKind, WastedResource, WasteScannerPort } from 'cloud-cost-domain';
 import { Result } from 'shared-kernel';
 
 const usEast = AwsRegion.create('us-east-1');
-const euWest = AwsRegion.create('eu-west-1');
 
 function makeEbsVolume(id: string, region = usEast): EbsVolume {
   return new EbsVolume({
@@ -55,10 +49,7 @@ function makeGp2Volume(id: string): Gp2Volume {
 }
 
 /** Fake scanner: one response per region, in call order. */
-function makeScanner(
-  kind: ResourceKind,
-  responses: Array<Result<WastedResource[]>>,
-): WasteScannerPort {
+function makeScanner(kind: ResourceKind, responses: Array<Result<WastedResource[]>>): WasteScannerPort {
   let call = 0;
   return {
     kind,
@@ -66,6 +57,9 @@ function makeScanner(
   };
 }
 
+// Job scheduling, concurrency, and per-(scanner,region) error collection are
+// covered generically by shared-scan-coordination's own spec. These tests
+// only exercise the aggregation logic specific to this use case.
 describe('AnalyzeCloudWasteUseCase', () => {
   it('returns an empty summary when all scanners find nothing', async () => {
     const useCase = new AnalyzeCloudWasteUseCase([
@@ -113,42 +107,6 @@ describe('AnalyzeCloudWasteUseCase', () => {
     expect(result.value.totalOptimizationMonthlyUsd).toBeCloseTo(4, 2);
   });
 
-  it('records a scanError with kind and region when a scanner fails, preserving other results', async () => {
-    const err = new Error('EBS failed');
-    const useCase = new AnalyzeCloudWasteUseCase([
-      makeScanner('ebs-volume', [Result.fail(err)]),
-      makeScanner('elastic-ip', [Result.ok([makeElasticIp('eipalloc-1')])]),
-    ]);
-
-    const result = await useCase.execute({ regions: [usEast] });
-
-    expect(result.ok).toBe(true);
-    if (!result.ok) return;
-    expect(result.value.findings).toHaveLength(1);
-    expect(result.value.scanErrors).toEqual([
-      { kind: 'ebs-volume', region: 'us-east-1', error: err },
-    ]);
-  });
-
-  it('keeps results from healthy regions when one region fails', async () => {
-    const err = new Error('eu-west-1 not enabled');
-    const useCase = new AnalyzeCloudWasteUseCase([
-      makeScanner('ebs-volume', [
-        Result.ok([makeEbsVolume('vol-us')]),
-        Result.fail(err),
-      ]),
-    ]);
-
-    const result = await useCase.execute({ regions: [usEast, euWest] });
-
-    expect(result.ok).toBe(true);
-    if (!result.ok) return;
-    expect(result.value.findings.map((f) => f.id)).toEqual(['vol-us']);
-    expect(result.value.scanErrors).toEqual([
-      { kind: 'ebs-volume', region: 'eu-west-1', error: err },
-    ]);
-  });
-
   it('excludes failed scans from the total cost', async () => {
     const useCase = new AnalyzeCloudWasteUseCase([
       makeScanner('ebs-volume', [Result.fail(new Error('boom'))]),
@@ -162,66 +120,18 @@ describe('AnalyzeCloudWasteUseCase', () => {
     expect(result.value.totalWasteMonthlyUsd).toBeCloseTo(3.6, 2);
   });
 
-  it('scans every region with every scanner', async () => {
-    const calls: string[] = [];
-    const tracking: WasteScannerPort = {
-      kind: 'ebs-volume',
-      scan: async (region) => {
-        calls.push(region.code);
-        return Result.ok([]);
-      },
-    };
+  it('records a scanError with the real ResourceKind and region when a scanner fails', async () => {
+    const err = new Error('EBS failed');
+    const useCase = new AnalyzeCloudWasteUseCase([
+      makeScanner('ebs-volume', [Result.fail(err)]),
+      makeScanner('elastic-ip', [Result.ok([makeElasticIp('eipalloc-1')])]),
+    ]);
 
-    const useCase = new AnalyzeCloudWasteUseCase([tracking]);
-    await useCase.execute({ regions: [usEast, euWest] });
-
-    expect(calls).toEqual(['us-east-1', 'eu-west-1']);
-  });
-
-  it('bounds in-flight scans to the configured concurrency, across any scanner×region mix', async () => {
-    let inFlight = 0;
-    let peak = 0;
-    const slowScanner = (kind: ResourceKind): WasteScannerPort => ({
-      kind,
-      scan: async () => {
-        inFlight++;
-        peak = Math.max(peak, inFlight);
-        await new Promise((resolve) => setTimeout(resolve, 0));
-        inFlight--;
-        return Result.ok([]);
-      },
-    });
-
-    // 3 scanner × 2 regioni = 6 job, pool da 2 worker
-    const useCase = new AnalyzeCloudWasteUseCase(
-      [slowScanner('ebs-volume'), slowScanner('elastic-ip'), slowScanner('log-group')],
-      2,
-    );
-    await useCase.execute({ regions: [usEast, euWest] });
-
-    expect(peak).toBe(2);
-  });
-
-  it('scans regions of the same scanner concurrently when a worker is free', async () => {
-    // us-east-1 only unblocks once eu-west-1 starts: with the old
-    // sequential per-region loop this test would time out.
-    let releaseFirst!: () => void;
-    const firstBlocked = new Promise<void>((resolve) => (releaseFirst = resolve));
-    const scanner: WasteScannerPort = {
-      kind: 'ebs-volume',
-      scan: async (region) => {
-        if (region.code === 'us-east-1') {
-          await firstBlocked;
-        } else {
-          releaseFirst();
-        }
-        return Result.ok([]);
-      },
-    };
-
-    const useCase = new AnalyzeCloudWasteUseCase([scanner], 2);
-    const result = await useCase.execute({ regions: [usEast, euWest] });
+    const result = await useCase.execute({ regions: [usEast] });
 
     expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.findings).toHaveLength(1);
+    expect(result.value.scanErrors).toEqual([{ kind: 'ebs-volume', region: 'us-east-1', error: err }]);
   });
 });

--- a/libs/cloud-cost/application/src/use-cases/analyze-cloud-waste.use-case.ts
+++ b/libs/cloud-cost/application/src/use-cases/analyze-cloud-waste.use-case.ts
@@ -1,91 +1,30 @@
 // SPDX-License-Identifier: Apache-2.0
-import { Result, createLogger } from 'shared-kernel';
 import { categoryOf } from 'cloud-cost-domain';
 import type {
-  FindWastedResourcesRequest,
   FindWastedResourcesUseCasePort,
   WastedResourcesSummary,
   WastedResource,
-  WasteScannerPort,
-  ResourceScanError,
+  ResourceKind,
+  AwsRegion,
 } from 'cloud-cost-domain';
-
-const logger = createLogger('cloudrift:scanner');
-
-/**
- * Global bound on in-flight (scanner, region) scans, any mix. Overridable
- * via `CLOUDRIFT_SCAN_CONCURRENCY` (see `analyze-waste.composition.ts`).
- * Restored to 12 (2026-07-13, ADR-0064) after root-causing the socket
- * hang up that briefly dropped this to 1: it was a client-side bug (every
- * scanner shared one `NodeHttpHandler`, so one finishing destroyed another's
- * in-flight connections), not a real AWS reliability limit — ADR-0063's
- * original assumption was right, the earlier fix just targeted the wrong
- * layer. Re-verified against real AWS post-fix: 0 errors, identical findings,
- * at 1/3/5/10/20 in-flight scans alike.
- */
-const DEFAULT_SCAN_CONCURRENCY = 12;
+import { ScanCoordinatorUseCase } from 'shared-scan-coordination';
+import type { ScanCoordinatorError } from 'shared-scan-coordination';
 
 /**
- * Generic coordinator: every (scanner, region) pair becomes one job in a
- * FIFO queue consumed by a small worker pool with a single global bound —
- * instead of one unbounded Promise.all across scanners with regions in
- * series, where the total in-flight load was `scanners × internal fan-out`
- * on the first region and a multi-region scan took `regions × slowest
- * scanner`. Jobs are queued scanner-major (s1×r1, s1×r2, ..., s2×r1), so
- * the first batch the workers pull spreads across regions instead of
- * concentrating on the first one.
- *
- * Errors are collected per (scanner, region): the failure of one
- * region does not discard the results of the others, nor those of the other scanners.
+ * Orchestration (job scheduling, worker-pool concurrency, per-job error
+ * collection) lives in `ScanCoordinatorUseCase` — shared with
+ * `FindDeadResourcesUseCase`/`FindResourceSecurityFindingsUseCase`. This
+ * class only supplies cloud-cost's own aggregation: splitting findings into
+ * waste vs. optimization dollar totals.
  */
-export class AnalyzeCloudWasteUseCase implements FindWastedResourcesUseCasePort {
-  constructor(
-    private readonly scanners: readonly WasteScannerPort[],
-    private readonly scanConcurrency = DEFAULT_SCAN_CONCURRENCY,
-  ) {}
-
-  async execute(
-    request: FindWastedResourcesRequest,
-  ): Promise<Result<WastedResourcesSummary>> {
-    const findings: WastedResource[] = [];
-    const scanErrors: ResourceScanError[] = [];
-
-    const jobs = this.scanners.flatMap((scanner) =>
-      request.regions.map((region) => ({ scanner, region })),
-    );
-
-    let nextJob = 0;
-    const worker = async (): Promise<void> => {
-      while (nextJob < jobs.length) {
-        const { scanner, region } = jobs[nextJob++];
-        const startedAt = Date.now();
-        const result = await scanner.scan(region);
-        const durationMs = Date.now() - startedAt;
-        if (result.ok) {
-          logger.debug(`${scanner.kind} scan ok`, {
-            region: region.code,
-            durationMs,
-            findings: result.value.length,
-          });
-          findings.push(...result.value);
-        } else {
-          logger.debug(`${scanner.kind} scan failed`, {
-            region: region.code,
-            durationMs,
-            error: result.error.message,
-          });
-          scanErrors.push({
-            kind: scanner.kind,
-            region: region.code,
-            error: result.error,
-          });
-        }
-      }
-    };
-
-    const workerCount = Math.max(1, Math.min(this.scanConcurrency, jobs.length));
-    await Promise.all(Array.from({ length: workerCount }, () => worker()));
-
+export class AnalyzeCloudWasteUseCase
+  extends ScanCoordinatorUseCase<ResourceKind, AwsRegion, WastedResource, WastedResourcesSummary>
+  implements FindWastedResourcesUseCasePort
+{
+  protected override buildSummary(
+    findings: WastedResource[],
+    scanErrors: ScanCoordinatorError<ResourceKind>[],
+  ): WastedResourcesSummary {
     let totalWasteMonthlyUsd = 0;
     let totalOptimizationMonthlyUsd = 0;
     for (const finding of findings) {
@@ -96,12 +35,6 @@ export class AnalyzeCloudWasteUseCase implements FindWastedResourcesUseCasePort 
         totalOptimizationMonthlyUsd += amount;
       }
     }
-
-    return Result.ok({
-      findings,
-      totalWasteMonthlyUsd,
-      totalOptimizationMonthlyUsd,
-      scanErrors,
-    });
+    return { findings, totalWasteMonthlyUsd, totalOptimizationMonthlyUsd, scanErrors };
   }
 }

--- a/libs/dead-resources/application/jest.config.cjs
+++ b/libs/dead-resources/application/jest.config.cjs
@@ -18,6 +18,8 @@ module.exports = {
   moduleNameMapper: {
     '^shared-kernel$': '<rootDir>/../../shared/kernel/src/index.ts',
     '^shared-kernel/(.*)$': '<rootDir>/../../shared/kernel/src/$1',
+    '^shared-aws-infra-utils$': '<rootDir>/../../shared/aws-infra-utils/src/index.ts',
+    '^shared-aws-infra-utils/(.*)$': '<rootDir>/../../shared/aws-infra-utils/src/$1',
     // dead-resources-domain re-exports AwsRegion from cloud-cost-domain, so
     // that source also needs to resolve here, not just in the domain lib's
     // own jest config.
@@ -25,6 +27,8 @@ module.exports = {
     '^cloud-cost-domain/(.*)$': '<rootDir>/../../cloud-cost/domain/src/$1',
     '^dead-resources-domain$': '<rootDir>/../domain/src/index.ts',
     '^dead-resources-domain/(.*)$': '<rootDir>/../domain/src/$1',
+    '^shared-scan-coordination$': '<rootDir>/../../shared/scan-coordination/src/index.ts',
+    '^shared-scan-coordination/(.*)$': '<rootDir>/../../shared/scan-coordination/src/$1',
     '^(\\.{1,2}/.*)\\.js$': '$1',
   },
 };

--- a/libs/dead-resources/application/package.json
+++ b/libs/dead-resources/application/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "dead-resources-domain": "workspace:*",
     "shared-kernel": "workspace:*",
+    "shared-scan-coordination": "workspace:*",
     "tslib": "^2.8.1"
   }
 }

--- a/libs/dead-resources/application/src/use-cases/find-dead-resources.use-case.spec.ts
+++ b/libs/dead-resources/application/src/use-cases/find-dead-resources.use-case.spec.ts
@@ -5,7 +5,6 @@ import type { DeadResourceKind, DeadResource, DeadResourceScannerPort } from 'de
 import { Result } from 'shared-kernel';
 
 const usEast = AwsRegion.create('us-east-1');
-const euWest = AwsRegion.create('eu-west-1');
 
 function makeKeyPair(id: string): Ec2KeyPairUnused {
   return new Ec2KeyPairUnused({
@@ -28,6 +27,9 @@ function makeScanner(kind: DeadResourceKind, responses: Array<Result<DeadResourc
   };
 }
 
+// Job scheduling, concurrency, and per-(scanner,region) error collection are
+// covered generically by shared-scan-coordination's own spec. These tests
+// only exercise the aggregation logic specific to this use case.
 describe('FindDeadResourcesUseCase', () => {
   it('returns an empty summary when all scanners find nothing', async () => {
     const useCase = new FindDeadResourcesUseCase([makeScanner('ec2-keypair-unused', [Result.ok([])])]);
@@ -54,7 +56,7 @@ describe('FindDeadResourcesUseCase', () => {
     expect(result.value.countBySeverity).toEqual({ info: 2, warning: 0, critical: 0 });
   });
 
-  it('records a scanError with kind and region when a scanner fails, preserving other results', async () => {
+  it('records a scanError with the real DeadResourceKind and region when a scanner fails', async () => {
     const err = new Error('EC2 failed');
     const useCase = new FindDeadResourcesUseCase([makeScanner('ec2-keypair-unused', [Result.fail(err)])]);
 
@@ -64,100 +66,5 @@ describe('FindDeadResourcesUseCase', () => {
     if (!result.ok) return;
     expect(result.value.findings).toHaveLength(0);
     expect(result.value.scanErrors).toEqual([{ kind: 'ec2-keypair-unused', region: 'us-east-1', error: err }]);
-  });
-
-  it('keeps results from healthy regions when one region fails', async () => {
-    const err = new Error('eu-west-1 not enabled');
-    const useCase = new FindDeadResourcesUseCase([
-      makeScanner('ec2-keypair-unused', [Result.ok([makeKeyPair('key-us')]), Result.fail(err)]),
-    ]);
-
-    const result = await useCase.execute({ regions: [usEast, euWest] });
-
-    expect(result.ok).toBe(true);
-    if (!result.ok) return;
-    expect(result.value.findings.map((f) => f.id)).toEqual(['key-us']);
-    expect(result.value.scanErrors).toEqual([{ kind: 'ec2-keypair-unused', region: 'eu-west-1', error: err }]);
-  });
-
-  it('calls a global-scope scanner exactly once, regardless of how many regions were requested', async () => {
-    const calls: string[] = [];
-    const globalScanner: DeadResourceScannerPort = {
-      kind: 'iam-user-inactive',
-      scope: 'global',
-      scan: async (region) => {
-        calls.push(region.code);
-        return Result.ok([]);
-      },
-    };
-
-    const useCase = new FindDeadResourcesUseCase([globalScanner]);
-    await useCase.execute({ regions: [usEast, euWest] });
-
-    expect(calls).toHaveLength(1);
-  });
-
-  it('still calls a regional scanner once per region alongside a global one', async () => {
-    const regionalCalls: string[] = [];
-    let globalCalls = 0;
-    const scanners: DeadResourceScannerPort[] = [
-      {
-        kind: 'ec2-keypair-unused',
-        scan: async (region) => {
-          regionalCalls.push(region.code);
-          return Result.ok([]);
-        },
-      },
-      {
-        kind: 'iam-user-inactive',
-        scope: 'global',
-        scan: async () => {
-          globalCalls++;
-          return Result.ok([]);
-        },
-      },
-    ];
-
-    const useCase = new FindDeadResourcesUseCase(scanners);
-    await useCase.execute({ regions: [usEast, euWest] });
-
-    expect(regionalCalls.sort()).toEqual(['eu-west-1', 'us-east-1']);
-    expect(globalCalls).toBe(1);
-  });
-
-  it('labels a global scanner scanError as "global", not a real region', async () => {
-    const err = new Error('AccessDenied');
-    const globalScanner: DeadResourceScannerPort = {
-      kind: 'iam-user-inactive',
-      scope: 'global',
-      scan: async () => Result.fail(err),
-    };
-
-    const useCase = new FindDeadResourcesUseCase([globalScanner]);
-    const result = await useCase.execute({ regions: [usEast, euWest] });
-
-    expect(result.ok).toBe(true);
-    if (!result.ok) return;
-    expect(result.value.scanErrors).toEqual([{ kind: 'iam-user-inactive', region: 'global', error: err }]);
-  });
-
-  it('bounds in-flight scans to the configured concurrency, across any scanner×region mix', async () => {
-    let inFlight = 0;
-    let peak = 0;
-    const slowScanner = (kind: DeadResourceKind): DeadResourceScannerPort => ({
-      kind,
-      scan: async () => {
-        inFlight++;
-        peak = Math.max(peak, inFlight);
-        await new Promise((resolve) => setTimeout(resolve, 0));
-        inFlight--;
-        return Result.ok([]);
-      },
-    });
-
-    const useCase = new FindDeadResourcesUseCase([slowScanner('ec2-keypair-unused')], 1);
-    await useCase.execute({ regions: [usEast, euWest] });
-
-    expect(peak).toBe(1);
   });
 });

--- a/libs/dead-resources/application/src/use-cases/find-dead-resources.use-case.ts
+++ b/libs/dead-resources/application/src/use-cases/find-dead-resources.use-case.ts
@@ -1,72 +1,34 @@
 // SPDX-License-Identifier: Apache-2.0
-import { Result, createLogger } from 'shared-kernel';
 import type {
-  FindDeadResourcesRequest,
   FindDeadResourcesUseCasePort,
   DeadResourcesSummary,
   DeadResource,
-  DeadResourceScannerPort,
-  DeadResourceScanError,
+  DeadResourceKind,
   DeadResourceSeverity,
+  AwsRegion,
 } from 'dead-resources-domain';
-
-const logger = createLogger('cloudrift:scanner');
-
-/** Same bound as `AnalyzeCloudWasteUseCase` (`cloud-cost-application`) — see ADR-0064/ADR-0063. */
-const DEFAULT_SCAN_CONCURRENCY = 12;
+import { ScanCoordinatorUseCase } from 'shared-scan-coordination';
+import type { ScanCoordinatorError } from 'shared-scan-coordination';
 
 /**
- * Generic coordinator: every (scanner, region) pair becomes one job in a
- * FIFO queue consumed by a small worker pool with a single global bound.
- * Deliberately mirrors `AnalyzeCloudWasteUseCase`'s shape (ADR-0078) rather
- * than being shared with it — the two coordinators operate on disjoint
- * finding types and summing dollars has no equivalent to compute here.
+ * Orchestration (job scheduling, worker-pool concurrency, per-job error
+ * collection) lives in `ScanCoordinatorUseCase` — shared with
+ * `AnalyzeCloudWasteUseCase`/`FindResourceSecurityFindingsUseCase`. This
+ * class only supplies dead-resources' own aggregation: counting findings by
+ * severity.
  */
-export class FindDeadResourcesUseCase implements FindDeadResourcesUseCasePort {
-  constructor(
-    private readonly scanners: readonly DeadResourceScannerPort[],
-    private readonly scanConcurrency = DEFAULT_SCAN_CONCURRENCY,
-  ) {}
-
-  async execute(request: FindDeadResourcesRequest): Promise<Result<DeadResourcesSummary>> {
-    const findings: DeadResource[] = [];
-    const scanErrors: DeadResourceScanError[] = [];
-
-    // Global-scope scanners (IAM) get exactly one job, not one per region —
-    // an AWS global service has no per-region data to deduplicate. The
-    // region passed to that one job is arbitrary (the first requested) and
-    // the scanner implementation must ignore it (ADR-0078). Callers always
-    // pass at least one region (CLI default, wizard requires a selection).
-    const jobs = this.scanners.flatMap((scanner) =>
-      scanner.scope === 'global' ? [{ scanner, region: request.regions[0] }] : request.regions.map((region) => ({ scanner, region })),
-    );
-
-    let nextJob = 0;
-    const worker = async (): Promise<void> => {
-      while (nextJob < jobs.length) {
-        const { scanner, region } = jobs[nextJob++];
-        const regionLabel = scanner.scope === 'global' ? 'global' : region.code;
-        const startedAt = Date.now();
-        const result = await scanner.scan(region);
-        const durationMs = Date.now() - startedAt;
-        if (result.ok) {
-          logger.debug(`${scanner.kind} scan ok`, { region: regionLabel, durationMs, findings: result.value.length });
-          findings.push(...result.value);
-        } else {
-          logger.debug(`${scanner.kind} scan failed`, { region: regionLabel, durationMs, error: result.error.message });
-          scanErrors.push({ kind: scanner.kind, region: regionLabel, error: result.error });
-        }
-      }
-    };
-
-    const workerCount = Math.max(1, Math.min(this.scanConcurrency, jobs.length));
-    await Promise.all(Array.from({ length: workerCount }, () => worker()));
-
+export class FindDeadResourcesUseCase
+  extends ScanCoordinatorUseCase<DeadResourceKind, AwsRegion, DeadResource, DeadResourcesSummary>
+  implements FindDeadResourcesUseCasePort
+{
+  protected override buildSummary(
+    findings: DeadResource[],
+    scanErrors: ScanCoordinatorError<DeadResourceKind>[],
+  ): DeadResourcesSummary {
     const countBySeverity: Record<DeadResourceSeverity, number> = { info: 0, warning: 0, critical: 0 };
     for (const finding of findings) {
       countBySeverity[finding.severity]++;
     }
-
-    return Result.ok({ findings, countBySeverity, scanErrors });
+    return { findings, countBySeverity, scanErrors };
   }
 }

--- a/libs/dead-resources/application/tsconfig.lib.json
+++ b/libs/dead-resources/application/tsconfig.lib.json
@@ -12,10 +12,13 @@
   "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"],
   "references": [
     {
-      "path": "../domain/tsconfig.lib.json"
+      "path": "../../shared/scan-coordination/tsconfig.lib.json"
     },
     {
       "path": "../../shared/kernel/tsconfig.lib.json"
+    },
+    {
+      "path": "../domain/tsconfig.lib.json"
     }
   ]
 }

--- a/libs/resource-security/application/jest.config.cjs
+++ b/libs/resource-security/application/jest.config.cjs
@@ -18,10 +18,14 @@ module.exports = {
   moduleNameMapper: {
     '^shared-kernel$': '<rootDir>/../../shared/kernel/src/index.ts',
     '^shared-kernel/(.*)$': '<rootDir>/../../shared/kernel/src/$1',
+    '^shared-aws-infra-utils$': '<rootDir>/../../shared/aws-infra-utils/src/index.ts',
+    '^shared-aws-infra-utils/(.*)$': '<rootDir>/../../shared/aws-infra-utils/src/$1',
     '^cloud-cost-domain$': '<rootDir>/../../cloud-cost/domain/src/index.ts',
     '^cloud-cost-domain/(.*)$': '<rootDir>/../../cloud-cost/domain/src/$1',
     '^resource-security-domain$': '<rootDir>/../domain/src/index.ts',
     '^resource-security-domain/(.*)$': '<rootDir>/../domain/src/$1',
+    '^shared-scan-coordination$': '<rootDir>/../../shared/scan-coordination/src/index.ts',
+    '^shared-scan-coordination/(.*)$': '<rootDir>/../../shared/scan-coordination/src/$1',
     '^(\\.{1,2}/.*)\\.js$': '$1',
   },
 };

--- a/libs/resource-security/application/src/use-cases/find-resource-security-findings.use-case.spec.ts
+++ b/libs/resource-security/application/src/use-cases/find-resource-security-findings.use-case.spec.ts
@@ -5,7 +5,6 @@ import type { ResourceSecurityKind, SecurityFinding, ResourceSecurityScannerPort
 import { Result } from 'shared-kernel';
 
 const usEast = AwsRegion.create('us-east-1');
-const euWest = AwsRegion.create('eu-west-1');
 
 function makeVolume(id: string): Ec2VolumeUnencrypted {
   return new Ec2VolumeUnencrypted({
@@ -26,6 +25,9 @@ function makeScanner(kind: ResourceSecurityKind, responses: Array<Result<Securit
   };
 }
 
+// Job scheduling, concurrency, and per-(scanner,region) error collection are
+// covered generically by shared-scan-coordination's own spec. These tests
+// only exercise the aggregation logic specific to this use case.
 describe('FindResourceSecurityFindingsUseCase', () => {
   it('returns an empty summary when all scanners find nothing', async () => {
     const useCase = new FindResourceSecurityFindingsUseCase([makeScanner('ec2-volume-unencrypted', [Result.ok([])])]);
@@ -52,7 +54,7 @@ describe('FindResourceSecurityFindingsUseCase', () => {
     expect(result.value.countBySeverity).toEqual({ info: 0, warning: 2, critical: 0 });
   });
 
-  it('records a scanError with kind and region when a scanner fails, preserving other results', async () => {
+  it('records a scanError with the real ResourceSecurityKind and region when a scanner fails', async () => {
     const err = new Error('EC2 failed');
     const useCase = new FindResourceSecurityFindingsUseCase([makeScanner('ec2-volume-unencrypted', [Result.fail(err)])]);
 
@@ -62,86 +64,5 @@ describe('FindResourceSecurityFindingsUseCase', () => {
     if (!result.ok) return;
     expect(result.value.findings).toHaveLength(0);
     expect(result.value.scanErrors).toEqual([{ kind: 'ec2-volume-unencrypted', region: 'us-east-1', error: err }]);
-  });
-
-  it('calls a global-scope scanner exactly once, regardless of how many regions were requested', async () => {
-    const calls: string[] = [];
-    const globalScanner: ResourceSecurityScannerPort = {
-      kind: 'iam-root-mfa-disabled',
-      scope: 'global',
-      scan: async (region) => {
-        calls.push(region.code);
-        return Result.ok([]);
-      },
-    };
-
-    const useCase = new FindResourceSecurityFindingsUseCase([globalScanner]);
-    await useCase.execute({ regions: [usEast, euWest] });
-
-    expect(calls).toHaveLength(1);
-  });
-
-  it('still calls a regional scanner once per region alongside a global one', async () => {
-    const regionalCalls: string[] = [];
-    let globalCalls = 0;
-    const scanners: ResourceSecurityScannerPort[] = [
-      {
-        kind: 'ec2-volume-unencrypted',
-        scan: async (region) => {
-          regionalCalls.push(region.code);
-          return Result.ok([]);
-        },
-      },
-      {
-        kind: 'iam-root-mfa-disabled',
-        scope: 'global',
-        scan: async () => {
-          globalCalls++;
-          return Result.ok([]);
-        },
-      },
-    ];
-
-    const useCase = new FindResourceSecurityFindingsUseCase(scanners);
-    await useCase.execute({ regions: [usEast, euWest] });
-
-    expect(regionalCalls.sort()).toEqual(['eu-west-1', 'us-east-1']);
-    expect(globalCalls).toBe(1);
-  });
-
-  it('labels a global scanner scanError as "global", not a real region', async () => {
-    const err = new Error('AccessDenied');
-    const globalScanner: ResourceSecurityScannerPort = {
-      kind: 'iam-root-mfa-disabled',
-      scope: 'global',
-      scan: async () => Result.fail(err),
-    };
-
-    const useCase = new FindResourceSecurityFindingsUseCase([globalScanner]);
-    const result = await useCase.execute({ regions: [usEast, euWest] });
-
-    expect(result.ok).toBe(true);
-    if (!result.ok) return;
-    expect(result.value.scanErrors).toEqual([{ kind: 'iam-root-mfa-disabled', region: 'global', error: err }]);
-  });
-
-  it('bounds in-flight scans to the configured concurrency, across any scanner×region mix', async () => {
-    let inFlight = 0;
-    let peak = 0;
-    const slowScanner = (kind: ResourceSecurityKind): ResourceSecurityScannerPort => ({
-      kind,
-      scan: async () => {
-        inFlight++;
-        peak = Math.max(peak, inFlight);
-        await new Promise((resolve) => setTimeout(resolve, 0));
-        inFlight--;
-        return Result.ok([]);
-      },
-    });
-
-    const useCase = new FindResourceSecurityFindingsUseCase([slowScanner('ec2-volume-unencrypted')], 1);
-    await useCase.execute({ regions: [usEast, euWest] });
-
-    expect(peak).toBe(1);
   });
 });

--- a/libs/resource-security/application/src/use-cases/find-resource-security-findings.use-case.ts
+++ b/libs/resource-security/application/src/use-cases/find-resource-security-findings.use-case.ts
@@ -1,71 +1,34 @@
 // SPDX-License-Identifier: Apache-2.0
-import { Result, createLogger } from 'shared-kernel';
 import type {
-  FindResourceSecurityFindingsRequest,
   FindResourceSecurityFindingsUseCasePort,
   ResourceSecuritySummary,
   SecurityFinding,
-  ResourceSecurityScannerPort,
-  ResourceSecurityScanError,
+  ResourceSecurityKind,
   ResourceSecuritySeverity,
+  AwsRegion,
 } from 'resource-security-domain';
-
-const logger = createLogger('cloudrift:scanner');
-
-/** Same bound as `FindDeadResourcesUseCase`/`AnalyzeCloudWasteUseCase` — see ADR-0064/ADR-0063. */
-const DEFAULT_SCAN_CONCURRENCY = 12;
+import { ScanCoordinatorUseCase } from 'shared-scan-coordination';
+import type { ScanCoordinatorError } from 'shared-scan-coordination';
 
 /**
- * Generic coordinator: every (scanner, region) pair becomes one job in a
- * FIFO queue consumed by a small worker pool with a single global bound.
- * Deliberately mirrors `FindDeadResourcesUseCase`'s shape rather than being
- * shared with it — the two coordinators operate on disjoint finding types.
+ * Orchestration (job scheduling, worker-pool concurrency, per-job error
+ * collection) lives in `ScanCoordinatorUseCase` — shared with
+ * `AnalyzeCloudWasteUseCase`/`FindDeadResourcesUseCase`. This class only
+ * supplies resource-security's own aggregation: counting findings by
+ * severity.
  */
-export class FindResourceSecurityFindingsUseCase implements FindResourceSecurityFindingsUseCasePort {
-  constructor(
-    private readonly scanners: readonly ResourceSecurityScannerPort[],
-    private readonly scanConcurrency = DEFAULT_SCAN_CONCURRENCY,
-  ) {}
-
-  async execute(request: FindResourceSecurityFindingsRequest): Promise<Result<ResourceSecuritySummary>> {
-    const findings: SecurityFinding[] = [];
-    const scanErrors: ResourceSecurityScanError[] = [];
-
-    // Global-scope scanners (IAM, S3 bucket listing, CloudTrail) get exactly
-    // one job, not one per region — the region passed to that one job is
-    // arbitrary (the first requested) and the scanner implementation must
-    // ignore it. Callers always pass at least one region (CLI default,
-    // wizard requires a selection).
-    const jobs = this.scanners.flatMap((scanner) =>
-      scanner.scope === 'global' ? [{ scanner, region: request.regions[0] }] : request.regions.map((region) => ({ scanner, region })),
-    );
-
-    let nextJob = 0;
-    const worker = async (): Promise<void> => {
-      while (nextJob < jobs.length) {
-        const { scanner, region } = jobs[nextJob++];
-        const regionLabel = scanner.scope === 'global' ? 'global' : region.code;
-        const startedAt = Date.now();
-        const result = await scanner.scan(region);
-        const durationMs = Date.now() - startedAt;
-        if (result.ok) {
-          logger.debug(`${scanner.kind} scan ok`, { region: regionLabel, durationMs, findings: result.value.length });
-          findings.push(...result.value);
-        } else {
-          logger.debug(`${scanner.kind} scan failed`, { region: regionLabel, durationMs, error: result.error.message });
-          scanErrors.push({ kind: scanner.kind, region: regionLabel, error: result.error });
-        }
-      }
-    };
-
-    const workerCount = Math.max(1, Math.min(this.scanConcurrency, jobs.length));
-    await Promise.all(Array.from({ length: workerCount }, () => worker()));
-
+export class FindResourceSecurityFindingsUseCase
+  extends ScanCoordinatorUseCase<ResourceSecurityKind, AwsRegion, SecurityFinding, ResourceSecuritySummary>
+  implements FindResourceSecurityFindingsUseCasePort
+{
+  protected override buildSummary(
+    findings: SecurityFinding[],
+    scanErrors: ScanCoordinatorError<ResourceSecurityKind>[],
+  ): ResourceSecuritySummary {
     const countBySeverity: Record<ResourceSecuritySeverity, number> = { info: 0, warning: 0, critical: 0 };
     for (const finding of findings) {
       countBySeverity[finding.severity]++;
     }
-
-    return Result.ok({ findings, countBySeverity, scanErrors });
+    return { findings, countBySeverity, scanErrors };
   }
 }

--- a/libs/resource-security/application/tsconfig.lib.json
+++ b/libs/resource-security/application/tsconfig.lib.json
@@ -12,10 +12,13 @@
   "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"],
   "references": [
     {
-      "path": "../domain/tsconfig.lib.json"
+      "path": "../../shared/scan-coordination/tsconfig.lib.json"
     },
     {
       "path": "../../shared/kernel/tsconfig.lib.json"
+    },
+    {
+      "path": "../domain/tsconfig.lib.json"
     }
   ]
 }

--- a/libs/shared/scan-coordination/eslint.config.mjs
+++ b/libs/shared/scan-coordination/eslint.config.mjs
@@ -1,0 +1,10 @@
+import baseConfig from '../../../eslint.config.mjs';
+
+export default [
+  ...baseConfig,
+  {
+    files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
+    // Override or add rules here
+    rules: {},
+  },
+];

--- a/libs/shared/scan-coordination/jest.config.cjs
+++ b/libs/shared/scan-coordination/jest.config.cjs
@@ -1,0 +1,25 @@
+/** @type {import('@jest/types').Config.InitialOptions} */
+module.exports = {
+  displayName: 'shared-scan-coordination',
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      { tsconfig: '<rootDir>/tsconfig.spec.json', diagnostics: false },
+    ],
+  },
+  moduleFileExtensions: ['ts', 'js', 'json'],
+  testMatch: ['<rootDir>/src/**/*.spec.ts'],
+  collectCoverageFrom: ['<rootDir>/src/**/*.ts', '!<rootDir>/src/**/*.spec.ts', '!<rootDir>/src/index.ts'],
+  coverageThreshold: {
+    global: { statements: 80, branches: 80, functions: 80, lines: 80 },
+  },
+  moduleNameMapper: {
+    '^shared-kernel$': '<rootDir>/../kernel/src/index.ts',
+    '^shared-kernel/(.*)$': '<rootDir>/../kernel/src/$1',
+    '^shared-aws-infra-utils$': '<rootDir>/../aws-infra-utils/src/index.ts',
+    '^shared-aws-infra-utils/(.*)$': '<rootDir>/../aws-infra-utils/src/$1',
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
+};

--- a/libs/shared/scan-coordination/package.json
+++ b/libs/shared/scan-coordination/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "resource-security-application",
+  "name": "shared-scan-coordination",
   "version": "0.0.1",
   "private": true,
   "type": "module",
@@ -17,7 +17,7 @@
   },
   "nx": {
     "tags": [
-      "scope:application"
+      "scope:shared"
     ],
     "targets": {
       "test": {
@@ -26,16 +26,15 @@
           "{workspaceRoot}/coverage/{projectRoot}"
         ],
         "options": {
-          "jestConfig": "libs/resource-security/application/jest.config.cjs",
+          "jestConfig": "libs/shared/scan-coordination/jest.config.cjs",
           "passWithNoTests": true
         }
       }
     }
   },
   "dependencies": {
-    "resource-security-domain": "workspace:*",
     "shared-kernel": "workspace:*",
-    "shared-scan-coordination": "workspace:*",
+    "shared-aws-infra-utils": "workspace:*",
     "tslib": "^2.8.1"
   }
 }

--- a/libs/shared/scan-coordination/src/index.ts
+++ b/libs/shared/scan-coordination/src/index.ts
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+export {
+  ScanCoordinatorUseCase,
+  DEFAULT_SCAN_CONCURRENCY,
+} from './scan-coordinator.use-case';
+export type {
+  ScanCoordinatorError,
+  ScannableRegion,
+  ScannableScanner,
+  ScanCoordinatorRequest,
+} from './scan-coordinator.use-case';

--- a/libs/shared/scan-coordination/src/scan-coordinator.use-case.spec.ts
+++ b/libs/shared/scan-coordination/src/scan-coordinator.use-case.spec.ts
@@ -1,0 +1,234 @@
+// SPDX-License-Identifier: Apache-2.0
+import { Result } from 'shared-kernel';
+import { ScanCoordinatorUseCase } from './scan-coordinator.use-case';
+import type { ScanCoordinatorError, ScannableRegion, ScannableScanner } from './scan-coordinator.use-case';
+
+type FakeKind = 'fake-a' | 'fake-b';
+
+interface FakeFinding {
+  readonly id: string;
+}
+
+interface FakeSummary {
+  readonly findings: FakeFinding[];
+  readonly count: number;
+  readonly scanErrors: ScanCoordinatorError<FakeKind>[];
+}
+
+type FakeRegion = ScannableRegion;
+
+/** Minimal concrete subclass: aggregation just counts findings. */
+class FakeUseCase extends ScanCoordinatorUseCase<FakeKind, FakeRegion, FakeFinding, FakeSummary> {
+  protected buildSummary(findings: FakeFinding[], scanErrors: ScanCoordinatorError<FakeKind>[]): FakeSummary {
+    return { findings, count: findings.length, scanErrors };
+  }
+}
+
+const usEast: FakeRegion = { code: 'us-east-1' };
+const euWest: FakeRegion = { code: 'eu-west-1' };
+
+/** Fake scanner: one response per region, in call order. */
+function makeScanner(
+  kind: FakeKind,
+  responses: Array<Result<FakeFinding[], Error>>,
+  scope?: 'regional' | 'global',
+): ScannableScanner<FakeKind, FakeRegion, FakeFinding> {
+  let call = 0;
+  return {
+    kind,
+    scope,
+    scan: async () => responses[Math.min(call++, responses.length - 1)],
+  };
+}
+
+describe('ScanCoordinatorUseCase', () => {
+  it('returns an empty summary when all scanners find nothing', async () => {
+    const useCase = new FakeUseCase([makeScanner('fake-a', [Result.ok([])])]);
+
+    const result = await useCase.execute({ regions: [usEast] });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.findings).toHaveLength(0);
+    expect(result.value.scanErrors).toHaveLength(0);
+  });
+
+  it('aggregates findings from all scanners via buildSummary', async () => {
+    const useCase = new FakeUseCase([
+      makeScanner('fake-a', [Result.ok([{ id: 'a-1' }, { id: 'a-2' }])]),
+      makeScanner('fake-b', [Result.ok([{ id: 'b-1' }])]),
+    ]);
+
+    const result = await useCase.execute({ regions: [usEast] });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.count).toBe(3);
+  });
+
+  it('records a scanError with kind and region when a scanner fails, preserving other results', async () => {
+    const err = new Error('scanner A failed');
+    const useCase = new FakeUseCase([
+      makeScanner('fake-a', [Result.fail(err)]),
+      makeScanner('fake-b', [Result.ok([{ id: 'b-1' }])]),
+    ]);
+
+    const result = await useCase.execute({ regions: [usEast] });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.findings).toHaveLength(1);
+    expect(result.value.scanErrors).toEqual([{ kind: 'fake-a', region: 'us-east-1', error: err }]);
+  });
+
+  it('keeps results from healthy regions when one region fails', async () => {
+    const err = new Error('eu-west-1 not enabled');
+    const useCase = new FakeUseCase([makeScanner('fake-a', [Result.ok([{ id: 'us' }]), Result.fail(err)])]);
+
+    const result = await useCase.execute({ regions: [usEast, euWest] });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.findings.map((f) => f.id)).toEqual(['us']);
+    expect(result.value.scanErrors).toEqual([{ kind: 'fake-a', region: 'eu-west-1', error: err }]);
+  });
+
+  it('scans every region with every regional scanner', async () => {
+    const calls: string[] = [];
+    const tracking: ScannableScanner<FakeKind, FakeRegion, FakeFinding> = {
+      kind: 'fake-a',
+      scan: async (region) => {
+        calls.push(region.code);
+        return Result.ok([]);
+      },
+    };
+
+    const useCase = new FakeUseCase([tracking]);
+    await useCase.execute({ regions: [usEast, euWest] });
+
+    expect(calls).toEqual(['us-east-1', 'eu-west-1']);
+  });
+
+  it('calls a global-scope scanner exactly once, regardless of how many regions were requested', async () => {
+    const calls: string[] = [];
+    const globalScanner = makeScanner('fake-a', [Result.ok([])], 'global');
+    globalScanner.scan = async (region) => {
+      calls.push(region.code);
+      return Result.ok([]);
+    };
+
+    const useCase = new FakeUseCase([globalScanner]);
+    await useCase.execute({ regions: [usEast, euWest] });
+
+    expect(calls).toHaveLength(1);
+  });
+
+  it('still calls a regional scanner once per region alongside a global one', async () => {
+    const regionalCalls: string[] = [];
+    let globalCalls = 0;
+    const scanners: ScannableScanner<FakeKind, FakeRegion, FakeFinding>[] = [
+      {
+        kind: 'fake-a',
+        scan: async (region) => {
+          regionalCalls.push(region.code);
+          return Result.ok([]);
+        },
+      },
+      {
+        kind: 'fake-b',
+        scope: 'global',
+        scan: async () => {
+          globalCalls++;
+          return Result.ok([]);
+        },
+      },
+    ];
+
+    const useCase = new FakeUseCase(scanners);
+    await useCase.execute({ regions: [usEast, euWest] });
+
+    expect(regionalCalls.sort()).toEqual(['eu-west-1', 'us-east-1']);
+    expect(globalCalls).toBe(1);
+  });
+
+  it('labels a global scanner scanError as "global", not a real region', async () => {
+    const err = new Error('AccessDenied');
+    const globalScanner: ScannableScanner<FakeKind, FakeRegion, FakeFinding> = {
+      kind: 'fake-a',
+      scope: 'global',
+      scan: async () => Result.fail(err),
+    };
+
+    const useCase = new FakeUseCase([globalScanner]);
+    const result = await useCase.execute({ regions: [usEast, euWest] });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.scanErrors).toEqual([{ kind: 'fake-a', region: 'global', error: err }]);
+  });
+
+  it('bounds in-flight scans to the configured concurrency, across any scanner×region mix', async () => {
+    let inFlight = 0;
+    let peak = 0;
+    const slowScanner = (kind: FakeKind): ScannableScanner<FakeKind, FakeRegion, FakeFinding> => ({
+      kind,
+      scan: async () => {
+        inFlight++;
+        peak = Math.max(peak, inFlight);
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        inFlight--;
+        return Result.ok([]);
+      },
+    });
+
+    // 3 scanner × 2 regions = 6 job, pool of 2 workers
+    const useCase = new FakeUseCase([slowScanner('fake-a'), slowScanner('fake-b'), slowScanner('fake-a')], 2);
+    await useCase.execute({ regions: [usEast, euWest] });
+
+    expect(peak).toBe(2);
+  });
+
+  it('scans regions of the same scanner concurrently when a worker is free', async () => {
+    // us-east-1 only unblocks once eu-west-1 starts: with a sequential
+    // per-region loop this test would time out.
+    let releaseFirst!: () => void;
+    const firstBlocked = new Promise<void>((resolve) => (releaseFirst = resolve));
+    const scanner: ScannableScanner<FakeKind, FakeRegion, FakeFinding> = {
+      kind: 'fake-a',
+      scan: async (region) => {
+        if (region.code === 'us-east-1') {
+          await firstBlocked;
+        } else {
+          releaseFirst();
+        }
+        return Result.ok([]);
+      },
+    };
+
+    const useCase = new FakeUseCase([scanner], 2);
+    const result = await useCase.execute({ regions: [usEast, euWest] });
+
+    expect(result.ok).toBe(true);
+  });
+
+  it('uses the default concurrency (12) when none is provided', async () => {
+    let inFlight = 0;
+    let peak = 0;
+    const slowScanner = (kind: FakeKind): ScannableScanner<FakeKind, FakeRegion, FakeFinding> => ({
+      kind,
+      scan: async () => {
+        inFlight++;
+        peak = Math.max(peak, inFlight);
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        inFlight--;
+        return Result.ok([]);
+      },
+    });
+
+    const scanners = Array.from({ length: 20 }, () => slowScanner('fake-a'));
+    const useCase = new FakeUseCase(scanners);
+    await useCase.execute({ regions: [usEast] });
+
+    expect(peak).toBe(12);
+  });
+});

--- a/libs/shared/scan-coordination/src/scan-coordinator.use-case.ts
+++ b/libs/shared/scan-coordination/src/scan-coordinator.use-case.ts
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+import { Result, createLogger } from 'shared-kernel';
+import { mapWithConcurrency } from 'shared-aws-infra-utils';
+
+const logger = createLogger('cloudrift:scanner');
+
+/**
+ * Global bound on in-flight (scanner, region) scans, any mix. Restored to 12
+ * (2026-07-13, ADR-0064) after root-causing a socket hang up that briefly
+ * dropped this to 1: it was a client-side bug (every scanner shared one
+ * `NodeHttpHandler`, so one finishing destroyed another's in-flight
+ * connections), not a real AWS reliability limit. Re-verified against real
+ * AWS post-fix: 0 errors, identical findings, at 1/3/5/10/20 in-flight scans
+ * alike. Overridable per domain via the constructor's second argument (e.g.
+ * `CLOUDRIFT_SCAN_CONCURRENCY`, see `analyze-waste.composition.ts`).
+ */
+export const DEFAULT_SCAN_CONCURRENCY = 12;
+
+export interface ScanCoordinatorError<TKind extends string = string> {
+  readonly kind: TKind;
+  readonly region: string;
+  readonly error: Error;
+}
+
+export interface ScannableRegion {
+  readonly code: string;
+}
+
+export interface ScannableScanner<TKind extends string, TRegion extends ScannableRegion, TFinding> {
+  readonly kind: TKind;
+  readonly scope?: 'regional' | 'global';
+  scan(region: TRegion): Promise<Result<TFinding[], Error>>;
+}
+
+export interface ScanCoordinatorRequest<TRegion extends ScannableRegion> {
+  readonly regions: readonly TRegion[];
+}
+
+/**
+ * Shared orchestration for cloudrift's scan domains (cloud-cost,
+ * dead-resources, resource-security): every (scanner, region) pair becomes
+ * one job in a FIFO queue consumed by a bounded worker pool. Jobs are queued
+ * scanner-major, so the first batch workers pull spreads across regions
+ * instead of concentrating on the first one. Errors are collected per
+ * (scanner, region) — the failure of one job does not discard the results
+ * of the others, nor does it fail the use case as a whole.
+ *
+ * Global-scope scanners get exactly one job, not one per region — an AWS
+ * global service (e.g. IAM) has no per-region data to deduplicate. The
+ * region passed to that one job is arbitrary (the first requested) and the
+ * scanner implementation must ignore it. Callers always pass at least one
+ * region (CLI default, wizard requires a selection).
+ *
+ * Subclasses supply only the domain-specific final aggregation (dollar
+ * totals, severity counts, ...) via `buildSummary`.
+ */
+export abstract class ScanCoordinatorUseCase<
+  TKind extends string,
+  TRegion extends ScannableRegion,
+  TFinding,
+  TSummary,
+> {
+  constructor(
+    private readonly scanners: readonly ScannableScanner<TKind, TRegion, TFinding>[],
+    private readonly scanConcurrency: number = DEFAULT_SCAN_CONCURRENCY,
+  ) {}
+
+  protected abstract buildSummary(findings: TFinding[], scanErrors: ScanCoordinatorError<TKind>[]): TSummary;
+
+  async execute(request: ScanCoordinatorRequest<TRegion>): Promise<Result<TSummary>> {
+    const findings: TFinding[] = [];
+    const scanErrors: ScanCoordinatorError<TKind>[] = [];
+
+    const jobs = this.scanners.flatMap((scanner) =>
+      scanner.scope === 'global' ? [{ scanner, region: request.regions[0] }] : request.regions.map((region) => ({ scanner, region })),
+    );
+
+    await mapWithConcurrency(jobs, this.scanConcurrency, async ({ scanner, region }) => {
+      const regionLabel = scanner.scope === 'global' ? 'global' : region.code;
+      const startedAt = Date.now();
+      const result = await scanner.scan(region);
+      const durationMs = Date.now() - startedAt;
+      if (result.ok) {
+        logger.debug(`${scanner.kind} scan ok`, { region: regionLabel, durationMs, findings: result.value.length });
+        findings.push(...result.value);
+      } else {
+        logger.debug(`${scanner.kind} scan failed`, { region: regionLabel, durationMs, error: result.error.message });
+        scanErrors.push({ kind: scanner.kind, region: regionLabel, error: result.error });
+      }
+    });
+
+    return Result.ok(this.buildSummary(findings, scanErrors));
+  }
+}

--- a/libs/shared/scan-coordination/tsconfig.json
+++ b/libs/shared/scan-coordination/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/libs/shared/scan-coordination/tsconfig.lib.json
+++ b/libs/shared/scan-coordination/tsconfig.lib.json
@@ -12,13 +12,10 @@
   "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"],
   "references": [
     {
-      "path": "../../shared/scan-coordination/tsconfig.lib.json"
+      "path": "../aws-infra-utils/tsconfig.lib.json"
     },
     {
-      "path": "../../shared/kernel/tsconfig.lib.json"
-    },
-    {
-      "path": "../domain/tsconfig.lib.json"
+      "path": "../kernel/tsconfig.lib.json"
     }
   ]
 }

--- a/libs/shared/scan-coordination/tsconfig.spec.json
+++ b/libs/shared/scan-coordination/tsconfig.spec.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "outDir": "./dist/test",
+    "types": ["jest", "node"],
+    "strict": true,
+    "esModuleInterop": true
+  },
+  "include": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -302,6 +302,9 @@ importers:
       shared-kernel:
         specifier: workspace:*
         version: link:../../shared/kernel
+      shared-scan-coordination:
+        specifier: workspace:*
+        version: link:../../shared/scan-coordination
       tslib:
         specifier: ^2.8.1
         version: 2.8.1
@@ -461,6 +464,9 @@ importers:
       shared-kernel:
         specifier: workspace:*
         version: link:../../shared/kernel
+      shared-scan-coordination:
+        specifier: workspace:*
+        version: link:../../shared/scan-coordination
       tslib:
         specifier: ^2.8.1
         version: 2.8.1
@@ -557,6 +563,9 @@ importers:
       shared-kernel:
         specifier: workspace:*
         version: link:../../shared/kernel
+      shared-scan-coordination:
+        specifier: workspace:*
+        version: link:../../shared/scan-coordination
       tslib:
         specifier: ^2.8.1
         version: 2.8.1
@@ -623,6 +632,18 @@ importers:
 
   libs/shared/kernel:
     dependencies:
+      tslib:
+        specifier: ^2.8.1
+        version: 2.8.1
+
+  libs/shared/scan-coordination:
+    dependencies:
+      shared-aws-infra-utils:
+        specifier: workspace:*
+        version: link:../aws-infra-utils
+      shared-kernel:
+        specifier: workspace:*
+        version: link:../kernel
       tslib:
         specifier: ^2.8.1
         version: 2.8.1

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -50,6 +50,9 @@
     },
     {
       "path": "./libs/mcp-server/application"
+    },
+    {
+      "path": "./libs/shared/scan-coordination"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Replace the ASCII "Open ->" link label in PDF report tables with a small vector-drawn arrow icon (↗), drawn via pdfkit's native path API — the base-14 Helvetica font has no glyph for unicode arrows, so this avoids needing an embedded font or image asset.
- Unify the three near-identical scan-orchestration use-cases (`AnalyzeCloudWasteUseCase`, `FindDeadResourcesUseCase`, `FindResourceSecurityFindingsUseCase`) into a shared `ScanCoordinatorUseCase` base class (new `libs/shared/scan-coordination` lib, `scope:shared`), removing ~70-100 duplicated lines per use-case. See ADR-0095.

## Test plan
- [x] `nx run-many --target={build,lint,typecheck,test} --all --coverage` green across all affected projects
- [x] `waste-report.pdf-formatter.spec.ts` / `severity-report.formatter.spec.ts` pass
- [x] Sample PDF generated and visually reviewed (link icon renders correctly)
- [x] Manual CLI smoke test against LocalStack/real AWS (optional, read-only scan)
