### PR TITLE
feat(cli): cross-account scanning via --assume-role-arn

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -196,6 +196,7 @@
     "@clack/prompts": "^1.7.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@smithy/node-http-handler": "^4.9.11",
+    "@smithy/types": "^4.9.0",
     "chalk": "^4.1.2",
     "cli-table3": "^0.6.5",
     "cloud-cost-application": "workspace:*",
@@ -213,6 +214,7 @@
     "resource-security-application": "workspace:*",
     "resource-security-domain": "workspace:*",
     "resource-security-infrastructure-aws-adapter": "workspace:*",
+    "shared-aws-infra-utils": "workspace:*",
     "shared-kernel": "workspace:*",
     "zod": "^4.4.3"
   }

--- a/apps/cli/src/commands/always-on-scanners.ts
+++ b/apps/cli/src/commands/always-on-scanners.ts
@@ -72,33 +72,41 @@ import type { ScannerBuildContext, ScannerRegistration } from './scanner-registr
  * that never need `--live-pricing`. See {@link LIVE_PRICING_SCANNERS} in
  * `./live-pricing-scanners` for the per-instance-type-priced counterpart.
  */
+// `ctx.credentials` (set only for --assume-role-arn cross-account scans)
+// slots in at a different position per scanner: "flat" scanners take it
+// right after `ctx.accountId` (before the policy); `CloudWatchIdleScanner`
+// subclasses take it as their own LAST constructor param (forwarded to the
+// shared base class), so it's appended after their other args instead.
 export const ALWAYS_ON_SCANNERS: ScannerRegistration<ScannerBuildContext>[] = [
   {
     kind: 'ebs-volume',
-    create: (ctx) => new AwsEbsVolumeScanner(ctx.pricing, ctx.accountId, new EbsVolumeWastePolicy(ctx.policyOptions)),
+    create: (ctx) =>
+      new AwsEbsVolumeScanner(ctx.pricing, ctx.accountId, ctx.credentials, new EbsVolumeWastePolicy(ctx.policyOptions)),
   },
   {
     kind: 'elastic-ip',
-    create: (ctx) => new AwsElasticIpScanner(ctx.pricing, ctx.accountId, new ElasticIpWastePolicy(ctx.policyOptions)),
+    create: (ctx) =>
+      new AwsElasticIpScanner(ctx.pricing, ctx.accountId, ctx.credentials, new ElasticIpWastePolicy(ctx.policyOptions)),
   },
   {
     kind: 'rds-instance',
     create: (ctx) =>
-      new AwsRdsInstanceScanner(ctx.pricing, ctx.accountId, new RdsInstanceWastePolicy(ctx.policyOptions)),
+      new AwsRdsInstanceScanner(ctx.pricing, ctx.accountId, ctx.credentials, new RdsInstanceWastePolicy(ctx.policyOptions)),
   },
   {
     kind: 'load-balancer',
     create: (ctx) =>
-      new AwsLoadBalancerScanner(ctx.pricing, ctx.accountId, new LoadBalancerWastePolicy(ctx.policyOptions)),
+      new AwsLoadBalancerScanner(ctx.pricing, ctx.accountId, ctx.credentials, new LoadBalancerWastePolicy(ctx.policyOptions)),
   },
   {
     kind: 'ec2-instance',
-    create: (ctx) => new AwsEc2InstanceScanner(ctx.pricing, ctx.accountId, new Ec2InstanceWastePolicy(ctx.policyOptions)),
+    create: (ctx) =>
+      new AwsEc2InstanceScanner(ctx.pricing, ctx.accountId, ctx.credentials, new Ec2InstanceWastePolicy(ctx.policyOptions)),
   },
   {
     kind: 'ebs-snapshot',
     create: (ctx) =>
-      new AwsEbsSnapshotScanner(ctx.pricing, ctx.accountId, new EbsSnapshotWastePolicy(ctx.policyOptions)),
+      new AwsEbsSnapshotScanner(ctx.pricing, ctx.accountId, ctx.credentials, new EbsSnapshotWastePolicy(ctx.policyOptions)),
   },
   {
     kind: 'nat-gateway',
@@ -108,11 +116,13 @@ export const ALWAYS_ON_SCANNERS: ScannerRegistration<ScannerBuildContext>[] = [
         ctx.accountId,
         new NatGatewayWastePolicy(ctx.policyOptions),
         ctx.cloudwatchWindowHours,
+        ctx.credentials,
       ),
   },
   {
     kind: 'ebs-gp2-upgrade',
-    create: (ctx) => new AwsGp2UpgradeScanner(ctx.pricing, ctx.accountId, new EbsGp2UpgradePolicy(ctx.policyOptions)),
+    create: (ctx) =>
+      new AwsGp2UpgradeScanner(ctx.pricing, ctx.accountId, ctx.credentials, new EbsGp2UpgradePolicy(ctx.policyOptions)),
   },
   {
     kind: 'ebs-idle',
@@ -122,20 +132,22 @@ export const ALWAYS_ON_SCANNERS: ScannerRegistration<ScannerBuildContext>[] = [
         ctx.accountId,
         new EbsIdlePolicy(ctx.policyOptions, ctx.config.thresholds?.ebsIdleMaxOps ?? 0),
         ctx.cloudwatchWindowHours,
+        ctx.credentials,
       ),
   },
   {
     kind: 'log-group',
-    create: (ctx) => new AwsLogGroupScanner(ctx.pricing, ctx.accountId, new LogGroupWastePolicy(ctx.policyOptions)),
+    create: (ctx) =>
+      new AwsLogGroupScanner(ctx.pricing, ctx.accountId, ctx.credentials, new LogGroupWastePolicy(ctx.policyOptions)),
   },
   {
     kind: 'eni-orphaned',
-    create: (ctx) => new AwsEniOrphanedScanner(ctx.accountId, new OrphanedEniWastePolicy(ctx.policyOptions)),
+    create: (ctx) => new AwsEniOrphanedScanner(ctx.accountId, ctx.credentials, new OrphanedEniWastePolicy(ctx.policyOptions)),
   },
   {
     kind: 's3-no-lifecycle',
     create: (ctx) =>
-      new AwsS3NoLifecycleScanner(ctx.pricing, ctx.accountId, new S3NoLifecyclePolicy(ctx.policyOptions)),
+      new AwsS3NoLifecycleScanner(ctx.pricing, ctx.accountId, ctx.credentials, new S3NoLifecyclePolicy(ctx.policyOptions)),
   },
   {
     kind: 'lambda-underutilized',
@@ -144,6 +156,7 @@ export const ALWAYS_ON_SCANNERS: ScannerRegistration<ScannerBuildContext>[] = [
         ctx.accountId,
         new LambdaUnderutilizedPolicy(ctx.policyOptions, ctx.config.thresholds?.lambdaInvocationsMin ?? 0),
         ctx.utilizationWindowHours,
+        ctx.credentials,
       ),
   },
   {
@@ -154,6 +167,7 @@ export const ALWAYS_ON_SCANNERS: ScannerRegistration<ScannerBuildContext>[] = [
         ctx.accountId,
         new EfsUnusedPolicy(ctx.policyOptions, ctx.config.thresholds?.efsIoBytesMin ?? 0),
         ctx.cloudwatchWindowHours,
+        ctx.credentials,
       ),
   },
   {
@@ -167,6 +181,7 @@ export const ALWAYS_ON_SCANNERS: ScannerRegistration<ScannerBuildContext>[] = [
           ctx.config.thresholds?.dynamoCapacityUtilizationPercent ?? 10,
         ),
         ctx.utilizationWindowHours,
+        ctx.credentials,
       ),
   },
   // Phase 5.5 (ADR-0038): low-cardinality fixed-SKU prices, always-on like
@@ -174,7 +189,13 @@ export const ALWAYS_ON_SCANNERS: ScannerRegistration<ScannerBuildContext>[] = [
   {
     kind: 'fsx-idle-filesystem',
     create: (ctx) =>
-      new AwsFsxIdleScanner(ctx.pricing, ctx.accountId, new FsxIdleFilesystemPolicy(ctx.policyOptions), ctx.cloudwatchWindowHours),
+      new AwsFsxIdleScanner(
+        ctx.pricing,
+        ctx.accountId,
+        new FsxIdleFilesystemPolicy(ctx.policyOptions),
+        ctx.cloudwatchWindowHours,
+        ctx.credentials,
+      ),
   },
   {
     kind: 'vpn-connection-idle',
@@ -184,6 +205,7 @@ export const ALWAYS_ON_SCANNERS: ScannerRegistration<ScannerBuildContext>[] = [
         ctx.accountId,
         new VpnConnectionIdlePolicy(ctx.policyOptions),
         ctx.cloudwatchWindowHours,
+        ctx.credentials,
       ),
   },
   {
@@ -194,6 +216,7 @@ export const ALWAYS_ON_SCANNERS: ScannerRegistration<ScannerBuildContext>[] = [
         ctx.accountId,
         new TransitGatewayIdleAttachmentPolicy(ctx.policyOptions),
         ctx.cloudwatchWindowHours,
+        ctx.credentials,
       ),
   },
   {
@@ -204,12 +227,19 @@ export const ALWAYS_ON_SCANNERS: ScannerRegistration<ScannerBuildContext>[] = [
         ctx.accountId,
         new KinesisProvisionedIdleStreamPolicy(ctx.policyOptions),
         ctx.cloudwatchWindowHours,
+        ctx.credentials,
       ),
   },
   // Phase 6.1 (ADR-0065): serverless orphans vertical.
   {
     kind: 'sqs-dlq-abandoned',
-    create: (ctx) => new AwsSqsDlqAbandonedScanner(ctx.accountId, new SqsDlqAbandonedWastePolicy(ctx.policyOptions)),
+    create: (ctx) =>
+      new AwsSqsDlqAbandonedScanner(
+        ctx.accountId,
+        new SqsDlqAbandonedWastePolicy(ctx.policyOptions),
+        undefined,
+        ctx.credentials,
+      ),
   },
   {
     kind: 'lambda-loggroup-orphaned',
@@ -217,6 +247,7 @@ export const ALWAYS_ON_SCANNERS: ScannerRegistration<ScannerBuildContext>[] = [
       new AwsLambdaLogGroupOrphanedScanner(
         ctx.pricing,
         ctx.accountId,
+        ctx.credentials,
         new LambdaLogGroupOrphanedPolicy(ctx.policyOptions),
       ),
   },
@@ -234,6 +265,7 @@ export const ALWAYS_ON_SCANNERS: ScannerRegistration<ScannerBuildContext>[] = [
           ctx.config.thresholds?.auroraMinAcuUtilizationPercent ?? 50,
         ),
         ctx.utilizationWindowHours,
+        ctx.credentials,
       ),
   },
   // Phase 6.3 (ADR-0065): SageMaker vertical. A model's own cost is $0; the
@@ -241,7 +273,12 @@ export const ALWAYS_ON_SCANNERS: ScannerRegistration<ScannerBuildContext>[] = [
   {
     kind: 'sagemaker-training-orphaned',
     create: (ctx) =>
-      new AwsSageMakerTrainingOrphanedScanner(ctx.pricing, ctx.accountId, new SageMakerTrainingOrphanedPolicy(ctx.policyOptions)),
+      new AwsSageMakerTrainingOrphanedScanner(
+        ctx.pricing,
+        ctx.accountId,
+        ctx.credentials,
+        new SageMakerTrainingOrphanedPolicy(ctx.policyOptions),
+      ),
   },
   // Phase 6.4 (ADR-0065): Dev/PR ghost environments. $0 hygiene flag (see
   // EnvironmentGhost), so always-on like sqs-dlq-abandoned/eni-orphaned.
@@ -251,6 +288,7 @@ export const ALWAYS_ON_SCANNERS: ScannerRegistration<ScannerBuildContext>[] = [
       const inactivityDays = ctx.config.environmentDetection?.inactivityDays ?? 7;
       return new AwsEnvironmentGhostScanner(
         ctx.accountId,
+        ctx.credentials,
         new EnvironmentGhostPolicy(ctx.policyOptions, inactivityDays),
         ctx.config.environmentDetection?.tagKeys,
         ctx.config.environmentDetection?.namingPatterns,
@@ -262,18 +300,20 @@ export const ALWAYS_ON_SCANNERS: ScannerRegistration<ScannerBuildContext>[] = [
   // pricing, so always-on (ADR-0037) — pairs with eks-node-overprovisioned above.
   {
     kind: 'eks-orphan-pvc',
-    create: (ctx) => new AwsEksOrphanPvcScanner(ctx.pricing, ctx.accountId, new EksOrphanPvcPolicy(ctx.policyOptions)),
+    create: (ctx) =>
+      new AwsEksOrphanPvcScanner(ctx.pricing, ctx.accountId, ctx.credentials, new EksOrphanPvcPolicy(ctx.policyOptions)),
   },
   // Added 2026-07-22: all fixed at-rest cost, always-on like the rest of
   // the EC2/S3/RDS scanners above.
   {
     kind: 'ami-unused',
-    create: (ctx) => new AwsAmiUnusedScanner(ctx.pricing, ctx.accountId, new AmiUnusedPolicy(ctx.policyOptions)),
+    create: (ctx) =>
+      new AwsAmiUnusedScanner(ctx.pricing, ctx.accountId, ctx.credentials, new AmiUnusedPolicy(ctx.policyOptions)),
   },
   {
     kind: 'ecr-image-untagged',
     create: (ctx) =>
-      new AwsEcrImageUntaggedScanner(ctx.pricing, ctx.accountId, new EcrImageUntaggedPolicy(ctx.policyOptions)),
+      new AwsEcrImageUntaggedScanner(ctx.pricing, ctx.accountId, ctx.credentials, new EcrImageUntaggedPolicy(ctx.policyOptions)),
   },
   {
     kind: 's3-multipart-upload-abandoned',
@@ -281,18 +321,29 @@ export const ALWAYS_ON_SCANNERS: ScannerRegistration<ScannerBuildContext>[] = [
       new AwsS3MultipartUploadAbandonedScanner(
         ctx.pricing,
         ctx.accountId,
+        ctx.credentials,
         new S3MultipartUploadAbandonedPolicy(ctx.policyOptions),
       ),
   },
   {
     kind: 'rds-manual-snapshot-old',
     create: (ctx) =>
-      new AwsRdsManualSnapshotOldScanner(ctx.pricing, ctx.accountId, new RdsManualSnapshotOldPolicy(ctx.policyOptions)),
+      new AwsRdsManualSnapshotOldScanner(
+        ctx.pricing,
+        ctx.accountId,
+        ctx.credentials,
+        new RdsManualSnapshotOldPolicy(ctx.policyOptions),
+      ),
   },
   {
     kind: 'secretsmanager-unused',
     create: (ctx) =>
-      new AwsSecretsManagerUnusedScanner(ctx.pricing, ctx.accountId, new SecretsManagerUnusedPolicy(ctx.policyOptions)),
+      new AwsSecretsManagerUnusedScanner(
+        ctx.pricing,
+        ctx.accountId,
+        ctx.credentials,
+        new SecretsManagerUnusedPolicy(ctx.policyOptions),
+      ),
   },
   // Added 2026-07-23: flat $1/mo-per-pipeline fixed cost (ADR-0037 criteria),
   // moved here from the dead-resources candidate list — see wasted-resource.ts.
@@ -302,6 +353,7 @@ export const ALWAYS_ON_SCANNERS: ScannerRegistration<ScannerBuildContext>[] = [
       new AwsCodepipelinePipelineStaleScanner(
         ctx.pricing,
         ctx.accountId,
+        ctx.credentials,
         new CodepipelinePipelineStalePolicy(ctx.policyOptions),
       ),
   },

--- a/apps/cli/src/commands/analyze-waste.command.ts
+++ b/apps/cli/src/commands/analyze-waste.command.ts
@@ -18,7 +18,7 @@ import {
   defaultAnalyzeDeps,
   type AnalyzeDeps,
 } from './analyze-waste.composition';
-import { resolveMinAgeDays, resolveExplicitScanners, resolveRegions } from './resolve-options';
+import { resolveMinAgeDays, resolveExplicitScanners, resolveRegions, resolveCredentials } from './resolve-options';
 import { writeArtifacts, applyCostGate } from './post-analysis';
 import { reportCliError as fail } from './report-cli-error';
 
@@ -30,6 +30,8 @@ const DEFAULT_UTILIZATION_WINDOW_HOURS = 168;
 export interface AnalyzeWasteOptions {
   regions: string[];
   accountId?: string;
+  assumeRoleArn?: string;
+  externalId?: string;
   config?: string;
   format?: string;
   livePricing?: boolean;
@@ -117,8 +119,12 @@ export async function analyzeWasteCommand(
   if (!regionsResult.ok) return fail(regionsResult.error.message);
   const { regions, skipped } = regionsResult.value;
 
+  const credentialsResult = await resolveCredentials(options);
+  if (!credentialsResult.ok) return fail(credentialsResult.error.message);
+  const credentials = credentialsResult.value;
+
   const accountId =
-    options.accountId ?? (await deps.resolveAccountId()) ?? 'unknown';
+    options.accountId ?? (await deps.resolveAccountId(credentials)) ?? 'unknown';
   // accountId is only ever 'unknown' when both --account-id was omitted and
   // STS GetCallerIdentity failed (e.g. credentials lack that permission) —
   // surfaced here so the omission in the report isn't silent, with the
@@ -150,6 +156,7 @@ export async function analyzeWasteCommand(
     regions,
     config,
     accountId,
+    credentials,
     livePricing: options.livePricing === true,
     policyOptions,
     cloudwatchWindowHours,

--- a/apps/cli/src/commands/analyze-waste.composition.ts
+++ b/apps/cli/src/commands/analyze-waste.composition.ts
@@ -8,6 +8,7 @@ import type {
 } from 'cloud-cost-domain';
 import { AnalyzeCloudWasteUseCase } from 'cloud-cost-application';
 import { resolveAwsAccountId } from 'cloud-cost-infrastructure-aws-adapter';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { loadConfig, type CloudriftConfig, type ConfigError } from '../config/cloudrift.config';
 import { buildPricing } from './pricing.factory';
 import { buildScanners } from './scanner-registry';
@@ -17,6 +18,8 @@ export interface AnalysisContext {
   regions: AwsRegion[];
   config: CloudriftConfig;
   accountId: string;
+  /** Set only when scanning cross-account via --assume-role-arn; undefined uses the ambient credential chain. */
+  credentials?: AwsCredentialIdentityProvider;
   livePricing: boolean;
   policyOptions: WastePolicyOptions;
   cloudwatchWindowHours: number;
@@ -40,7 +43,7 @@ export interface Analysis {
  */
 export interface AnalyzeDeps {
   loadConfig(cwd: string, explicitPath?: string): Promise<Result<CloudriftConfig, ConfigError>>;
-  resolveAccountId(): Promise<string | undefined>;
+  resolveAccountId(credentials?: AwsCredentialIdentityProvider): Promise<string | undefined>;
   createAnalysis(ctx: AnalysisContext): Promise<Analysis>;
 }
 
@@ -64,6 +67,7 @@ async function defaultCreateAnalysis(ctx: AnalysisContext): Promise<Analysis> {
     {
       pricing,
       accountId: ctx.accountId,
+      credentials: ctx.credentials,
       policyOptions: ctx.policyOptions,
       cloudwatchWindowHours: ctx.cloudwatchWindowHours,
       utilizationWindowHours: ctx.utilizationWindowHours,

--- a/apps/cli/src/commands/cost-analytics.composition.ts
+++ b/apps/cli/src/commands/cost-analytics.composition.ts
@@ -3,6 +3,7 @@ import type { Result } from 'shared-kernel';
 import type { CostExplorerPort } from 'cost-analytics-domain';
 import { resolveAwsAccountId } from 'cloud-cost-infrastructure-aws-adapter';
 import { AwsCostExplorerAdapter, CachedCostExplorerAdapter } from 'cost-analytics-infrastructure-aws-adapter';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { loadConfig, type CloudriftConfig, type ConfigError } from '../config/cloudrift.config';
 
 /**
@@ -13,13 +14,13 @@ import { loadConfig, type CloudriftConfig, type ConfigError } from '../config/cl
  */
 export interface CostAnalyticsDeps {
   loadConfig(cwd: string, explicitPath?: string): Promise<Result<CloudriftConfig, ConfigError>>;
-  resolveAccountId(): Promise<string | undefined>;
-  createCostExplorer(accountId: string, refreshCache: boolean): CostExplorerPort;
+  resolveAccountId(credentials?: AwsCredentialIdentityProvider): Promise<string | undefined>;
+  createCostExplorer(accountId: string, refreshCache: boolean, credentials?: AwsCredentialIdentityProvider): CostExplorerPort;
 }
 
 export const defaultCostAnalyticsDeps: CostAnalyticsDeps = {
   loadConfig,
   resolveAccountId: resolveAwsAccountId,
-  createCostExplorer: (accountId, refreshCache) =>
-    new CachedCostExplorerAdapter(new AwsCostExplorerAdapter(), accountId, { refresh: refreshCache }),
+  createCostExplorer: (accountId, refreshCache, credentials) =>
+    new CachedCostExplorerAdapter(new AwsCostExplorerAdapter(credentials), accountId, { refresh: refreshCache }),
 };

--- a/apps/cli/src/commands/cost.command.ts
+++ b/apps/cli/src/commands/cost.command.ts
@@ -14,9 +14,12 @@ import { defaultCostAnalyticsDeps, type CostAnalyticsDeps } from './cost-analyti
 import { applyCostTrendGate } from './post-analysis';
 import { reportCliError as fail } from './report-cli-error';
 import { OUTPUT_FORMATS, isOutputFormat } from '../output-format';
+import { resolveCredentials } from './resolve-options';
 
 export interface CostCommandOptions {
   accountId?: string;
+  assumeRoleArn?: string;
+  externalId?: string;
   config?: string;
   format?: string;
   failOnIncrease?: string;
@@ -66,12 +69,16 @@ export async function costCommand(
   const proceed = await confirmCostExplorerCharge({ yes: options.yes === true, silent });
   if (!proceed) return;
 
-  const accountId = options.accountId ?? (await deps.resolveAccountId()) ?? 'unknown';
+  const credentialsResult = await resolveCredentials(options);
+  if (!credentialsResult.ok) return fail(credentialsResult.error.message);
+  const credentials = credentialsResult.value;
+
+  const accountId = options.accountId ?? (await deps.resolveAccountId(credentials)) ?? 'unknown';
   if (accountId === 'unknown') {
     info(chalk.dim('  Could not resolve the AWS account ID via STS — pass --account-id to set it explicitly.'));
   }
 
-  const costExplorer = deps.createCostExplorer(accountId, options.refreshCache === true);
+  const costExplorer = deps.createCostExplorer(accountId, options.refreshCache === true, credentials);
   const spinner = quietStdout ? undefined : await startScanSpinner('  Fetching from Cost Explorer...');
   const result = await new CompareCostUseCase(costExplorer).execute({});
   spinner?.stop(chalk.dim('  Done.'));

--- a/apps/cli/src/commands/dead-resources.command.ts
+++ b/apps/cli/src/commands/dead-resources.command.ts
@@ -13,12 +13,15 @@ import { startScanSpinner } from '../wizard/scan-spinner';
 import { defaultDeadResourcesDeps, type DeadResourcesDeps } from './dead-resources.composition';
 import { reportCliError as fail } from './report-cli-error';
 import { OUTPUT_FORMATS, isOutputFormat } from '../output-format';
+import { resolveCredentials } from './resolve-options';
 
 export type { DeadResourcesDeps };
 
 export interface DeadResourcesCommandOptions {
   regions: string[];
   accountId?: string;
+  assumeRoleArn?: string;
+  externalId?: string;
   format?: string;
   minAgeDays?: string;
   ignoreTag?: string;
@@ -90,7 +93,11 @@ export async function deadResourcesCommand(
     console.log(`\n${renderBrandMark()}\n`);
   }
 
-  const accountId = options.accountId ?? (await deps.resolveAccountId()) ?? 'unknown';
+  const credentialsResult = await resolveCredentials(options);
+  if (!credentialsResult.ok) return fail(credentialsResult.error.message);
+  const credentials = credentialsResult.value;
+
+  const accountId = options.accountId ?? (await deps.resolveAccountId(credentials)) ?? 'unknown';
   if (accountId === 'unknown') {
     info(chalk.dim('  Could not resolve the AWS account ID via STS — pass --account-id to set it explicitly.'));
   }
@@ -108,7 +115,7 @@ export async function deadResourcesCommand(
     ignoreTag: options.ignoreTag ?? DEFAULT_IGNORE_TAG,
   };
 
-  const { useCase } = await deps.createAnalysis({ regions, accountId, policyOptions, scannerKinds });
+  const { useCase } = await deps.createAnalysis({ regions, accountId, credentials, policyOptions, scannerKinds });
 
   const spinner = quietStdout ? undefined : await startScanSpinner('  Rolling through your account...');
   const result = await useCase.execute({ regions });

--- a/apps/cli/src/commands/dead-resources.composition.ts
+++ b/apps/cli/src/commands/dead-resources.composition.ts
@@ -27,6 +27,7 @@ import {
   StepfunctionsStatemachineUnusedPolicy,
 } from 'dead-resources-domain';
 import { FindDeadResourcesUseCase } from 'dead-resources-application';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import {
   AwsEc2KeyPairUnusedScanner,
   AwsEc2RiExpiringSoonScanner,
@@ -52,6 +53,8 @@ import { resolveAwsAccountId } from 'cloud-cost-infrastructure-aws-adapter';
 /** Everything a dead-resource scanner factory may need to build its instance. */
 export interface DeadResourceScanContext {
   accountId: string;
+  /** Set only when scanning cross-account via --assume-role-arn; undefined uses the ambient credential chain. */
+  credentials?: AwsCredentialIdentityProvider;
   policyOptions: DeadResourcePolicyOptions;
 }
 
@@ -64,6 +67,7 @@ export interface DeadResourceScanContext {
 export interface DeadResourceAnalysisContext {
   regions: AwsRegion[];
   accountId: string;
+  credentials?: AwsCredentialIdentityProvider;
   policyOptions: DeadResourcePolicyOptions;
   /** Restrict the scan to these kinds (from the wizard). Undefined runs every check. */
   scannerKinds?: DeadResourceKind[];
@@ -74,7 +78,7 @@ export interface DeadResourceAnalysis {
 }
 
 export interface DeadResourcesDeps {
-  resolveAccountId(): Promise<string | undefined>;
+  resolveAccountId(credentials?: AwsCredentialIdentityProvider): Promise<string | undefined>;
   createAnalysis(ctx: DeadResourceAnalysisContext): Promise<DeadResourceAnalysis>;
 }
 
@@ -87,29 +91,29 @@ export interface DeadResourcesDeps {
  */
 function buildScanners(ctx: DeadResourceScanContext): DeadResourceScannerPort[] {
   return [
-    new AwsEc2KeyPairUnusedScanner(ctx.accountId, new Ec2KeyPairUnusedPolicy(ctx.policyOptions)),
-    new AwsEc2RiExpiringSoonScanner(ctx.accountId, new Ec2RiExpiringSoonPolicy(ctx.policyOptions)),
-    new AwsIamUserInactiveScanner(ctx.accountId, new IamUserInactivePolicy(ctx.policyOptions)),
-    new AwsIamPolicyUnattachedScanner(ctx.accountId, new IamPolicyUnattachedPolicy(ctx.policyOptions)),
-    new AwsIamRoleUnusedScanner(ctx.accountId, new IamRoleUnusedPolicy(ctx.policyOptions)),
-    new AwsIamAccessKeyStaleScanner(ctx.accountId, new IamAccessKeyStalePolicy(ctx.policyOptions)),
-    new AwsEc2SecurityGroupUnusedScanner(ctx.accountId, new Ec2SecurityGroupUnusedPolicy(ctx.policyOptions)),
-    new AwsLogsLogGroupEmptyScanner(ctx.accountId, new LogsLogGroupEmptyPolicy(ctx.policyOptions)),
-    new AwsAcmCertificateUnusedScanner(ctx.accountId, new AcmCertificateUnusedPolicy(ctx.policyOptions)),
-    new AwsRoute53HostedZoneEmptyScanner(ctx.accountId, new Route53HostedZoneEmptyPolicy(ctx.policyOptions)),
-    new AwsCloudformationStackStuckScanner(ctx.accountId, new CloudformationStackStuckPolicy(ctx.policyOptions)),
-    new AwsS3BucketEmptyScanner(ctx.accountId, new S3BucketEmptyPolicy(ctx.policyOptions)),
-    new AwsCloudwatchAlarmOrphanedScanner(ctx.accountId, new CloudwatchAlarmOrphanedPolicy(ctx.policyOptions)),
-    new AwsSnsTopicUnsubscribedScanner(ctx.accountId, new SnsTopicUnsubscribedPolicy(ctx.policyOptions)),
-    new AwsIamInstanceProfileUnattachedScanner(ctx.accountId, new IamInstanceProfileUnattachedPolicy(ctx.policyOptions)),
-    new AwsEventbridgeRuleNoTargetsScanner(ctx.accountId, new EventbridgeRuleNoTargetsPolicy(ctx.policyOptions)),
-    new AwsEcrRepositoryEmptyScanner(ctx.accountId, new EcrRepositoryEmptyPolicy(ctx.policyOptions)),
-    new AwsStepfunctionsStatemachineUnusedScanner(ctx.accountId, new StepfunctionsStatemachineUnusedPolicy(ctx.policyOptions)),
+    new AwsEc2KeyPairUnusedScanner(ctx.accountId, ctx.credentials, new Ec2KeyPairUnusedPolicy(ctx.policyOptions)),
+    new AwsEc2RiExpiringSoonScanner(ctx.accountId, ctx.credentials, new Ec2RiExpiringSoonPolicy(ctx.policyOptions)),
+    new AwsIamUserInactiveScanner(ctx.accountId, ctx.credentials, new IamUserInactivePolicy(ctx.policyOptions)),
+    new AwsIamPolicyUnattachedScanner(ctx.accountId, ctx.credentials, new IamPolicyUnattachedPolicy(ctx.policyOptions)),
+    new AwsIamRoleUnusedScanner(ctx.accountId, ctx.credentials, new IamRoleUnusedPolicy(ctx.policyOptions)),
+    new AwsIamAccessKeyStaleScanner(ctx.accountId, ctx.credentials, new IamAccessKeyStalePolicy(ctx.policyOptions)),
+    new AwsEc2SecurityGroupUnusedScanner(ctx.accountId, ctx.credentials, new Ec2SecurityGroupUnusedPolicy(ctx.policyOptions)),
+    new AwsLogsLogGroupEmptyScanner(ctx.accountId, ctx.credentials, new LogsLogGroupEmptyPolicy(ctx.policyOptions)),
+    new AwsAcmCertificateUnusedScanner(ctx.accountId, ctx.credentials, new AcmCertificateUnusedPolicy(ctx.policyOptions)),
+    new AwsRoute53HostedZoneEmptyScanner(ctx.accountId, ctx.credentials, new Route53HostedZoneEmptyPolicy(ctx.policyOptions)),
+    new AwsCloudformationStackStuckScanner(ctx.accountId, ctx.credentials, new CloudformationStackStuckPolicy(ctx.policyOptions)),
+    new AwsS3BucketEmptyScanner(ctx.accountId, ctx.credentials, new S3BucketEmptyPolicy(ctx.policyOptions)),
+    new AwsCloudwatchAlarmOrphanedScanner(ctx.accountId, ctx.credentials, new CloudwatchAlarmOrphanedPolicy(ctx.policyOptions)),
+    new AwsSnsTopicUnsubscribedScanner(ctx.accountId, ctx.credentials, new SnsTopicUnsubscribedPolicy(ctx.policyOptions)),
+    new AwsIamInstanceProfileUnattachedScanner(ctx.accountId, ctx.credentials, new IamInstanceProfileUnattachedPolicy(ctx.policyOptions)),
+    new AwsEventbridgeRuleNoTargetsScanner(ctx.accountId, ctx.credentials, new EventbridgeRuleNoTargetsPolicy(ctx.policyOptions)),
+    new AwsEcrRepositoryEmptyScanner(ctx.accountId, ctx.credentials, new EcrRepositoryEmptyPolicy(ctx.policyOptions)),
+    new AwsStepfunctionsStatemachineUnusedScanner(ctx.accountId, ctx.credentials, new StepfunctionsStatemachineUnusedPolicy(ctx.policyOptions)),
   ];
 }
 
 async function defaultCreateAnalysis(ctx: DeadResourceAnalysisContext): Promise<DeadResourceAnalysis> {
-  const scanners = buildScanners({ accountId: ctx.accountId, policyOptions: ctx.policyOptions });
+  const scanners = buildScanners({ accountId: ctx.accountId, credentials: ctx.credentials, policyOptions: ctx.policyOptions });
   const kindFilter = ctx.scannerKinds ? new Set(ctx.scannerKinds) : undefined;
   const selected = kindFilter ? scanners.filter((scanner) => kindFilter.has(scanner.kind)) : scanners;
   return { useCase: new FindDeadResourcesUseCase(selected) };

--- a/apps/cli/src/commands/live-pricing-scanners.ts
+++ b/apps/cli/src/commands/live-pricing-scanners.ts
@@ -38,6 +38,10 @@ import type { LivePricingScannerBuildContext, ScannerRegistration } from './scan
 // known, but it's still gated on the same resource). See
 // {@link ALWAYS_ON_SCANNERS} in `./always-on-scanners` for the statically
 // priced counterpart.
+// Same `ctx.credentials` placement rule as `always-on-scanners.ts`: every
+// scanner in this file extends `CloudWatchIdleScanner` (except
+// `workspaces-idle`), so it's appended as the LAST arg; `workspaces-idle`
+// is a "flat" scanner and takes it right after `ctx.accountId` instead.
 export const LIVE_PRICING_SCANNERS: ScannerRegistration<LivePricingScannerBuildContext>[] = [
   {
     kind: 'ec2-underutilized',
@@ -47,6 +51,7 @@ export const LIVE_PRICING_SCANNERS: ScannerRegistration<LivePricingScannerBuildC
         ctx.accountId,
         new Ec2UnderutilizedPolicy(ctx.policyOptions, ctx.config.thresholds?.ec2CpuPercent ?? 5),
         ctx.utilizationWindowHours,
+        ctx.credentials,
       ),
   },
   {
@@ -57,6 +62,7 @@ export const LIVE_PRICING_SCANNERS: ScannerRegistration<LivePricingScannerBuildC
         ctx.accountId,
         new RdsUnderutilizedPolicy(ctx.policyOptions, ctx.config.thresholds?.rdsCpuPercent ?? 5),
         ctx.utilizationWindowHours,
+        ctx.credentials,
       ),
   },
   {
@@ -67,6 +73,7 @@ export const LIVE_PRICING_SCANNERS: ScannerRegistration<LivePricingScannerBuildC
         ctx.accountId,
         new ElastiCacheIdlePolicy(ctx.policyOptions),
         ctx.cloudwatchWindowHours,
+        ctx.credentials,
       ),
   },
   // Phase 5.5 (ADR-0038): per-instance/node/broker-type pricing, same
@@ -79,6 +86,7 @@ export const LIVE_PRICING_SCANNERS: ScannerRegistration<LivePricingScannerBuildC
         ctx.accountId,
         new RedshiftIdleClusterPolicy(ctx.policyOptions),
         ctx.cloudwatchWindowHours,
+        ctx.credentials,
       ),
   },
   {
@@ -89,6 +97,7 @@ export const LIVE_PRICING_SCANNERS: ScannerRegistration<LivePricingScannerBuildC
         ctx.accountId,
         new OpenSearchIdleDomainPolicy(ctx.policyOptions),
         ctx.cloudwatchWindowHours,
+        ctx.credentials,
       ),
   },
   {
@@ -99,6 +108,7 @@ export const LIVE_PRICING_SCANNERS: ScannerRegistration<LivePricingScannerBuildC
         ctx.accountId,
         new MskIdleClusterPolicy(ctx.policyOptions),
         ctx.cloudwatchWindowHours,
+        ctx.credentials,
       ),
   },
   {
@@ -109,6 +119,7 @@ export const LIVE_PRICING_SCANNERS: ScannerRegistration<LivePricingScannerBuildC
         ctx.accountId,
         new DocumentDbIdleInstancePolicy(ctx.policyOptions),
         ctx.cloudwatchWindowHours,
+        ctx.credentials,
       ),
   },
   {
@@ -119,6 +130,7 @@ export const LIVE_PRICING_SCANNERS: ScannerRegistration<LivePricingScannerBuildC
         ctx.accountId,
         new NeptuneIdleInstancePolicy(ctx.policyOptions),
         ctx.cloudwatchWindowHours,
+        ctx.credentials,
       ),
   },
   {
@@ -129,12 +141,18 @@ export const LIVE_PRICING_SCANNERS: ScannerRegistration<LivePricingScannerBuildC
         ctx.accountId,
         new MqIdleBrokerPolicy(ctx.policyOptions),
         ctx.cloudwatchWindowHours,
+        ctx.credentials,
       ),
   },
   {
     kind: 'workspaces-idle',
     create: (ctx) =>
-      new AwsWorkspacesIdleScanner(ctx.livePricingAdapter, ctx.accountId, new WorkspacesIdlePolicy(ctx.policyOptions)),
+      new AwsWorkspacesIdleScanner(
+        ctx.livePricingAdapter,
+        ctx.accountId,
+        ctx.credentials,
+        new WorkspacesIdlePolicy(ctx.policyOptions),
+      ),
   },
   // Phase 6.3 (ADR-0065): SageMaker vertical. Per-instance-type pricing, same
   // reasoning as EC2/RDS/ElastiCache above (ADR-0037).
@@ -146,6 +164,7 @@ export const LIVE_PRICING_SCANNERS: ScannerRegistration<LivePricingScannerBuildC
         ctx.accountId,
         new SageMakerNotebookIdlePolicy(ctx.policyOptions, ctx.config.thresholds?.sagemakerNotebookCpuPercent ?? 2),
         ctx.utilizationWindowHours,
+        ctx.credentials,
       ),
   },
   {
@@ -156,6 +175,7 @@ export const LIVE_PRICING_SCANNERS: ScannerRegistration<LivePricingScannerBuildC
         ctx.accountId,
         new SageMakerEndpointIdlePolicy(ctx.policyOptions),
         ctx.cloudwatchWindowHours,
+        ctx.credentials,
       ),
   },
   // Phase 6.5 (ADR-0065/ADR-0066): EKS cost visibility vertical. Per-instance-
@@ -168,6 +188,7 @@ export const LIVE_PRICING_SCANNERS: ScannerRegistration<LivePricingScannerBuildC
         ctx.accountId,
         new EksNodeOverprovisionedPolicy(ctx.policyOptions, ctx.config.thresholds?.eksNodeUtilizationPercent ?? 30),
         ctx.utilizationWindowHours,
+        ctx.credentials,
       ),
   },
 ];

--- a/apps/cli/src/commands/pricing.factory.ts
+++ b/apps/cli/src/commands/pricing.factory.ts
@@ -32,7 +32,7 @@ export async function buildPricing(ctx: AnalysisContext): Promise<BuiltPricing> 
 
   if (ctx.livePricing) {
     ctx.info(chalk.dim('  Fetching current prices from the AWS Pricing API...'));
-    livePricingAdapter = new AwsPricingApiAdapter();
+    livePricingAdapter = new AwsPricingApiAdapter(ctx.credentials);
     const live = await livePricingAdapter.warmUp(ctx.regions);
     if (live.ok) {
       priceTable = mergePriceTables(priceTable, live.value);

--- a/apps/cli/src/commands/resolve-options.ts
+++ b/apps/cli/src/commands/resolve-options.ts
@@ -2,8 +2,26 @@
 import { Result } from 'shared-kernel';
 import { AwsRegion, DEFAULT_MIN_AGE_DAYS, RESOURCE_KINDS } from 'cloud-cost-domain';
 import type { ResourceKind } from 'cloud-cost-domain';
+import { assumeRole } from 'shared-aws-infra-utils';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import type { CloudriftConfig } from '../config/cloudrift.config';
 import type { AnalyzeWasteOptions } from './analyze-waste.command';
+
+/**
+ * --assume-role-arn: resolved once per command invocation, before any AWS
+ * call. Hard-fails (never silently falls back to ambient credentials) so a
+ * bad role ARN/trust policy/external ID can't result in silently scanning
+ * the wrong account.
+ */
+export async function resolveCredentials(options: {
+  assumeRoleArn?: string;
+  externalId?: string;
+}): Promise<Result<AwsCredentialIdentityProvider | undefined, Error>> {
+  if (!options.assumeRoleArn) return Result.ok(undefined);
+  const result = await assumeRole(options.assumeRoleArn, options.externalId);
+  if (!result.ok) return Result.fail(result.error);
+  return Result.ok(result.value);
+}
 
 /** Grace period: CLI > config > default. */
 export function resolveMinAgeDays(

--- a/apps/cli/src/commands/resource-security.command.ts
+++ b/apps/cli/src/commands/resource-security.command.ts
@@ -13,12 +13,15 @@ import { startScanSpinner } from '../wizard/scan-spinner';
 import { defaultResourceSecurityDeps, type ResourceSecurityDeps } from './resource-security.composition';
 import { reportCliError as fail } from './report-cli-error';
 import { OUTPUT_FORMATS, isOutputFormat } from '../output-format';
+import { resolveCredentials } from './resolve-options';
 
 export type { ResourceSecurityDeps };
 
 export interface ResourceSecurityCommandOptions {
   regions: string[];
   accountId?: string;
+  assumeRoleArn?: string;
+  externalId?: string;
   format?: string;
   ignoreTag?: string;
   silent?: boolean;
@@ -81,7 +84,11 @@ export async function resourceSecurityCommand(
     console.log(`\n${renderBrandMark()}\n`);
   }
 
-  const accountId = options.accountId ?? (await deps.resolveAccountId()) ?? 'unknown';
+  const credentialsResult = await resolveCredentials(options);
+  if (!credentialsResult.ok) return fail(credentialsResult.error.message);
+  const credentials = credentialsResult.value;
+
+  const accountId = options.accountId ?? (await deps.resolveAccountId(credentials)) ?? 'unknown';
   if (accountId === 'unknown') {
     info(chalk.dim('  Could not resolve the AWS account ID via STS — pass --account-id to set it explicitly.'));
   }
@@ -96,7 +103,7 @@ export async function resourceSecurityCommand(
     ignoreTag: options.ignoreTag ?? DEFAULT_IGNORE_TAG,
   };
 
-  const { useCase } = await deps.createAnalysis({ regions, accountId, policyOptions, scannerKinds });
+  const { useCase } = await deps.createAnalysis({ regions, accountId, credentials, policyOptions, scannerKinds });
 
   const spinner = quietStdout ? undefined : await startScanSpinner('  Rolling through your account...');
   const result = await useCase.execute({ regions });

--- a/apps/cli/src/commands/resource-security.composition.ts
+++ b/apps/cli/src/commands/resource-security.composition.ts
@@ -23,6 +23,7 @@ import {
   CloudtrailNotMultiregionPolicy,
 } from 'resource-security-domain';
 import { FindResourceSecurityFindingsUseCase } from 'resource-security-application';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import {
   AwsIamRootMfaDisabledScanner,
   AwsIamUserMfaDisabledScanner,
@@ -44,6 +45,8 @@ import { resolveAwsAccountId } from 'cloud-cost-infrastructure-aws-adapter';
 /** Everything a resource-security scanner factory may need to build its instance. */
 export interface ResourceSecurityScanContext {
   accountId: string;
+  /** Set only when scanning cross-account via --assume-role-arn; undefined uses the ambient credential chain. */
+  credentials?: AwsCredentialIdentityProvider;
   policyOptions: ResourceSecurityPolicyOptions;
 }
 
@@ -54,6 +57,7 @@ export interface ResourceSecurityScanContext {
 export interface ResourceSecurityAnalysisContext {
   regions: AwsRegion[];
   accountId: string;
+  credentials?: AwsCredentialIdentityProvider;
   policyOptions: ResourceSecurityPolicyOptions;
   /** Restrict the scan to these kinds (from the wizard). Undefined runs every check. */
   scannerKinds?: ResourceSecurityKind[];
@@ -64,32 +68,32 @@ export interface ResourceSecurityAnalysis {
 }
 
 export interface ResourceSecurityDeps {
-  resolveAccountId(): Promise<string | undefined>;
+  resolveAccountId(credentials?: AwsCredentialIdentityProvider): Promise<string | undefined>;
   createAnalysis(ctx: ResourceSecurityAnalysisContext): Promise<ResourceSecurityAnalysis>;
 }
 
 /** One entry per resource-security kind — same shape as `dead-resources.composition.ts`'s `buildScanners`, 14 entries doesn't warrant a registry split (ADR-0077's threshold was 43). */
 function buildScanners(ctx: ResourceSecurityScanContext): ResourceSecurityScannerPort[] {
   return [
-    new AwsIamRootMfaDisabledScanner(ctx.accountId, new IamRootMfaDisabledPolicy(ctx.policyOptions)),
-    new AwsIamUserMfaDisabledScanner(ctx.accountId, new IamUserMfaDisabledPolicy(ctx.policyOptions)),
-    new AwsIamAccessKeyRotationOverdueScanner(ctx.accountId, new IamAccessKeyRotationOverduePolicy(ctx.policyOptions)),
-    new AwsIamRootAccessKeyActiveScanner(ctx.accountId, new IamRootAccessKeyActivePolicy(ctx.policyOptions)),
-    new AwsIamPasswordPolicyWeakScanner(ctx.accountId, new IamPasswordPolicyWeakPolicy(ctx.policyOptions)),
-    new AwsEc2SecurityGroupOpenIngressScanner(ctx.accountId, new Ec2SecurityGroupOpenIngressPolicy(ctx.policyOptions)),
-    new AwsEc2DefaultSecurityGroupPermissiveScanner(ctx.accountId, new Ec2DefaultSecurityGroupPermissivePolicy(ctx.policyOptions)),
-    new AwsS3BucketPublicScanner(ctx.accountId, new S3BucketPublicPolicy(ctx.policyOptions)),
-    new AwsEc2SnapshotPublicScanner(ctx.accountId, new Ec2SnapshotPublicPolicy(ctx.policyOptions)),
-    new AwsEc2VolumeUnencryptedScanner(ctx.accountId, new Ec2VolumeUnencryptedPolicy(ctx.policyOptions)),
-    new AwsRdsInstanceUnencryptedScanner(ctx.accountId, new RdsInstanceUnencryptedPolicy(ctx.policyOptions)),
-    new AwsS3BucketEncryptionMissingScanner(ctx.accountId, new S3BucketEncryptionMissingPolicy(ctx.policyOptions)),
-    new AwsRdsInstancePubliclyAccessibleScanner(ctx.accountId, new RdsInstancePubliclyAccessiblePolicy(ctx.policyOptions)),
-    new AwsCloudtrailNotMultiregionScanner(ctx.accountId, new CloudtrailNotMultiregionPolicy(ctx.policyOptions)),
+    new AwsIamRootMfaDisabledScanner(ctx.accountId, ctx.credentials, new IamRootMfaDisabledPolicy(ctx.policyOptions)),
+    new AwsIamUserMfaDisabledScanner(ctx.accountId, ctx.credentials, new IamUserMfaDisabledPolicy(ctx.policyOptions)),
+    new AwsIamAccessKeyRotationOverdueScanner(ctx.accountId, ctx.credentials, new IamAccessKeyRotationOverduePolicy(ctx.policyOptions)),
+    new AwsIamRootAccessKeyActiveScanner(ctx.accountId, ctx.credentials, new IamRootAccessKeyActivePolicy(ctx.policyOptions)),
+    new AwsIamPasswordPolicyWeakScanner(ctx.accountId, ctx.credentials, new IamPasswordPolicyWeakPolicy(ctx.policyOptions)),
+    new AwsEc2SecurityGroupOpenIngressScanner(ctx.accountId, ctx.credentials, new Ec2SecurityGroupOpenIngressPolicy(ctx.policyOptions)),
+    new AwsEc2DefaultSecurityGroupPermissiveScanner(ctx.accountId, ctx.credentials, new Ec2DefaultSecurityGroupPermissivePolicy(ctx.policyOptions)),
+    new AwsS3BucketPublicScanner(ctx.accountId, ctx.credentials, new S3BucketPublicPolicy(ctx.policyOptions)),
+    new AwsEc2SnapshotPublicScanner(ctx.accountId, ctx.credentials, new Ec2SnapshotPublicPolicy(ctx.policyOptions)),
+    new AwsEc2VolumeUnencryptedScanner(ctx.accountId, ctx.credentials, new Ec2VolumeUnencryptedPolicy(ctx.policyOptions)),
+    new AwsRdsInstanceUnencryptedScanner(ctx.accountId, ctx.credentials, new RdsInstanceUnencryptedPolicy(ctx.policyOptions)),
+    new AwsS3BucketEncryptionMissingScanner(ctx.accountId, ctx.credentials, new S3BucketEncryptionMissingPolicy(ctx.policyOptions)),
+    new AwsRdsInstancePubliclyAccessibleScanner(ctx.accountId, ctx.credentials, new RdsInstancePubliclyAccessiblePolicy(ctx.policyOptions)),
+    new AwsCloudtrailNotMultiregionScanner(ctx.accountId, ctx.credentials, new CloudtrailNotMultiregionPolicy(ctx.policyOptions)),
   ];
 }
 
 async function defaultCreateAnalysis(ctx: ResourceSecurityAnalysisContext): Promise<ResourceSecurityAnalysis> {
-  const scanners = buildScanners({ accountId: ctx.accountId, policyOptions: ctx.policyOptions });
+  const scanners = buildScanners({ accountId: ctx.accountId, credentials: ctx.credentials, policyOptions: ctx.policyOptions });
   const kindFilter = ctx.scannerKinds ? new Set(ctx.scannerKinds) : undefined;
   const selected = kindFilter ? scanners.filter((scanner) => kindFilter.has(scanner.kind)) : scanners;
   return { useCase: new FindResourceSecurityFindingsUseCase(selected) };

--- a/apps/cli/src/commands/scanner-registry.ts
+++ b/apps/cli/src/commands/scanner-registry.ts
@@ -2,6 +2,7 @@
 import { RESOURCE_KINDS } from 'cloud-cost-domain';
 import type { PricingPort, ResourceKind, WastePolicyOptions, WasteScannerPort } from 'cloud-cost-domain';
 import type { AwsPricingApiAdapter } from 'cloud-cost-infrastructure-aws-adapter';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import type { CloudriftConfig } from '../config/cloudrift.config';
 import { ALWAYS_ON_SCANNERS } from './always-on-scanners';
 import { LIVE_PRICING_SCANNERS } from './live-pricing-scanners';
@@ -13,6 +14,8 @@ export { LIVE_PRICING_SCANNERS } from './live-pricing-scanners';
 export interface ScannerBuildContext {
   pricing: PricingPort;
   accountId: string;
+  /** Set only when scanning cross-account via --assume-role-arn; undefined uses the ambient credential chain. */
+  credentials?: AwsCredentialIdentityProvider;
   policyOptions: WastePolicyOptions;
   cloudwatchWindowHours: number;
   utilizationWindowHours: number;

--- a/apps/cli/src/commands/trend.command.ts
+++ b/apps/cli/src/commands/trend.command.ts
@@ -14,12 +14,15 @@ import { startScanSpinner } from '../wizard/scan-spinner';
 import { defaultCostAnalyticsDeps, type CostAnalyticsDeps } from './cost-analytics.composition';
 import { reportCliError as fail } from './report-cli-error';
 import { OUTPUT_FORMATS, isOutputFormat } from '../output-format';
+import { resolveCredentials } from './resolve-options';
 
 const DEFAULT_MONTHS = 6;
 const MAX_MONTHS = 36;
 
 export interface TrendCommandOptions {
   accountId?: string;
+  assumeRoleArn?: string;
+  externalId?: string;
   config?: string;
   format?: string;
   months?: string;
@@ -70,12 +73,16 @@ export async function trendCommand(
   const proceed = await confirmCostExplorerCharge({ yes: options.yes === true, silent });
   if (!proceed) return;
 
-  const accountId = options.accountId ?? (await deps.resolveAccountId()) ?? 'unknown';
+  const credentialsResult = await resolveCredentials(options);
+  if (!credentialsResult.ok) return fail(credentialsResult.error.message);
+  const credentials = credentialsResult.value;
+
+  const accountId = options.accountId ?? (await deps.resolveAccountId(credentials)) ?? 'unknown';
   if (accountId === 'unknown') {
     info(chalk.dim('  Could not resolve the AWS account ID via STS — pass --account-id to set it explicitly.'));
   }
 
-  const costExplorer = deps.createCostExplorer(accountId, options.refreshCache === true);
+  const costExplorer = deps.createCostExplorer(accountId, options.refreshCache === true, credentials);
   const spinner = quietStdout ? undefined : await startScanSpinner('  Fetching from Cost Explorer...');
   const result = await new CostTrendUseCase(costExplorer).execute({ months, services });
   spinner?.stop(chalk.dim('  Done.'));

--- a/apps/cli/src/iam-policy.ts
+++ b/apps/cli/src/iam-policy.ts
@@ -92,6 +92,12 @@ export const REQUIRED_IAM_POLICY = {
         'cloudtrail:DescribeTrails',
         'ce:GetCostAndUsage',
         'sts:GetCallerIdentity',
+        // Only needed when scanning with --assume-role-arn: this grants the
+        // CALLING principal permission to assume a role elsewhere. The
+        // TARGET role (in the account being scanned) needs its own trust
+        // policy granting this principal — that trust relationship isn't
+        // expressible here, see docs/en/iam-permissions.md for a sample.
+        'sts:AssumeRole',
       ],
       Resource: '*',
     },

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -30,6 +30,14 @@ program
     'AWS account ID override (auto-detected via STS when omitted)',
   )
   .option(
+    '--assume-role-arn <arn>',
+    'assume this IAM role via STS before scanning, for cross-account access',
+  )
+  .option(
+    '--external-id <id>',
+    'external ID to pass when assuming --assume-role-arn (only needed if the role trust policy requires one)',
+  )
+  .option(
     '--config <path>',
     'path to a cloudrift config file (defaults to cloudrift.config.json / .cloudriftrc in the cwd)',
   )
@@ -84,6 +92,11 @@ program
   .command('cost')
   .description('Compare current spend against the same period last month, broken down by service')
   .option('--account-id <id>', 'AWS account ID override (auto-detected via STS when omitted)')
+  .option('--assume-role-arn <arn>', 'assume this IAM role via STS before scanning, for cross-account access')
+  .option(
+    '--external-id <id>',
+    'external ID to pass when assuming --assume-role-arn (only needed if the role trust policy requires one)',
+  )
   .option(
     '--config <path>',
     'path to a cloudrift config file (defaults to cloudrift.config.json / .cloudriftrc in the cwd)',
@@ -106,6 +119,11 @@ program
   .command('trend')
   .description('Monthly spend over the last N months, optionally filtered to specific services')
   .option('--account-id <id>', 'AWS account ID override (auto-detected via STS when omitted)')
+  .option('--assume-role-arn <arn>', 'assume this IAM role via STS before scanning, for cross-account access')
+  .option(
+    '--external-id <id>',
+    'external ID to pass when assuming --assume-role-arn (only needed if the role trust policy requires one)',
+  )
   .option(
     '--config <path>',
     'path to a cloudrift config file (defaults to cloudrift.config.json / .cloudriftrc in the cwd)',
@@ -132,6 +150,11 @@ program
     ['us-east-1'],
   )
   .option('--account-id <id>', 'AWS account ID override (auto-detected via STS when omitted)')
+  .option('--assume-role-arn <arn>', 'assume this IAM role via STS before scanning, for cross-account access')
+  .option(
+    '--external-id <id>',
+    'external ID to pass when assuming --assume-role-arn (only needed if the role trust policy requires one)',
+  )
   .option(
     '--min-age-days <days>',
     'grace period: resources younger than this many days are not reported (default 7)',
@@ -167,6 +190,11 @@ program
     ['us-east-1'],
   )
   .option('--account-id <id>', 'AWS account ID override (auto-detected via STS when omitted)')
+  .option('--assume-role-arn <arn>', 'assume this IAM role via STS before scanning, for cross-account access')
+  .option(
+    '--external-id <id>',
+    'external ID to pass when assuming --assume-role-arn (only needed if the role trust policy requires one)',
+  )
   .option(
     '--ignore-tag <tag>',
     'resources carrying this tag are excluded from the report (default cloudrift:ignore)',

--- a/apps/cli/tsconfig.app.json
+++ b/apps/cli/tsconfig.app.json
@@ -13,31 +13,7 @@
       "path": "../../libs/shared/kernel/tsconfig.lib.json"
     },
     {
-      "path": "../../libs/dead-resources/infrastructure/aws-adapter/tsconfig.lib.json"
-    },
-    {
-      "path": "../../libs/dead-resources/domain/tsconfig.lib.json"
-    },
-    {
-      "path": "../../libs/dead-resources/application/tsconfig.lib.json"
-    },
-    {
-      "path": "../../libs/cloud-cost/infrastructure/aws-adapter/tsconfig.lib.json"
-    },
-    {
-      "path": "../../libs/cloud-cost/domain/tsconfig.lib.json"
-    },
-    {
-      "path": "../../libs/cloud-cost/application/tsconfig.lib.json"
-    },
-    {
-      "path": "../../libs/cost-analytics/infrastructure/aws-adapter/tsconfig.lib.json"
-    },
-    {
-      "path": "../../libs/cost-analytics/domain/tsconfig.lib.json"
-    },
-    {
-      "path": "../../libs/cost-analytics/application/tsconfig.lib.json"
+      "path": "../../libs/shared/aws-infra-utils/tsconfig.lib.json"
     },
     {
       "path": "../../libs/resource-security/infrastructure/aws-adapter/tsconfig.lib.json"
@@ -50,6 +26,33 @@
     },
     {
       "path": "../../libs/mcp-server/application/tsconfig.lib.json"
+    },
+    {
+      "path": "../../libs/dead-resources/infrastructure/aws-adapter/tsconfig.lib.json"
+    },
+    {
+      "path": "../../libs/dead-resources/domain/tsconfig.lib.json"
+    },
+    {
+      "path": "../../libs/dead-resources/application/tsconfig.lib.json"
+    },
+    {
+      "path": "../../libs/cost-analytics/infrastructure/aws-adapter/tsconfig.lib.json"
+    },
+    {
+      "path": "../../libs/cost-analytics/domain/tsconfig.lib.json"
+    },
+    {
+      "path": "../../libs/cost-analytics/application/tsconfig.lib.json"
+    },
+    {
+      "path": "../../libs/cloud-cost/infrastructure/aws-adapter/tsconfig.lib.json"
+    },
+    {
+      "path": "../../libs/cloud-cost/domain/tsconfig.lib.json"
+    },
+    {
+      "path": "../../libs/cloud-cost/application/tsconfig.lib.json"
     }
   ]
 }

--- a/docs/adr/0096-cross-account-scanning-assume-role.md
+++ b/docs/adr/0096-cross-account-scanning-assume-role.md
@@ -1,0 +1,32 @@
+# ADR-0096: Cross-account scanning via `--assume-role-arn` (STS AssumeRole)
+
+- **Status:** Accepted (2026-07-29)
+
+## Context
+
+Every scanner, and `resolveAwsAccountId()` ([ADR-0026](0026-account-id-via-sts.md)), used whatever credentials the AWS SDK's default provider chain resolved (env vars, shared config/profile, EC2/ECS/Lambda role, SSO) with no way to override them per invocation. Scanning a second AWS account required the user to switch their ambient credentials (a different `AWS_PROFILE`, a fresh SSO login, editing `~/.aws/config`) before each run — awkward for a one-off cross-account check, and unworkable for scripting "run this same scan across N accounts" without shelling out to `aws sts assume-role` by hand and exporting the resulting keys as env vars.
+
+## Decision
+
+New `--assume-role-arn <arn>` flag (plus optional `--external-id <id>`) on all five scanning/reporting commands (`analyze`, `cost`, `trend`, `dead-resources`, `resource-security`). Resolution is centralized in one place per command:
+
+- `resolveCredentials()` (`apps/cli/src/commands/resolve-options.ts`) calls the new `assumeRole()` (`libs/shared/aws-infra-utils/src/utils/assume-role.ts`), built on `fromTemporaryCredentials` from `@aws-sdk/credential-providers`. It resolves the credential provider **eagerly** — invoking it once right there — specifically so a bad role ARN, a trust policy that denies the caller, or a wrong `--external-id` fails loudly at the top of the command, never silently, and never by falling back to the ambient credentials (which would scan the wrong account without telling anyone).
+- When `--assume-role-arn` is omitted, `resolveCredentials()` returns `undefined` and every downstream call keeps using the SDK's own default provider chain exactly as before — this is strictly additive, zero behavior change for the common case.
+- The resulting `AwsCredentialIdentityProvider | undefined` is threaded as an explicit optional constructor/function parameter through every layer that talks to AWS: `createAwsClientConfig(credentials?)` conditionally spreads a `credentials` key into the client config; `resolveAwsAccountId(credentials?)` passes it to the `STSClient` so the reported `accountId` reflects the **assumed** identity, not the caller's own (no separate "which account did we actually scan" bookkeeping needed); every scanner constructor across `cloud-cost`, `dead-resources`, and `resource-security` gained one more optional parameter; `AwsPricingApiAdapter` and `AwsCostExplorerAdapter` gained a constructor parameter.
+- **Positional convention, not a breaking one:** scanner constructors already took positional args (pricing, accountId, policy, window hours, ...) with no options-object refactor — adding `credentials` mid-list would have been a silent, easy-to-miss breaking change for every call site. Convention adopted: "flat" scanners (not extending `CloudWatchIdleScanner`) take `credentials` right after `accountId`; `CloudWatchIdleScanner` subclasses ([ADR-0044](0044-cloudwatch-idle-scanner-template-method.md)) take it as their own last constructor parameter, forwarded into the shared base class's constructor. This keeps every existing positional argument at the same index — the new parameter is always appended, never inserted.
+- `sts:AssumeRole` added to `REQUIRED_IAM_POLICY` (`apps/cli/src/iam-policy.ts`) — this is the action the **calling** principal needs; the **target** role's own trust policy (in the account being scanned) must separately grant that principal `sts:AssumeRole`, which cloudrift cannot express or provision — documented with a sample trust policy in `docs/en/iam-permissions.md` / `docs/it/permessi-iam.md`.
+
+## Alternatives Considered
+
+- **Rely on AWS named profiles (`AWS_PROFILE` / `~/.aws/config`) per invocation.** Rejected: requires the user to pre-provision a profile per target account outside cloudrift, doesn't compose with a single scripted invocation that names the target account inline, and is exactly the friction this feature exists to remove.
+- **Built-in multi-account "sweep" mode** (cloudrift itself iterating an AWS Organizations account list and scanning each one). Deferred, not rejected outright: out of scope for this phase. A single assumed role per invocation already composes with an external loop (a shell `for` loop over role ARNs, or a CI matrix) without cloudrift needing `organizations:*` permissions or owning any new orchestration/aggregation logic. Revisit if users actually want a single command that fans out across an entire Organization — similar in spirit to the deferred-for-now stance in [ADR-0067](0067-saas-readiness-architectural-hints.md).
+- **Silently fall back to ambient credentials if `assumeRole()` fails.** Rejected: the whole point of this flag is "scan *that* account, not mine" — a silent fallback would scan the wrong account and still print a report, with nothing in the output to say so.
+- **Lazy credential resolution** (pass the provider through unresolved, let the first AWS SDK call surface any failure). Rejected: the first failure would then surface deep inside whichever scanner happened to run first, with a stack trace/error shape that varies scanner to scanner, instead of one clear message at the top of the command before any scan begins.
+
+## Consequences
+
+Cross-account scanning is a **per-invocation** flag, not a built-in multi-account feature: covering N accounts means invoking cloudrift N times (once per role ARN), each invocation fully independent — its own report, its own `accountId` (the assumed one), its own exit code. This is intentionally left to the caller (shell loop, CI matrix) rather than built into cloudrift.
+
+New dependency: `@aws-sdk/credential-providers` in `shared-aws-infra-utils`. Every scanner constructor across three domains gained one more optional parameter — a mechanical, purely additive change (verified via `nx run-many -t typecheck,lint,test` across all affected projects; zero test regressions).
+
+`sts:AssumeRole` is now part of the policy printed by `cloudrift iam-policy` and returned by the `get_required_iam_permissions` MCP tool — users who don't use `--assume-role-arn` gain one unused-but-harmless action in that policy; there's no per-flag IAM policy variant today (same limitation `iam-policy` already has for `--scanners`-style narrowing).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -108,6 +108,7 @@ Each entry follows: Context → Decision → Alternatives Considered → Consequ
 | [0071](0071-unified-entry-wizard-bare-invocation.md) | Bare `cloudrift` (no subcommand, real terminal) launches a unified mode-picker wizard | Accepted |
 | [0073](0073-brand-mark-pixel-art-pipeline.md) | Brand mark generated from the real logo via an offline pixel-art sampling pipeline | Accepted |
 | [0087](0087-precommit-hooks-eslint-only-no-prettier.md) | Pre-commit hooks via husky + lint-staged, `eslint --fix` only — no `prettier --write` | Accepted |
+| [0096](0096-cross-account-scanning-assume-role.md) | Cross-account scanning via `--assume-role-arn` (STS AssumeRole) | Accepted |
 
 ## Reporting
 

--- a/docs/en/iam-permissions.md
+++ b/docs/en/iam-permissions.md
@@ -124,3 +124,25 @@ The `resource-security` command (security-posture checks — IAM/account hygiene
 ```
 
 `iam:ListUsers`, `iam:ListAccessKeys`, `ec2:DescribeSecurityGroups`, `ec2:DescribeVolumes`, `ec2:DescribeSnapshots`, `s3:ListAllMyBuckets`, and `rds:DescribeDBInstances` (all already in the main policy or the `dead-resources` block above) are reused — this command adds no new hygiene/inventory calls, only the read-only checks (`Get*`/`DescribeSnapshotAttribute`/`DescribeTrails`) needed to evaluate each resource's security configuration. `cloudtrail:DescribeTrails` is the one action from a service not otherwise used by cloudrift. None of these actions are needed for `analyze` or `dead-resources` — only for `resource-security`.
+
+## Cross-account scanning (`--assume-role-arn`)
+
+Scanning a different AWS account by assuming a role into it (`--assume-role-arn <arn>`, optionally `--external-id <id>`) needs `sts:AssumeRole` on the **calling** principal — already included in the main policy above. The **target** role (in the account being scanned) needs its own trust policy granting the calling principal permission to assume it, plus the same read-only permissions as this document (matching whichever commands you intend to run against that account):
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": { "AWS": "arn:aws:iam::<calling-account-id>:role/<calling-role-name>" },
+      "Action": "sts:AssumeRole",
+      "Condition": {
+        "StringEquals": { "sts:ExternalId": "<your-external-id>" }
+      }
+    }
+  ]
+}
+```
+
+The `Condition`/`sts:ExternalId` block is only required if you pass `--external-id` — omit both if the trust relationship doesn't need one (e.g. within a single AWS Organization you already control).

--- a/docs/en/technical-choices.md
+++ b/docs/en/technical-choices.md
@@ -101,6 +101,14 @@ try {
 
 ---
 
+## Cross-account scanning via STS AssumeRole, resolved eagerly
+
+**Choice:** `--assume-role-arn <arn>` (plus optional `--external-id <id>`) assumes a role via `fromTemporaryCredentials`, invoking the resulting provider once immediately rather than passing it through unresolved. Omitting the flag keeps every scanner on the SDK's own default credential chain, unchanged.
+
+**Why:** a bad role ARN, a denied trust policy, or a wrong external ID must fail loudly at the top of the command — never by silently scanning the caller's own account instead, and never as a confusing error surfacing deep inside whichever scanner happens to run first. See [ADR-0096](../adr/0096-cross-account-scanning-assume-role.md).
+
+---
+
 ## Parametric waste policies instead of hardcoded heuristics
 
 **Choice:** waste conditions live in domain policies (`WastePolicy<T>`) with two cross-cutting parameters exposed by the CLI: `--min-age-days` (default 7) and `--ignore-tag` (default `cloudrift:ignore`).

--- a/docs/en/usage.md
+++ b/docs/en/usage.md
@@ -6,6 +6,20 @@ Flags, examples, the PDF report, partial-failure handling, and per-region pricin
 
 **Interactive wizard:** running `cloudrift` with **no subcommand** in a real terminal (outside CI) launches a mode-picker wizard — choose "Find wasted resources" / "Compare spend vs. last month" / "View monthly spend trend" / "Find dead/unused resources" / "Scan for security-posture risks", then answer a few prompts (regions, which scanners, output format). It calls the exact same `analyze`/`cost`/`trend`/`dead-resources`/`resource-security` code the flags below drive, so it's never out of sync with them. Any explicit subcommand, any flag, CI, or non-interactive stdout skips the wizard entirely — scripts and pipelines are unaffected. See [ADR-0071](../adr/0071-unified-entry-wizard-bare-invocation.md).
 
+**Cross-account scanning:** every command below (`analyze`, `cost`, `trend`, `dead-resources`, `resource-security`) accepts `--assume-role-arn <arn>` (optionally with `--external-id <id>`) to scan an account other than the one your ambient credentials belong to — cloudrift assumes that role via STS before making any AWS call, and the whole command fails immediately if the role can't be assumed, rather than silently falling back to your own credentials. There is no built-in "scan my whole organization" mode: to cover several accounts, invoke cloudrift once per role ARN (a shell loop or a CI matrix), each run producing its own independent report. See [ADR-0096](../adr/0096-cross-account-scanning-assume-role.md) and the "Cross-account scanning" section of [docs/en/iam-permissions.md](iam-permissions.md) for the required trust policy on the target role.
+
+```sh
+# Scan a different account by assuming a role into it
+node apps/cli/dist/main.js analyze --assume-role-arn arn:aws:iam::222222222222:role/cloudrift-scanner --external-id my-shared-secret
+
+# Sweep several accounts from a shell loop, one independent report each
+for account in 111111111111 222222222222; do
+  node apps/cli/dist/main.js dead-resources \
+    --assume-role-arn "arn:aws:iam::${account}:role/cloudrift-scanner" \
+    --format json > "report-${account}.json"
+done
+```
+
 ## `analyze` — find wasted resources
 
 ```sh
@@ -21,6 +35,8 @@ node apps/cli/dist/main.js analyze [options]
 | `--scanners <kinds...>`      | Only run these services (space-separated resource kinds, e.g. `ebs-volume elastic-ip`); skips the interactive picker | — |
 | `--all-services`             | Run every scanner without the interactive picker                                                               | on in CI / non-TTY |
 | `--account-id <id>`          | AWS account ID override (auto-detected via `sts:GetCallerIdentity` when omitted)                               | auto-detected      |
+| `--assume-role-arn <arn>`    | Assume this IAM role via STS before scanning, for cross-account access                                        | —                  |
+| `--external-id <id>`        | External ID to pass when assuming `--assume-role-arn` (only needed if the role trust policy requires one)     | —                  |
 | `--min-age-days <days>`      | Grace period: resources younger than this many days are not reported (overrides config)                       | `7`                |
 | `--ignore-tag <tag>`         | Resources carrying this tag are excluded from the report (overrides config)                                   | `cloudrift:ignore` |
 | `--pdf [filename]`           | Also write a PDF report to disk (defaults to `cloudrift-report-YYYY-MM-DD.pdf`)                                | —                  |
@@ -119,6 +135,8 @@ node apps/cli/dist/main.js trend [options]
 | Option | Description | Default |
 | --- | --- | --- |
 | `--account-id <id>` | AWS account ID override (auto-detected via STS when omitted) | auto-detected |
+| `--assume-role-arn <arn>` | Assume this IAM role via STS before scanning, for cross-account access | — |
+| `--external-id <id>` | External ID to pass when assuming `--assume-role-arn` (only needed if the role trust policy requires one) | — |
 | `--config <path>` | Path to a config file | auto-discovered |
 | `--format <format>` | stdout format: `table`, `json`, or `csv` | `table` |
 | `--fail-on-increase <pct>` | Exit with code 2 if spend increased more than this percent vs. the previous period (overrides `config.costIncreaseAlertPercent`) | off |
@@ -132,6 +150,8 @@ node apps/cli/dist/main.js trend [options]
 | Option | Description | Default |
 | --- | --- | --- |
 | `--account-id <id>` | AWS account ID override | auto-detected |
+| `--assume-role-arn <arn>` | Assume this IAM role via STS before scanning, for cross-account access | — |
+| `--external-id <id>` | External ID to pass when assuming `--assume-role-arn` (only needed if the role trust policy requires one) | — |
 | `--config <path>` | Path to a config file | auto-discovered |
 | `--months <n>` | Number of calendar months to show (1–36) | `6` |
 | `--services <names...>` | Restrict to these services (shorthand like `ec2 s3 rds`, or the exact Cost Explorer service name) | all services |
@@ -171,6 +191,8 @@ node apps/cli/dist/main.js dead-resources [options]
 | ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ |
 | `-r, --regions <regions...>` | AWS regions to scan (ignored by the global-scope checks — see below)                                           | `us-east-1`        |
 | `--account-id <id>`          | AWS account ID override (auto-detected via `sts:GetCallerIdentity` when omitted)                               | auto-detected      |
+| `--assume-role-arn <arn>`    | Assume this IAM role via STS before scanning, for cross-account access                                        | —                  |
+| `--external-id <id>`        | External ID to pass when assuming `--assume-role-arn` (only needed if the role trust policy requires one)     | —                  |
 | `--min-age-days <days>`      | Grace period: resources younger than this many days are not reported (`ec2-ri-expiring-soon` doesn't use this — see below) | `7`     |
 | `--ignore-tag <tag>`         | Resources carrying this tag are excluded from the report                                                       | `cloudrift:ignore` |
 | `--scanners <kinds...>`      | Only run these checks (space-separated, e.g. `ec2-keypair-unused iam-user-inactive`)                           | all checks          |
@@ -234,6 +256,8 @@ node apps/cli/dist/main.js resource-security [options]
 | ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ |
 | `-r, --regions <regions...>` | AWS regions to scan (ignored by the global-scope checks — see below)                                           | `us-east-1`        |
 | `--account-id <id>`          | AWS account ID override (auto-detected via `sts:GetCallerIdentity` when omitted)                               | auto-detected      |
+| `--assume-role-arn <arn>`    | Assume this IAM role via STS before scanning, for cross-account access                                        | —                  |
+| `--external-id <id>`        | External ID to pass when assuming `--assume-role-arn` (only needed if the role trust policy requires one)     | —                  |
 | `--ignore-tag <tag>`         | Resources carrying this tag are excluded from the report                                                       | `cloudrift:ignore` |
 | `--scanners <kinds...>`      | Only run these checks (space-separated, e.g. `iam-root-mfa-disabled s3-bucket-public`)                         | all checks          |
 | `--format <format>`          | stdout output format: `table`, `json`, or `csv`                                                                | `table`            |

--- a/docs/it/permessi-iam.md
+++ b/docs/it/permessi-iam.md
@@ -124,3 +124,25 @@ Il comando `resource-security` (check di postura di sicurezza — hygiene IAM/ac
 ```
 
 `iam:ListUsers`, `iam:ListAccessKeys`, `ec2:DescribeSecurityGroups`, `ec2:DescribeVolumes`, `ec2:DescribeSnapshots`, `s3:ListAllMyBuckets` e `rds:DescribeDBInstances` (già presenti nella policy principale o nel blocco `dead-resources` sopra) vengono riusate — questo comando non aggiunge nuove chiamate di hygiene/inventario, solo le verifiche read-only (`Get*`/`DescribeSnapshotAttribute`/`DescribeTrails`) necessarie per valutare la configurazione di sicurezza di ogni risorsa. `cloudtrail:DescribeTrails` è l'unica action di un servizio non altrimenti usato da cloudrift. Nessuna di queste action serve per `analyze` o `dead-resources` — solo per `resource-security`.
+
+## Scansione cross-account (`--assume-role-arn`)
+
+Per scansionare un account AWS diverso assumendo un ruolo al suo interno (`--assume-role-arn <arn>`, opzionalmente `--external-id <id>`) serve `sts:AssumeRole` sul principal **chiamante** — già incluso nella policy principale sopra. Il ruolo **target** (nell'account da scansionare) ha bisogno di una propria trust policy che conceda al principal chiamante il permesso di assumerlo, più gli stessi permessi read-only descritti in questo documento (in base ai comandi che intendi eseguire su quell'account):
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": { "AWS": "arn:aws:iam::<account-id-chiamante>:role/<nome-ruolo-chiamante>" },
+      "Action": "sts:AssumeRole",
+      "Condition": {
+        "StringEquals": { "sts:ExternalId": "<tuo-external-id>" }
+      }
+    }
+  ]
+}
+```
+
+Il blocco `Condition`/`sts:ExternalId` serve solo se passi `--external-id` — omettilo (insieme al blocco) se la trust relationship non ne richiede uno (es. all'interno di un'unica AWS Organization che già controlli).

--- a/docs/it/scelte-tecniche.md
+++ b/docs/it/scelte-tecniche.md
@@ -101,6 +101,14 @@ try {
 
 ---
 
+## Scansione cross-account via STS AssumeRole, risolta in modo eager
+
+**Scelta:** `--assume-role-arn <arn>` (con opzionale `--external-id <id>`) assume un ruolo via `fromTemporaryCredentials`, invocando subito il provider risultante invece di passarlo non risolto. Omettere il flag mantiene ogni scanner sulla catena di credenziali di default dell'SDK, invariata.
+
+**Perché:** un role ARN errato, una trust policy che nega l'accesso, o un external ID sbagliato devono fallire rumorosamente in testa al comando — mai scansionando silenziosamente l'account del chiamante, e mai come un errore confuso che emerge in profondità dentro il primo scanner eseguito. Vedi [ADR-0096](../adr/0096-cross-account-scanning-assume-role.md) (in inglese).
+
+---
+
 ## Waste policy parametriche invece di euristiche hardcoded
 
 **Scelta:** le condizioni di spreco vivono in policy di dominio (`WastePolicy<T>`) con due parametri trasversali esposti dalla CLI: `--min-age-days` (default 7) e `--ignore-tag` (default `cloudrift:ignore`).

--- a/docs/it/utilizzo.md
+++ b/docs/it/utilizzo.md
@@ -6,6 +6,20 @@ Flag, esempi, report PDF, gestione errori parziali, e prezzi per regione per `cl
 
 **Wizard interattivo:** lanciando `cloudrift` senza **nessun sottocomando** in un vero terminale (fuori da CI) parte un wizard che ti fa scegliere cosa fare — "Trova risorse sprecate" / "Confronta la spesa col mese scorso" / "Vedi il trend mensile di spesa" / "Trova risorse morte/inutilizzate" / "Scansiona rischi di postura di sicurezza" — e poi pochi prompt (regioni, quali scanner, formato di output). Richiama esattamente lo stesso codice di `analyze`/`cost`/`trend`/`dead-resources`/`resource-security` guidato dai flag qui sotto, quindi non va mai fuori sincrono con loro. Qualunque sottocomando esplicito, qualunque flag, CI, o stdout non interattivo saltano del tutto il wizard — script e pipeline non ne sono toccati. Vedi [ADR-0071](../adr/0071-unified-entry-wizard-bare-invocation.md).
 
+**Scansione cross-account:** ogni comando qui sotto (`analyze`, `cost`, `trend`, `dead-resources`, `resource-security`) accetta `--assume-role-arn <arn>` (opzionalmente con `--external-id <id>`) per scansionare un account diverso da quello a cui appartengono le tue credenziali correnti — cloudrift assume quel ruolo via STS prima di fare qualsiasi chiamata AWS, e l'intero comando fallisce subito se il ruolo non può essere assunto, invece di ricadere silenziosamente sulle tue credenziali. Non esiste una modalità integrata "scansiona tutta la mia organizzazione": per coprire più account, lancia cloudrift una volta per ogni role ARN (un loop di shell o una matrice CI), ogni esecuzione produce un report indipendente. Vedi [ADR-0096](../adr/0096-cross-account-scanning-assume-role.md) (in inglese) e la sezione "Scansione cross-account" di [docs/it/permessi-iam.md](permessi-iam.md) per la trust policy richiesta sul ruolo target.
+
+```sh
+# Scansiona un account diverso assumendo un ruolo al suo interno
+node apps/cli/dist/main.js analyze --assume-role-arn arn:aws:iam::222222222222:role/cloudrift-scanner --external-id il-mio-secret-condiviso
+
+# Scansiona più account da un loop di shell, un report indipendente per ciascuno
+for account in 111111111111 222222222222; do
+  node apps/cli/dist/main.js dead-resources \
+    --assume-role-arn "arn:aws:iam::${account}:role/cloudrift-scanner" \
+    --format json > "report-${account}.json"
+done
+```
+
 ## `analyze` — trova risorse sprecate
 
 ```sh
@@ -21,6 +35,8 @@ node apps/cli/dist/main.js analyze [opzioni]
 | `--scanners <kinds...>`      | Esegue solo questi servizi (elenco di resource kind separati da spazio, es. `ebs-volume elastic-ip`); salta il picker interattivo | — |
 | `--all-services`             | Esegue tutti gli scanner senza il picker interattivo                                                                  | on in CI / non-TTY |
 | `--account-id <id>`          | Override dell'account ID (rilevato automaticamente via `sts:GetCallerIdentity` se omesso)                            | auto-rilevato      |
+| `--assume-role-arn <arn>`    | Assume questo ruolo IAM via STS prima di scansionare, per l'accesso cross-account                                   | —                  |
+| `--external-id <id>`        | External ID da passare quando si assume `--assume-role-arn` (serve solo se la trust policy del ruolo lo richiede)   | —                  |
 | `--min-age-days <giorni>`    | Periodo di grazia: le risorse più giovani di N giorni non vengono segnalate (ha precedenza sul config)              | `7`                |
 | `--ignore-tag <tag>`         | Le risorse con questo tag vengono escluse dal report (ha precedenza sul config)                                     | `cloudrift:ignore` |
 | `--pdf [filename]`           | Scrive anche un report PDF su disco (default `cloudrift-report-YYYY-MM-DD.pdf`)                                      | —                  |
@@ -134,6 +150,8 @@ node apps/cli/dist/main.js trend [opzioni]
 | Opzione | Descrizione | Default |
 | --- | --- | --- |
 | `--account-id <id>` | Override dell'account ID (auto-rilevato via STS se omesso) | auto-rilevato |
+| `--assume-role-arn <arn>` | Assume questo ruolo IAM via STS prima di scansionare, per l'accesso cross-account | — |
+| `--external-id <id>` | External ID da passare quando si assume `--assume-role-arn` (serve solo se la trust policy del ruolo lo richiede) | — |
 | `--config <path>` | Percorso del file di config | auto-rilevato |
 | `--format <format>` | Formato di stdout: `table` o `json` | `table` |
 | `--fail-on-increase <pct>` | Esce con codice 2 se la spesa è aumentata più di questa percentuale rispetto al periodo precedente (ha precedenza su `config.costIncreaseAlertPercent`) | off |
@@ -147,6 +165,8 @@ node apps/cli/dist/main.js trend [opzioni]
 | Opzione | Descrizione | Default |
 | --- | --- | --- |
 | `--account-id <id>` | Override dell'account ID | auto-rilevato |
+| `--assume-role-arn <arn>` | Assume questo ruolo IAM via STS prima di scansionare, per l'accesso cross-account | — |
+| `--external-id <id>` | External ID da passare quando si assume `--assume-role-arn` (serve solo se la trust policy del ruolo lo richiede) | — |
 | `--config <path>` | Percorso del file di config | auto-rilevato |
 | `--months <n>` | Numero di mesi solari da mostrare (1–36) | `6` |
 | `--services <nomi...>` | Limita a questi servizi (scorciatoie tipo `ec2 s3 rds`, oppure il nome esatto usato da Cost Explorer) | tutti i servizi |
@@ -186,6 +206,8 @@ node apps/cli/dist/main.js dead-resources [opzioni]
 | ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ |
 | `-r, --regions <regioni...>` | Regioni AWS da scansionare (ignorato dai check a scope globale — vedi sotto)                                    | `us-east-1`        |
 | `--account-id <id>`          | Override dell'account ID (rilevato automaticamente via `sts:GetCallerIdentity` se omesso)                      | auto-rilevato      |
+| `--assume-role-arn <arn>`    | Assume questo ruolo IAM via STS prima di scansionare, per l'accesso cross-account                             | —                  |
+| `--external-id <id>`        | External ID da passare quando si assume `--assume-role-arn` (serve solo se la trust policy del ruolo lo richiede) | — |
 | `--min-age-days <giorni>`    | Periodo di grazia: le risorse più giovani di N giorni non vengono segnalate (`ec2-ri-expiring-soon` non lo usa — vedi sotto) | `7` |
 | `--ignore-tag <tag>`         | Le risorse con questo tag vengono escluse dal report                                                            | `cloudrift:ignore` |
 | `--scanners <kinds...>`      | Esegue solo questi check (separati da spazio, es. `ec2-keypair-unused iam-user-inactive`)                       | tutti i check       |
@@ -249,6 +271,8 @@ node apps/cli/dist/main.js resource-security [opzioni]
 | ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ |
 | `-r, --regions <regions...>` | Regioni AWS da scansionare (ignorato dai check a scope globale — vedi sotto)                                   | `us-east-1`        |
 | `--account-id <id>`          | Override dell'account ID AWS (auto-rilevato via `sts:GetCallerIdentity` se omesso)                             | auto-rilevato      |
+| `--assume-role-arn <arn>`    | Assume questo ruolo IAM via STS prima di scansionare, per l'accesso cross-account                             | —                  |
+| `--external-id <id>`        | External ID da passare quando si assume `--assume-role-arn` (serve solo se la trust policy del ruolo lo richiede) | — |
 | `--ignore-tag <tag>`         | Le risorse con questo tag sono escluse dal report                                                              | `cloudrift:ignore` |
 | `--scanners <kinds...>`      | Esegue solo questi check (separati da spazio, es. `iam-root-mfa-disabled s3-bucket-public`)                    | tutti i check       |
 | `--format <format>`          | Formato di output su stdout: `table` o `json`                                                                  | `table`            |

--- a/libs/cloud-cost/infrastructure/aws-adapter/package.json
+++ b/libs/cloud-cost/infrastructure/aws-adapter/package.json
@@ -61,6 +61,7 @@
     "@aws-sdk/client-sqs": "~3.1095.0",
     "@aws-sdk/client-sts": "^3.1095.0",
     "@aws-sdk/client-workspaces": "^3.1095.0",
+    "@smithy/types": "^4.9.0",
     "cloud-cost-domain": "workspace:*",
     "shared-aws-infra-utils": "workspace:*",
     "shared-kernel": "workspace:*",

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/account/aws-account-id.resolver.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/account/aws-account-id.resolver.ts
@@ -1,13 +1,17 @@
 // SPDX-License-Identifier: Apache-2.0
 import { STSClient, GetCallerIdentityCommand } from '@aws-sdk/client-sts';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 
 /**
  * Resolves the AWS account ID from the current credentials via STS.
  * Returns undefined if credentials are not available: the caller decides
- * how to degrade (e.g. labeling the report as 'unknown').
+ * how to degrade (e.g. labeling the report as 'unknown'). Passing
+ * `credentials` (e.g. from `assumeRole()`) makes this reflect the assumed
+ * identity rather than the caller's own — no separate "which account did we
+ * actually scan" bookkeeping is needed elsewhere.
  */
-export async function resolveAwsAccountId(): Promise<string | undefined> {
-  const client = new STSClient({});
+export async function resolveAwsAccountId(credentials?: AwsCredentialIdentityProvider): Promise<string | undefined> {
+  const client = new STSClient({ credentials });
   try {
     const identity = await client.send(new GetCallerIdentityCommand({}));
     return identity.Account;

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/pricing/aws-pricing-api.adapter.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/pricing/aws-pricing-api.adapter.ts
@@ -4,6 +4,7 @@ import {
   GetProductsCommand,
   type Filter,
 } from '@aws-sdk/client-pricing';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { Result } from 'shared-kernel';
 import type { AwsRegion } from 'cloud-cost-domain';
 import { AwsAdapterError, createAwsClientConfig, mapWithConcurrency } from 'shared-aws-infra-utils';
@@ -166,8 +167,9 @@ const PRICE_SPECS: readonly PriceSpec[] = [
  */
 export class AwsPricingApiAdapter {
   constructor(
+    credentials?: AwsCredentialIdentityProvider,
     private readonly client = new PricingClient({
-      ...createAwsClientConfig(),
+      ...createAwsClientConfig(credentials),
       region: PRICING_API_REGION,
     }),
   ) {}

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-ami-unused.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-ami-unused.scanner.ts
@@ -10,6 +10,7 @@ import {
   type LaunchTemplate,
   type Reservation,
 } from '@aws-sdk/client-ec2';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { Result, createLogger } from 'shared-kernel';
 import type { AwsRegion, PricingPort, WasteScannerPort, WastedResource } from 'cloud-cost-domain';
 import { AmiUnused, AmiUnusedPolicy } from 'cloud-cost-domain';
@@ -32,11 +33,12 @@ export class AwsAmiUnusedScanner implements WasteScannerPort {
   constructor(
     private readonly pricing: PricingPort,
     private readonly accountId = 'unknown',
+    private readonly credentials?: AwsCredentialIdentityProvider,
     private readonly policy = new AmiUnusedPolicy(),
   ) {}
 
   async scan(region: AwsRegion): Promise<Result<WastedResource[]>> {
-    const client = new EC2Client({ ...createAwsClientConfig(), region: region.code });
+    const client = new EC2Client({ ...createAwsClientConfig(this.credentials), region: region.code });
     try {
       const [images, instances, templates] = await Promise.all([
         paginate<Image>(async (cursor) => {

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-aurora-serverless-idle.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-aurora-serverless-idle.scanner.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { RDSClient, DescribeDBClustersCommand, type DBCluster } from '@aws-sdk/client-rds';
 import type { CloudWatchClient } from '@aws-sdk/client-cloudwatch';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { createLogger } from 'shared-kernel';
 import type { AwsRegion, PricingPort, WastePolicy } from 'cloud-cost-domain';
 import { AuroraServerlessOverprovisioned, AuroraServerlessOverprovisionedPolicy } from 'cloud-cost-domain';
@@ -56,12 +57,13 @@ export class AwsAuroraServerlessIdleScanner extends CloudWatchIdleScanner<
     private readonly accountId = 'unknown',
     policy: WastePolicy<AuroraServerlessOverprovisioned> = new AuroraServerlessOverprovisionedPolicy(),
     windowHours = DEFAULT_LOOKBACK_HOURS,
+    credentials?: AwsCredentialIdentityProvider,
   ) {
-    super(policy, windowHours, METRIC_CONCURRENCY);
+    super(policy, windowHours, METRIC_CONCURRENCY, credentials);
   }
 
   protected createPrimaryClient(region: AwsRegion): RDSClient {
-    return new RDSClient({ ...createAwsClientConfig(), region: region.code });
+    return new RDSClient({ ...createAwsClientConfig(this.credentials), region: region.code });
   }
 
   protected destroyPrimaryClient(client: RDSClient): void {

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-codepipeline-pipeline-stale.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-codepipeline-pipeline-stale.scanner.ts
@@ -5,6 +5,7 @@ import {
   ListPipelineExecutionsCommand,
   type PipelineSummary,
 } from '@aws-sdk/client-codepipeline';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { Result } from 'shared-kernel';
 import type { AwsRegion, PricingPort, WasteScannerPort, WastedResource } from 'cloud-cost-domain';
 import { CodepipelinePipelineStale, CodepipelinePipelineStalePolicy } from 'cloud-cost-domain';
@@ -21,11 +22,12 @@ export class AwsCodepipelinePipelineStaleScanner implements WasteScannerPort {
   constructor(
     private readonly pricing: PricingPort,
     private readonly accountId = 'unknown',
+    private readonly credentials?: AwsCredentialIdentityProvider,
     private readonly policy = new CodepipelinePipelineStalePolicy(),
   ) {}
 
   async scan(region: AwsRegion): Promise<Result<WastedResource[]>> {
-    const client = new CodePipelineClient({ ...createAwsClientConfig(), region: region.code });
+    const client = new CodePipelineClient({ ...createAwsClientConfig(this.credentials), region: region.code });
     try {
       const rawPipelines = await paginate<PipelineSummary>(async (cursor) => {
         const r = await client.send(new ListPipelinesCommand({ nextToken: cursor }));

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-documentdb-idle.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-documentdb-idle.scanner.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { DocDBClient, DescribeDBInstancesCommand, type DBInstance } from '@aws-sdk/client-docdb';
 import type { CloudWatchClient } from '@aws-sdk/client-cloudwatch';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { createLogger } from 'shared-kernel';
 import type { AwsRegion } from 'cloud-cost-domain';
 import { DocumentDbInstance, DocumentDbIdleInstancePolicy, type WastePolicy } from 'cloud-cost-domain';
@@ -32,12 +33,13 @@ export class AwsDocumentDbIdleScanner extends CloudWatchIdleScanner<
     private readonly accountId = 'unknown',
     policy: WastePolicy<DocumentDbInstance> = new DocumentDbIdleInstancePolicy(),
     windowHours = DEFAULT_LOOKBACK_HOURS,
+    credentials?: AwsCredentialIdentityProvider,
   ) {
-    super(policy, windowHours);
+    super(policy, windowHours, undefined, credentials);
   }
 
   protected createPrimaryClient(region: AwsRegion): DocDBClient {
-    return new DocDBClient({ ...createAwsClientConfig(), region: region.code });
+    return new DocDBClient({ ...createAwsClientConfig(this.credentials), region: region.code });
   }
 
   protected destroyPrimaryClient(client: DocDBClient): void {

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-dynamodb-overprovisioned.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-dynamodb-overprovisioned.scanner.ts
@@ -6,6 +6,7 @@ import {
   type TableDescription,
 } from '@aws-sdk/client-dynamodb';
 import type { CloudWatchClient } from '@aws-sdk/client-cloudwatch';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { createLogger } from 'shared-kernel';
 import type { AwsRegion, PricingPort } from 'cloud-cost-domain';
 import { OverprovisionedDynamoDbTable, DynamoDbOverprovisionedPolicy, type WastePolicy } from 'cloud-cost-domain';
@@ -53,12 +54,13 @@ export class AwsDynamoDbOverprovisionedScanner extends CloudWatchIdleScanner<
     private readonly accountId = 'unknown',
     policy: WastePolicy<OverprovisionedDynamoDbTable> = new DynamoDbOverprovisionedPolicy(),
     windowHours = DEFAULT_WINDOW_HOURS,
+    credentials?: AwsCredentialIdentityProvider,
   ) {
-    super(policy, windowHours);
+    super(policy, windowHours, undefined, credentials);
   }
 
   protected createPrimaryClient(region: AwsRegion): DynamoDBClient {
-    return new DynamoDBClient({ ...createAwsClientConfig(), region: region.code });
+    return new DynamoDBClient({ ...createAwsClientConfig(this.credentials), region: region.code });
   }
 
   protected destroyPrimaryClient(client: DynamoDBClient): void {

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-ebs-idle.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-ebs-idle.scanner.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { EC2Client, DescribeVolumesCommand, type Volume } from '@aws-sdk/client-ec2';
 import type { CloudWatchClient } from '@aws-sdk/client-cloudwatch';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { createLogger } from 'shared-kernel';
 import type { AwsRegion, PricingPort } from 'cloud-cost-domain';
 import { IdleEbsVolume, EbsIdlePolicy, type WastePolicy } from 'cloud-cost-domain';
@@ -34,12 +35,13 @@ export class AwsEbsIdleScanner extends CloudWatchIdleScanner<EC2Client, VolumeWi
     private readonly accountId = 'unknown',
     policy: WastePolicy<IdleEbsVolume> = new EbsIdlePolicy(),
     windowHours = DEFAULT_LOOKBACK_HOURS,
+    credentials?: AwsCredentialIdentityProvider,
   ) {
-    super(policy, windowHours);
+    super(policy, windowHours, undefined, credentials);
   }
 
   protected createPrimaryClient(region: AwsRegion): EC2Client {
-    return new EC2Client({ ...createAwsClientConfig(), region: region.code });
+    return new EC2Client({ ...createAwsClientConfig(this.credentials), region: region.code });
   }
 
   protected destroyPrimaryClient(client: EC2Client): void {

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-ebs-snapshot.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-ebs-snapshot.scanner.ts
@@ -8,6 +8,7 @@ import {
   type Snapshot,
   type Volume,
 } from '@aws-sdk/client-ec2';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { Result, createLogger } from 'shared-kernel';
 import type {
   AwsRegion,
@@ -28,11 +29,12 @@ export class AwsEbsSnapshotScanner implements WasteScannerPort {
   constructor(
     private readonly pricing: PricingPort,
     private readonly accountId = 'unknown',
+    private readonly credentials?: AwsCredentialIdentityProvider,
     private readonly policy = new EbsSnapshotWastePolicy(),
   ) {}
 
   async scan(region: AwsRegion): Promise<Result<WastedResource[]>> {
-    const client = new EC2Client({ ...createAwsClientConfig(), region: region.code });
+    const client = new EC2Client({ ...createAwsClientConfig(this.credentials), region: region.code });
     try {
       // Volumes and images are correlation sets: a snapshot can only be judged
       // "orphaned" once we know for certain no volume/AMI references it anywhere

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-ebs-volume.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-ebs-volume.scanner.ts
@@ -4,6 +4,7 @@ import {
   DescribeVolumesCommand,
   type Volume,
 } from '@aws-sdk/client-ec2';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { Result, createLogger } from 'shared-kernel';
 import type {
   AwsRegion,
@@ -25,11 +26,12 @@ export class AwsEbsVolumeScanner implements WasteScannerPort {
   constructor(
     private readonly pricing: PricingPort,
     private readonly accountId = 'unknown',
+    private readonly credentials?: AwsCredentialIdentityProvider,
     private readonly policy = new EbsVolumeWastePolicy(),
   ) {}
 
   async scan(region: AwsRegion): Promise<Result<WastedResource[]>> {
-    const client = new EC2Client({ ...createAwsClientConfig(), region: region.code });
+    const client = new EC2Client({ ...createAwsClientConfig(this.credentials), region: region.code });
     try {
       // Server-side prefilter: 'available' volumes are the superset of
       // candidates; the final decision (grace period, tag) is up to the policy.

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-ec2-instance.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-ec2-instance.scanner.ts
@@ -7,6 +7,7 @@ import {
   type Reservation,
   type Volume,
 } from '@aws-sdk/client-ec2';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { Result, createLogger } from 'shared-kernel';
 import type {
   AttachedVolume,
@@ -37,11 +38,12 @@ export class AwsEc2InstanceScanner implements WasteScannerPort {
   constructor(
     private readonly pricing: PricingPort,
     private readonly accountId = 'unknown',
+    private readonly credentials?: AwsCredentialIdentityProvider,
     private readonly policy = new Ec2InstanceWastePolicy(),
   ) {}
 
   async scan(region: AwsRegion): Promise<Result<WastedResource[]>> {
-    const client = new EC2Client({ ...createAwsClientConfig(), region: region.code });
+    const client = new EC2Client({ ...createAwsClientConfig(this.credentials), region: region.code });
     try {
       const reservations = await paginate<Reservation>(async (cursor) => {
         const r = await client.send(

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-ec2-underutilized.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-ec2-underutilized.scanner.ts
@@ -6,6 +6,7 @@ import {
   type Reservation,
 } from '@aws-sdk/client-ec2';
 import type { CloudWatchClient } from '@aws-sdk/client-cloudwatch';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { createLogger } from 'shared-kernel';
 import type { AwsRegion } from 'cloud-cost-domain';
 import { UnderutilizedEc2Instance, Ec2UnderutilizedPolicy, type WastePolicy } from 'cloud-cost-domain';
@@ -53,12 +54,13 @@ export class AwsEc2UnderutilizedScanner extends CloudWatchIdleScanner<
     private readonly accountId = 'unknown',
     policy: WastePolicy<UnderutilizedEc2Instance> = new Ec2UnderutilizedPolicy(),
     windowHours = DEFAULT_WINDOW_HOURS,
+    credentials?: AwsCredentialIdentityProvider,
   ) {
-    super(policy, windowHours);
+    super(policy, windowHours, undefined, credentials);
   }
 
   protected createPrimaryClient(region: AwsRegion): EC2Client {
-    return new EC2Client({ ...createAwsClientConfig(), region: region.code });
+    return new EC2Client({ ...createAwsClientConfig(this.credentials), region: region.code });
   }
 
   protected destroyPrimaryClient(client: EC2Client): void {

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-ecr-image-untagged.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-ecr-image-untagged.scanner.ts
@@ -6,6 +6,7 @@ import {
   type ImageDetail,
   type Repository,
 } from '@aws-sdk/client-ecr';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { Result, createLogger } from 'shared-kernel';
 import type { AwsRegion, PricingPort, WasteScannerPort, WastedResource } from 'cloud-cost-domain';
 import { EcrImageUntagged, EcrImageUntaggedPolicy } from 'cloud-cost-domain';
@@ -28,11 +29,12 @@ export class AwsEcrImageUntaggedScanner implements WasteScannerPort {
   constructor(
     private readonly pricing: PricingPort,
     private readonly accountId = 'unknown',
+    private readonly credentials?: AwsCredentialIdentityProvider,
     private readonly policy = new EcrImageUntaggedPolicy(),
   ) {}
 
   async scan(region: AwsRegion): Promise<Result<WastedResource[]>> {
-    const client = new ECRClient({ ...createAwsClientConfig(), region: region.code });
+    const client = new ECRClient({ ...createAwsClientConfig(this.credentials), region: region.code });
     try {
       const repositories = await paginate<Repository>(async (cursor) => {
         const r = await client.send(new DescribeRepositoriesCommand({ nextToken: cursor }));

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-efs-unused.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-efs-unused.scanner.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { EFSClient, DescribeFileSystemsCommand, type FileSystemDescription } from '@aws-sdk/client-efs';
 import type { CloudWatchClient } from '@aws-sdk/client-cloudwatch';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { createLogger } from 'shared-kernel';
 import type { AwsRegion, PricingPort } from 'cloud-cost-domain';
 import { EfsFileSystem, EfsUnusedPolicy, type WastePolicy } from 'cloud-cost-domain';
@@ -33,12 +34,13 @@ export class AwsEfsUnusedScanner extends CloudWatchIdleScanner<
     private readonly accountId = 'unknown',
     policy: WastePolicy<EfsFileSystem> = new EfsUnusedPolicy(),
     windowHours = DEFAULT_LOOKBACK_HOURS,
+    credentials?: AwsCredentialIdentityProvider,
   ) {
-    super(policy, windowHours);
+    super(policy, windowHours, undefined, credentials);
   }
 
   protected createPrimaryClient(region: AwsRegion): EFSClient {
-    return new EFSClient({ ...createAwsClientConfig(), region: region.code });
+    return new EFSClient({ ...createAwsClientConfig(this.credentials), region: region.code });
   }
 
   protected destroyPrimaryClient(client: EFSClient): void {

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-eks-node-overprovisioned.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-eks-node-overprovisioned.scanner.ts
@@ -7,6 +7,7 @@ import {
   type Nodegroup,
 } from '@aws-sdk/client-eks';
 import type { CloudWatchClient } from '@aws-sdk/client-cloudwatch';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { createLogger } from 'shared-kernel';
 import type { AwsRegion, WastePolicy } from 'cloud-cost-domain';
 import { EksNodeOverprovisioned, EksNodeOverprovisionedPolicy } from 'cloud-cost-domain';
@@ -80,12 +81,13 @@ export class AwsEksNodeOverprovisionedScanner extends CloudWatchIdleScanner<
     private readonly accountId = 'unknown',
     policy: WastePolicy<EksNodeOverprovisioned> = new EksNodeOverprovisionedPolicy(),
     windowHours = DEFAULT_LOOKBACK_HOURS,
+    credentials?: AwsCredentialIdentityProvider,
   ) {
-    super(policy, windowHours);
+    super(policy, windowHours, undefined, credentials);
   }
 
   protected createPrimaryClient(region: AwsRegion): EKSClient {
-    return new EKSClient({ ...createAwsClientConfig(), region: region.code });
+    return new EKSClient({ ...createAwsClientConfig(this.credentials), region: region.code });
   }
 
   protected destroyPrimaryClient(client: EKSClient): void {

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-eks-orphan-pvc.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-eks-orphan-pvc.scanner.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { EC2Client, DescribeVolumesCommand, type Volume } from '@aws-sdk/client-ec2';
 import { EKSClient, ListClustersCommand } from '@aws-sdk/client-eks';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { Result, createLogger } from 'shared-kernel';
 import type { AwsRegion, PricingPort, WasteScannerPort, WastedResource } from 'cloud-cost-domain';
 import { EksOrphanPvc, EksOrphanPvcPolicy } from 'cloud-cost-domain';
@@ -34,12 +35,13 @@ export class AwsEksOrphanPvcScanner implements WasteScannerPort {
   constructor(
     private readonly pricing: PricingPort,
     private readonly accountId = 'unknown',
+    private readonly credentials?: AwsCredentialIdentityProvider,
     private readonly policy = new EksOrphanPvcPolicy(),
   ) {}
 
   async scan(region: AwsRegion): Promise<Result<WastedResource[]>> {
-    const ec2 = new EC2Client({ ...createAwsClientConfig(), region: region.code });
-    const eks = new EKSClient({ ...createAwsClientConfig(), region: region.code });
+    const ec2 = new EC2Client({ ...createAwsClientConfig(this.credentials), region: region.code });
+    const eks = new EKSClient({ ...createAwsClientConfig(this.credentials), region: region.code });
     try {
       const [rawVolumes, clusterNames] = await Promise.all([
         paginate<Volume>(async (cursor) => {

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-elastic-ip.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-elastic-ip.scanner.ts
@@ -4,6 +4,7 @@ import {
   DescribeAddressesCommand,
   type Address,
 } from '@aws-sdk/client-ec2';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { Result, createLogger } from 'shared-kernel';
 import type {
   AwsRegion,
@@ -24,11 +25,12 @@ export class AwsElasticIpScanner implements WasteScannerPort {
   constructor(
     private readonly pricing: PricingPort,
     private readonly accountId = 'unknown',
+    private readonly credentials?: AwsCredentialIdentityProvider,
     private readonly policy = new ElasticIpWastePolicy(),
   ) {}
 
   async scan(region: AwsRegion): Promise<Result<WastedResource[]>> {
-    const client = new EC2Client({ ...createAwsClientConfig(), region: region.code });
+    const client = new EC2Client({ ...createAwsClientConfig(this.credentials), region: region.code });
     try {
       const response = await client.send(
         new DescribeAddressesCommand({

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-elasticache-idle.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-elasticache-idle.scanner.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { ElastiCacheClient, DescribeCacheClustersCommand, type CacheCluster } from '@aws-sdk/client-elasticache';
 import type { CloudWatchClient } from '@aws-sdk/client-cloudwatch';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { createLogger } from 'shared-kernel';
 import type { AwsRegion } from 'cloud-cost-domain';
 import { IdleElastiCacheCluster, ElastiCacheIdlePolicy, type WastePolicy } from 'cloud-cost-domain';
@@ -32,12 +33,13 @@ export class AwsElastiCacheIdleScanner extends CloudWatchIdleScanner<
     private readonly accountId = 'unknown',
     policy: WastePolicy<IdleElastiCacheCluster> = new ElastiCacheIdlePolicy(),
     windowHours = DEFAULT_LOOKBACK_HOURS,
+    credentials?: AwsCredentialIdentityProvider,
   ) {
-    super(policy, windowHours);
+    super(policy, windowHours, undefined, credentials);
   }
 
   protected createPrimaryClient(region: AwsRegion): ElastiCacheClient {
-    return new ElastiCacheClient({ ...createAwsClientConfig(), region: region.code });
+    return new ElastiCacheClient({ ...createAwsClientConfig(this.credentials), region: region.code });
   }
 
   protected destroyPrimaryClient(client: ElastiCacheClient): void {

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-eni-orphaned.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-eni-orphaned.scanner.ts
@@ -4,6 +4,7 @@ import {
   DescribeNetworkInterfacesCommand,
   type NetworkInterface,
 } from '@aws-sdk/client-ec2';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { Result, createLogger } from 'shared-kernel';
 import type { AwsRegion, WasteScannerPort, WastedResource } from 'cloud-cost-domain';
 import { OrphanedEni, OrphanedEniWastePolicy } from 'cloud-cost-domain';
@@ -22,11 +23,12 @@ export class AwsEniOrphanedScanner implements WasteScannerPort {
 
   constructor(
     private readonly accountId = 'unknown',
+    private readonly credentials?: AwsCredentialIdentityProvider,
     private readonly policy = new OrphanedEniWastePolicy(),
   ) {}
 
   async scan(region: AwsRegion): Promise<Result<WastedResource[]>> {
-    const client = new EC2Client({ ...createAwsClientConfig(), region: region.code });
+    const client = new EC2Client({ ...createAwsClientConfig(this.credentials), region: region.code });
     try {
       const rawEnis = await paginate<NetworkInterface>(async (cursor) => {
         const r = await client.send(

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-environment-ghost.scanner.spec.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-environment-ghost.scanner.spec.ts
@@ -53,6 +53,7 @@ const OLD_TRANSITION = 'User initiated (2020-01-15 08:00:00 GMT)';
 function scanner(inactivityDays = 0, tagKeys = ['Environment']) {
   return new AwsEnvironmentGhostScanner(
     '000000000000',
+    undefined,
     new EnvironmentGhostPolicy({}, inactivityDays),
     tagKeys,
     undefined,

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-environment-ghost.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-environment-ghost.scanner.ts
@@ -16,6 +16,7 @@ import {
   type TargetGroup,
 } from '@aws-sdk/client-elastic-load-balancing-v2';
 import { CloudWatchClient } from '@aws-sdk/client-cloudwatch';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { Result } from 'shared-kernel';
 import type { AwsRegion, WasteScannerPort, WastedResource } from 'cloud-cost-domain';
 import { EnvironmentGhost, EnvironmentGhostPolicy, type WastePolicy } from 'cloud-cost-domain';
@@ -111,6 +112,7 @@ export class AwsEnvironmentGhostScanner implements WasteScannerPort {
 
   constructor(
     private readonly accountId = 'unknown',
+    private readonly credentials?: AwsCredentialIdentityProvider,
     private readonly policy: WastePolicy<EnvironmentGhost> = new EnvironmentGhostPolicy(),
     private readonly tagKeys: string[] = DEFAULT_TAG_KEYS,
     private readonly namingPatterns: string[] = DEFAULT_NAMING_PATTERNS,
@@ -118,12 +120,12 @@ export class AwsEnvironmentGhostScanner implements WasteScannerPort {
   ) {}
 
   async scan(region: AwsRegion): Promise<Result<WastedResource[]>> {
-    const taggingClient = new ResourceGroupsTaggingAPIClient({ ...createAwsClientConfig(), region: region.code });
-    const ec2Client = new EC2Client({ ...createAwsClientConfig(), region: region.code });
-    const rdsClient = new RDSClient({ ...createAwsClientConfig(), region: region.code });
-    const lambdaClient = new LambdaClient({ ...createAwsClientConfig(), region: region.code });
-    const elbClient = new ElasticLoadBalancingV2Client({ ...createAwsClientConfig(), region: region.code });
-    const cwClient = new CloudWatchClient({ ...createAwsClientConfig(), region: region.code });
+    const taggingClient = new ResourceGroupsTaggingAPIClient({ ...createAwsClientConfig(this.credentials), region: region.code });
+    const ec2Client = new EC2Client({ ...createAwsClientConfig(this.credentials), region: region.code });
+    const rdsClient = new RDSClient({ ...createAwsClientConfig(this.credentials), region: region.code });
+    const lambdaClient = new LambdaClient({ ...createAwsClientConfig(this.credentials), region: region.code });
+    const elbClient = new ElasticLoadBalancingV2Client({ ...createAwsClientConfig(this.credentials), region: region.code });
+    const cwClient = new CloudWatchClient({ ...createAwsClientConfig(this.credentials), region: region.code });
 
     try {
       const [ec2Instances, dbInstances, functions, loadBalancers] = await Promise.all([

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-fsx-idle.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-fsx-idle.scanner.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { FSxClient, DescribeFileSystemsCommand, type FileSystem } from '@aws-sdk/client-fsx';
 import type { CloudWatchClient } from '@aws-sdk/client-cloudwatch';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { createLogger } from 'shared-kernel';
 import type { AwsRegion, PricingPort } from 'cloud-cost-domain';
 import { FsxFileSystem, FsxIdleFilesystemPolicy, type WastePolicy } from 'cloud-cost-domain';
@@ -28,12 +29,13 @@ export class AwsFsxIdleScanner extends CloudWatchIdleScanner<FSxClient, FileSyst
     private readonly accountId = 'unknown',
     policy: WastePolicy<FsxFileSystem> = new FsxIdleFilesystemPolicy(),
     windowHours = DEFAULT_LOOKBACK_HOURS,
+    credentials?: AwsCredentialIdentityProvider,
   ) {
-    super(policy, windowHours);
+    super(policy, windowHours, undefined, credentials);
   }
 
   protected createPrimaryClient(region: AwsRegion): FSxClient {
-    return new FSxClient({ ...createAwsClientConfig(), region: region.code });
+    return new FSxClient({ ...createAwsClientConfig(this.credentials), region: region.code });
   }
 
   protected destroyPrimaryClient(client: FSxClient): void {

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-gp2-upgrade.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-gp2-upgrade.scanner.ts
@@ -4,6 +4,7 @@ import {
   DescribeVolumesCommand,
   type Volume,
 } from '@aws-sdk/client-ec2';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { Result, createLogger } from 'shared-kernel';
 import type {
   AwsRegion,
@@ -33,11 +34,12 @@ export class AwsGp2UpgradeScanner implements WasteScannerPort {
   constructor(
     private readonly pricing: PricingPort,
     private readonly accountId = 'unknown',
+    private readonly credentials?: AwsCredentialIdentityProvider,
     private readonly policy = new EbsGp2UpgradePolicy(),
   ) {}
 
   async scan(region: AwsRegion): Promise<Result<WastedResource[]>> {
-    const client = new EC2Client({ ...createAwsClientConfig(), region: region.code });
+    const client = new EC2Client({ ...createAwsClientConfig(this.credentials), region: region.code });
     try {
       const rawVolumes = await paginate<Volume>(async (cursor) => {
         const r = await client.send(

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-kinesis-idle.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-kinesis-idle.scanner.ts
@@ -6,6 +6,7 @@ import {
   type StreamDescriptionSummary,
 } from '@aws-sdk/client-kinesis';
 import type { CloudWatchClient } from '@aws-sdk/client-cloudwatch';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { createLogger } from 'shared-kernel';
 import type { AwsRegion, PricingPort } from 'cloud-cost-domain';
 import { KinesisStream, KinesisProvisionedIdleStreamPolicy, type WastePolicy } from 'cloud-cost-domain';
@@ -39,12 +40,13 @@ export class AwsKinesisIdleScanner extends CloudWatchIdleScanner<
     private readonly accountId = 'unknown',
     policy: WastePolicy<KinesisStream> = new KinesisProvisionedIdleStreamPolicy(),
     windowHours = DEFAULT_LOOKBACK_HOURS,
+    credentials?: AwsCredentialIdentityProvider,
   ) {
-    super(policy, windowHours, DESCRIBE_CONCURRENCY);
+    super(policy, windowHours, DESCRIBE_CONCURRENCY, credentials);
   }
 
   protected createPrimaryClient(region: AwsRegion): KinesisClient {
-    return new KinesisClient({ ...createAwsClientConfig(), region: region.code });
+    return new KinesisClient({ ...createAwsClientConfig(this.credentials), region: region.code });
   }
 
   protected destroyPrimaryClient(client: KinesisClient): void {

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-lambda-loggroup-orphaned.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-lambda-loggroup-orphaned.scanner.ts
@@ -6,6 +6,7 @@ import {
   type LogGroup as AwsLogGroup,
 } from '@aws-sdk/client-cloudwatch-logs';
 import { LambdaClient, ListFunctionsCommand, type FunctionConfiguration } from '@aws-sdk/client-lambda';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { Result, createLogger } from 'shared-kernel';
 import type { AwsRegion, PricingPort, WasteScannerPort, WastedResource } from 'cloud-cost-domain';
 import { LambdaLogGroupOrphaned, LambdaLogGroupOrphanedPolicy } from 'cloud-cost-domain';
@@ -30,12 +31,13 @@ export class AwsLambdaLogGroupOrphanedScanner implements WasteScannerPort {
   constructor(
     private readonly pricing: PricingPort,
     private readonly accountId = 'unknown',
+    private readonly credentials?: AwsCredentialIdentityProvider,
     private readonly policy = new LambdaLogGroupOrphanedPolicy(),
   ) {}
 
   async scan(region: AwsRegion): Promise<Result<WastedResource[]>> {
-    const logsClient = new CloudWatchLogsClient({ ...createAwsClientConfig(), region: region.code });
-    const lambdaClient = new LambdaClient({ ...createAwsClientConfig(), region: region.code });
+    const logsClient = new CloudWatchLogsClient({ ...createAwsClientConfig(this.credentials), region: region.code });
+    const lambdaClient = new LambdaClient({ ...createAwsClientConfig(this.credentials), region: region.code });
     try {
       const [rawLogGroups, functions] = await Promise.all([
         paginate<AwsLogGroup>(async (cursor) => {

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-lambda-underutilized.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-lambda-underutilized.scanner.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { LambdaClient, ListFunctionsCommand, type FunctionConfiguration } from '@aws-sdk/client-lambda';
 import type { CloudWatchClient } from '@aws-sdk/client-cloudwatch';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { createLogger } from 'shared-kernel';
 import type { AwsRegion } from 'cloud-cost-domain';
 import { UnderutilizedLambdaFunction, LambdaUnderutilizedPolicy, type WastePolicy } from 'cloud-cost-domain';
@@ -26,12 +27,13 @@ export class AwsLambdaUnderutilizedScanner extends CloudWatchIdleScanner<
     private readonly accountId = 'unknown',
     policy: WastePolicy<UnderutilizedLambdaFunction> = new LambdaUnderutilizedPolicy(),
     windowHours = DEFAULT_WINDOW_HOURS,
+    credentials?: AwsCredentialIdentityProvider,
   ) {
-    super(policy, windowHours);
+    super(policy, windowHours, undefined, credentials);
   }
 
   protected createPrimaryClient(region: AwsRegion): LambdaClient {
-    return new LambdaClient({ ...createAwsClientConfig(), region: region.code });
+    return new LambdaClient({ ...createAwsClientConfig(this.credentials), region: region.code });
   }
 
   protected destroyPrimaryClient(client: LambdaClient): void {

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-load-balancer.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-load-balancer.scanner.ts
@@ -7,6 +7,7 @@ import {
   type LoadBalancer as AwsLoadBalancer,
   type TargetGroup,
 } from '@aws-sdk/client-elastic-load-balancing-v2';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { Result, createLogger } from 'shared-kernel';
 import type {
   AwsRegion,
@@ -28,11 +29,12 @@ export class AwsLoadBalancerScanner implements WasteScannerPort {
   constructor(
     private readonly pricing: PricingPort,
     private readonly accountId = 'unknown',
+    private readonly credentials?: AwsCredentialIdentityProvider,
     private readonly policy = new LoadBalancerWastePolicy(),
   ) {}
 
   async scan(region: AwsRegion): Promise<Result<WastedResource[]>> {
-    const client = new ElasticLoadBalancingV2Client({ ...createAwsClientConfig(), region: region.code });
+    const client = new ElasticLoadBalancingV2Client({ ...createAwsClientConfig(this.credentials), region: region.code });
     try {
       const allLbs = await paginate<AwsLoadBalancer>(async (cursor) => {
         const r = await client.send(new DescribeLoadBalancersCommand({ Marker: cursor }));

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-log-group.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-log-group.scanner.ts
@@ -4,6 +4,7 @@ import {
   DescribeLogGroupsCommand,
   type LogGroup as AwsLogGroup,
 } from '@aws-sdk/client-cloudwatch-logs';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { Result, createLogger } from 'shared-kernel';
 import type { AwsRegion, PricingPort, WasteScannerPort, WastedResource } from 'cloud-cost-domain';
 import { LogGroup, LogGroupWastePolicy } from 'cloud-cost-domain';
@@ -19,11 +20,12 @@ export class AwsLogGroupScanner implements WasteScannerPort {
   constructor(
     private readonly pricing: PricingPort,
     private readonly accountId = 'unknown',
+    private readonly credentials?: AwsCredentialIdentityProvider,
     private readonly policy = new LogGroupWastePolicy(),
   ) {}
 
   async scan(region: AwsRegion): Promise<Result<WastedResource[]>> {
-    const client = new CloudWatchLogsClient({ ...createAwsClientConfig(), region: region.code });
+    const client = new CloudWatchLogsClient({ ...createAwsClientConfig(this.credentials), region: region.code });
     try {
       const pricePerGb = this.pricing.getPrice(region, 'cw-logs');
       const now = new Date();

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-mq-idle.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-mq-idle.scanner.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { MqClient, ListBrokersCommand, type BrokerSummary } from '@aws-sdk/client-mq';
 import type { CloudWatchClient } from '@aws-sdk/client-cloudwatch';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { createLogger } from 'shared-kernel';
 import type { AwsRegion } from 'cloud-cost-domain';
 import { MqBroker, MqIdleBrokerPolicy, type WastePolicy } from 'cloud-cost-domain';
@@ -61,12 +62,13 @@ export class AwsMqIdleScanner extends CloudWatchIdleScanner<MqClient, BrokerWith
     private readonly accountId = 'unknown',
     policy: WastePolicy<MqBroker> = new MqIdleBrokerPolicy(),
     windowHours = DEFAULT_LOOKBACK_HOURS,
+    credentials?: AwsCredentialIdentityProvider,
   ) {
-    super(policy, windowHours);
+    super(policy, windowHours, undefined, credentials);
   }
 
   protected createPrimaryClient(region: AwsRegion): MqClient {
-    return new MqClient({ ...createAwsClientConfig(), region: region.code });
+    return new MqClient({ ...createAwsClientConfig(this.credentials), region: region.code });
   }
 
   protected destroyPrimaryClient(client: MqClient): void {

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-msk-idle.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-msk-idle.scanner.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { KafkaClient, ListClustersV2Command, type Cluster } from '@aws-sdk/client-kafka';
 import type { CloudWatchClient } from '@aws-sdk/client-cloudwatch';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { createLogger } from 'shared-kernel';
 import type { AwsRegion } from 'cloud-cost-domain';
 import { MskCluster, MskIdleClusterPolicy, type WastePolicy } from 'cloud-cost-domain';
@@ -33,12 +34,13 @@ export class AwsMskIdleScanner extends CloudWatchIdleScanner<KafkaClient, Cluste
     private readonly accountId = 'unknown',
     policy: WastePolicy<MskCluster> = new MskIdleClusterPolicy(),
     windowHours = DEFAULT_LOOKBACK_HOURS,
+    credentials?: AwsCredentialIdentityProvider,
   ) {
-    super(policy, windowHours);
+    super(policy, windowHours, undefined, credentials);
   }
 
   protected createPrimaryClient(region: AwsRegion): KafkaClient {
-    return new KafkaClient({ ...createAwsClientConfig(), region: region.code });
+    return new KafkaClient({ ...createAwsClientConfig(this.credentials), region: region.code });
   }
 
   protected destroyPrimaryClient(client: KafkaClient): void {

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-nat-gateway.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-nat-gateway.scanner.ts
@@ -5,6 +5,7 @@ import {
   type NatGateway as AwsNatGateway,
 } from '@aws-sdk/client-ec2';
 import type { CloudWatchClient } from '@aws-sdk/client-cloudwatch';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { createLogger } from 'shared-kernel';
 import type { AwsRegion, PricingPort } from 'cloud-cost-domain';
 import { NatGateway, NatGatewayWastePolicy, type WastePolicy } from 'cloud-cost-domain';
@@ -27,12 +28,13 @@ export class AwsNatGatewayScanner extends CloudWatchIdleScanner<EC2Client, NatGa
     private readonly accountId = 'unknown',
     policy: WastePolicy<NatGateway> = new NatGatewayWastePolicy(),
     windowHours = DEFAULT_LOOKBACK_HOURS,
+    credentials?: AwsCredentialIdentityProvider,
   ) {
-    super(policy, windowHours);
+    super(policy, windowHours, undefined, credentials);
   }
 
   protected createPrimaryClient(region: AwsRegion): EC2Client {
-    return new EC2Client({ ...createAwsClientConfig(), region: region.code });
+    return new EC2Client({ ...createAwsClientConfig(this.credentials), region: region.code });
   }
 
   protected destroyPrimaryClient(client: EC2Client): void {

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-neptune-idle.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-neptune-idle.scanner.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { NeptuneClient, DescribeDBInstancesCommand, type DBInstance } from '@aws-sdk/client-neptune';
 import type { CloudWatchClient } from '@aws-sdk/client-cloudwatch';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { createLogger } from 'shared-kernel';
 import type { AwsRegion } from 'cloud-cost-domain';
 import { NeptuneInstance, NeptuneIdleInstancePolicy, type WastePolicy } from 'cloud-cost-domain';
@@ -27,12 +28,13 @@ export class AwsNeptuneIdleScanner extends CloudWatchIdleScanner<NeptuneClient, 
     private readonly accountId = 'unknown',
     policy: WastePolicy<NeptuneInstance> = new NeptuneIdleInstancePolicy(),
     windowHours = DEFAULT_LOOKBACK_HOURS,
+    credentials?: AwsCredentialIdentityProvider,
   ) {
-    super(policy, windowHours);
+    super(policy, windowHours, undefined, credentials);
   }
 
   protected createPrimaryClient(region: AwsRegion): NeptuneClient {
-    return new NeptuneClient({ ...createAwsClientConfig(), region: region.code });
+    return new NeptuneClient({ ...createAwsClientConfig(this.credentials), region: region.code });
   }
 
   protected destroyPrimaryClient(client: NeptuneClient): void {

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-opensearch-idle.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-opensearch-idle.scanner.ts
@@ -6,6 +6,7 @@ import {
   type DomainStatus,
 } from '@aws-sdk/client-opensearch';
 import type { CloudWatchClient } from '@aws-sdk/client-cloudwatch';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { createLogger } from 'shared-kernel';
 import type { AwsRegion } from 'cloud-cost-domain';
 import { OpenSearchDomain, OpenSearchIdleDomainPolicy, type WastePolicy } from 'cloud-cost-domain';
@@ -46,12 +47,13 @@ export class AwsOpenSearchIdleScanner extends CloudWatchIdleScanner<
     private readonly accountId = 'unknown',
     policy: WastePolicy<OpenSearchDomain> = new OpenSearchIdleDomainPolicy(),
     windowHours = DEFAULT_LOOKBACK_HOURS,
+    credentials?: AwsCredentialIdentityProvider,
   ) {
-    super(policy, windowHours);
+    super(policy, windowHours, undefined, credentials);
   }
 
   protected createPrimaryClient(region: AwsRegion): OpenSearchClient {
-    return new OpenSearchClient({ ...createAwsClientConfig(), region: region.code });
+    return new OpenSearchClient({ ...createAwsClientConfig(this.credentials), region: region.code });
   }
 
   protected destroyPrimaryClient(client: OpenSearchClient): void {

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-rds-instance.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-rds-instance.scanner.ts
@@ -4,6 +4,7 @@ import {
   DescribeDBInstancesCommand,
   type DBInstance,
 } from '@aws-sdk/client-rds';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { Result, createLogger } from 'shared-kernel';
 import type {
   AwsRegion,
@@ -26,11 +27,12 @@ export class AwsRdsInstanceScanner implements WasteScannerPort {
   constructor(
     private readonly pricing: PricingPort,
     private readonly accountId = 'unknown',
+    private readonly credentials?: AwsCredentialIdentityProvider,
     private readonly policy = new RdsInstanceWastePolicy(),
   ) {}
 
   async scan(region: AwsRegion): Promise<Result<WastedResource[]>> {
-    const client = new RDSClient({ ...createAwsClientConfig(), region: region.code });
+    const client = new RDSClient({ ...createAwsClientConfig(this.credentials), region: region.code });
     try {
       // `db-instance-status` is not a recognized DescribeDBInstances filter
       // name; RdsInstanceWastePolicy.judge() re-checks db.isStopped() below.

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-rds-manual-snapshot-old.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-rds-manual-snapshot-old.scanner.ts
@@ -4,6 +4,7 @@ import {
   DescribeDBSnapshotsCommand,
   type DBSnapshot,
 } from '@aws-sdk/client-rds';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { Result, createLogger } from 'shared-kernel';
 import type { AwsRegion, PricingPort, WasteScannerPort, WastedResource } from 'cloud-cost-domain';
 import { RdsManualSnapshotOld, RdsManualSnapshotOldPolicy } from 'cloud-cost-domain';
@@ -19,11 +20,12 @@ export class AwsRdsManualSnapshotOldScanner implements WasteScannerPort {
   constructor(
     private readonly pricing: PricingPort,
     private readonly accountId = 'unknown',
+    private readonly credentials?: AwsCredentialIdentityProvider,
     private readonly policy = new RdsManualSnapshotOldPolicy(),
   ) {}
 
   async scan(region: AwsRegion): Promise<Result<WastedResource[]>> {
-    const client = new RDSClient({ ...createAwsClientConfig(), region: region.code });
+    const client = new RDSClient({ ...createAwsClientConfig(this.credentials), region: region.code });
     try {
       const rawSnapshots = await paginate<DBSnapshot>(async (cursor) => {
         const r = await client.send(

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-rds-underutilized.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-rds-underutilized.scanner.ts
@@ -5,6 +5,7 @@ import {
   type DBInstance,
 } from '@aws-sdk/client-rds';
 import type { CloudWatchClient } from '@aws-sdk/client-cloudwatch';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { createLogger } from 'shared-kernel';
 import type { AwsRegion } from 'cloud-cost-domain';
 import { RdsUnderutilizedInstance, RdsUnderutilizedPolicy, type WastePolicy } from 'cloud-cost-domain';
@@ -77,12 +78,13 @@ export class AwsRdsUnderutilizedScanner extends CloudWatchIdleScanner<
     private readonly accountId = 'unknown',
     policy: WastePolicy<RdsUnderutilizedInstance> = new RdsUnderutilizedPolicy(),
     windowHours = DEFAULT_WINDOW_HOURS,
+    credentials?: AwsCredentialIdentityProvider,
   ) {
-    super(policy, windowHours);
+    super(policy, windowHours, undefined, credentials);
   }
 
   protected createPrimaryClient(region: AwsRegion): RDSClient {
-    return new RDSClient({ ...createAwsClientConfig(), region: region.code });
+    return new RDSClient({ ...createAwsClientConfig(this.credentials), region: region.code });
   }
 
   protected destroyPrimaryClient(client: RDSClient): void {

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-redshift-idle.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-redshift-idle.scanner.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { RedshiftClient, DescribeClustersCommand, type Cluster } from '@aws-sdk/client-redshift';
 import type { CloudWatchClient } from '@aws-sdk/client-cloudwatch';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { createLogger } from 'shared-kernel';
 import type { AwsRegion } from 'cloud-cost-domain';
 import { RedshiftCluster, RedshiftIdleClusterPolicy, type WastePolicy } from 'cloud-cost-domain';
@@ -27,12 +28,13 @@ export class AwsRedshiftIdleScanner extends CloudWatchIdleScanner<RedshiftClient
     private readonly accountId = 'unknown',
     policy: WastePolicy<RedshiftCluster> = new RedshiftIdleClusterPolicy(),
     windowHours = DEFAULT_LOOKBACK_HOURS,
+    credentials?: AwsCredentialIdentityProvider,
   ) {
-    super(policy, windowHours);
+    super(policy, windowHours, undefined, credentials);
   }
 
   protected createPrimaryClient(region: AwsRegion): RedshiftClient {
-    return new RedshiftClient({ ...createAwsClientConfig(), region: region.code });
+    return new RedshiftClient({ ...createAwsClientConfig(this.credentials), region: region.code });
   }
 
   protected destroyPrimaryClient(client: RedshiftClient): void {

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-s3-multipart-upload-abandoned.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-s3-multipart-upload-abandoned.scanner.ts
@@ -8,6 +8,7 @@ import {
   type MultipartUpload,
   type Part,
 } from '@aws-sdk/client-s3';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { Result, createLogger } from 'shared-kernel';
 import type { AwsRegion, PricingPort, WasteScannerPort, WastedResource } from 'cloud-cost-domain';
 import { S3MultipartUploadAbandoned, S3MultipartUploadAbandonedPolicy } from 'cloud-cost-domain';
@@ -39,12 +40,13 @@ export class AwsS3MultipartUploadAbandonedScanner implements WasteScannerPort {
   constructor(
     private readonly pricing: PricingPort,
     private readonly accountId = 'unknown',
+    private readonly credentials?: AwsCredentialIdentityProvider,
     private readonly policy = new S3MultipartUploadAbandonedPolicy(),
   ) {}
 
   async scan(region: AwsRegion): Promise<Result<WastedResource[]>> {
     const s3 = new S3Client({
-      ...createAwsClientConfig(),
+      ...createAwsClientConfig(this.credentials),
       region: region.code,
       forcePathStyle: !!process.env.AWS_ENDPOINT_URL,
     });

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-s3-no-lifecycle.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-s3-no-lifecycle.scanner.ts
@@ -6,6 +6,7 @@ import {
   type Bucket,
 } from '@aws-sdk/client-s3';
 import { CloudWatchClient } from '@aws-sdk/client-cloudwatch';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { Result, createLogger } from 'shared-kernel';
 import type { AwsRegion, PricingPort, WasteScannerPort, WastedResource } from 'cloud-cost-domain';
 import { S3Bucket, S3NoLifecyclePolicy } from 'cloud-cost-domain';
@@ -31,16 +32,17 @@ export class AwsS3NoLifecycleScanner implements WasteScannerPort {
   constructor(
     private readonly pricing: PricingPort,
     private readonly accountId = 'unknown',
+    private readonly credentials?: AwsCredentialIdentityProvider,
     private readonly policy = new S3NoLifecyclePolicy(),
   ) {}
 
   async scan(region: AwsRegion): Promise<Result<WastedResource[]>> {
     const s3 = new S3Client({
-      ...createAwsClientConfig(),
+      ...createAwsClientConfig(this.credentials),
       region: region.code,
       forcePathStyle: !!process.env.AWS_ENDPOINT_URL,
     });
-    const cw = new CloudWatchClient({ ...createAwsClientConfig(), region: region.code });
+    const cw = new CloudWatchClient({ ...createAwsClientConfig(this.credentials), region: region.code });
     try {
       const allBuckets = await paginate<Bucket>(async (cursor) => {
         const r = await s3.send(

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-sagemaker-endpoint-idle.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-sagemaker-endpoint-idle.scanner.ts
@@ -8,6 +8,7 @@ import {
   type EndpointSummary,
 } from '@aws-sdk/client-sagemaker';
 import type { CloudWatchClient } from '@aws-sdk/client-cloudwatch';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { createLogger } from 'shared-kernel';
 import type { AwsRegion } from 'cloud-cost-domain';
 import { SageMakerEndpointIdle, SageMakerEndpointIdlePolicy, type WastePolicy } from 'cloud-cost-domain';
@@ -60,12 +61,13 @@ export class AwsSageMakerEndpointIdleScanner extends CloudWatchIdleScanner<
     private readonly accountId = 'unknown',
     policy: WastePolicy<SageMakerEndpointIdle> = new SageMakerEndpointIdlePolicy(),
     windowHours = DEFAULT_LOOKBACK_HOURS,
+    credentials?: AwsCredentialIdentityProvider,
   ) {
-    super(policy, windowHours);
+    super(policy, windowHours, undefined, credentials);
   }
 
   protected createPrimaryClient(region: AwsRegion): SageMakerClient {
-    return new SageMakerClient({ ...createAwsClientConfig(), region: region.code });
+    return new SageMakerClient({ ...createAwsClientConfig(this.credentials), region: region.code });
   }
 
   protected destroyPrimaryClient(client: SageMakerClient): void {

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-sagemaker-notebook-idle.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-sagemaker-notebook-idle.scanner.ts
@@ -5,6 +5,7 @@ import {
   type NotebookInstanceSummary,
 } from '@aws-sdk/client-sagemaker';
 import type { CloudWatchClient } from '@aws-sdk/client-cloudwatch';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { createLogger } from 'shared-kernel';
 import type { AwsRegion } from 'cloud-cost-domain';
 import { SageMakerNotebookIdle, SageMakerNotebookIdlePolicy, type WastePolicy } from 'cloud-cost-domain';
@@ -43,12 +44,13 @@ export class AwsSageMakerNotebookIdleScanner extends CloudWatchIdleScanner<
     private readonly accountId = 'unknown',
     policy: WastePolicy<SageMakerNotebookIdle> = new SageMakerNotebookIdlePolicy(),
     windowHours = DEFAULT_LOOKBACK_HOURS,
+    credentials?: AwsCredentialIdentityProvider,
   ) {
-    super(policy, windowHours);
+    super(policy, windowHours, undefined, credentials);
   }
 
   protected createPrimaryClient(region: AwsRegion): SageMakerClient {
-    return new SageMakerClient({ ...createAwsClientConfig(), region: region.code });
+    return new SageMakerClient({ ...createAwsClientConfig(this.credentials), region: region.code });
   }
 
   protected destroyPrimaryClient(client: SageMakerClient): void {

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-sagemaker-training-orphaned.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-sagemaker-training-orphaned.scanner.ts
@@ -8,6 +8,7 @@ import {
   type ModelSummary,
   type EndpointConfigSummary,
 } from '@aws-sdk/client-sagemaker';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { Result, createLogger } from 'shared-kernel';
 import type { AwsRegion, PricingPort, WasteScannerPort, WastedResource } from 'cloud-cost-domain';
 import { SageMakerTrainingOrphaned, SageMakerTrainingOrphanedPolicy } from 'cloud-cost-domain';
@@ -44,11 +45,12 @@ export class AwsSageMakerTrainingOrphanedScanner implements WasteScannerPort {
   constructor(
     private readonly pricing: PricingPort,
     private readonly accountId = 'unknown',
+    private readonly credentials?: AwsCredentialIdentityProvider,
     private readonly policy = new SageMakerTrainingOrphanedPolicy(),
   ) {}
 
   async scan(region: AwsRegion): Promise<Result<WastedResource[]>> {
-    const client = new SageMakerClient({ ...createAwsClientConfig(), region: region.code });
+    const client = new SageMakerClient({ ...createAwsClientConfig(this.credentials), region: region.code });
     try {
       const [rawModels, rawConfigs] = await Promise.all([
         paginate<ModelSummary>(async (cursor) => {

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-secretsmanager-unused.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-secretsmanager-unused.scanner.ts
@@ -4,6 +4,7 @@ import {
   ListSecretsCommand,
   type SecretListEntry,
 } from '@aws-sdk/client-secrets-manager';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { Result, createLogger } from 'shared-kernel';
 import type { AwsRegion, PricingPort, WasteScannerPort, WastedResource } from 'cloud-cost-domain';
 import { SecretsManagerUnused, SecretsManagerUnusedPolicy } from 'cloud-cost-domain';
@@ -19,11 +20,12 @@ export class AwsSecretsManagerUnusedScanner implements WasteScannerPort {
   constructor(
     private readonly pricing: PricingPort,
     private readonly accountId = 'unknown',
+    private readonly credentials?: AwsCredentialIdentityProvider,
     private readonly policy = new SecretsManagerUnusedPolicy(),
   ) {}
 
   async scan(region: AwsRegion): Promise<Result<WastedResource[]>> {
-    const client = new SecretsManagerClient({ ...createAwsClientConfig(), region: region.code });
+    const client = new SecretsManagerClient({ ...createAwsClientConfig(this.credentials), region: region.code });
     try {
       const rawSecrets = await paginate<SecretListEntry>(async (cursor) => {
         const r = await client.send(new ListSecretsCommand({ NextToken: cursor }));

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-sqs-dlq-abandoned.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-sqs-dlq-abandoned.scanner.ts
@@ -7,6 +7,7 @@ import {
   ListQueueTagsCommand,
 } from '@aws-sdk/client-sqs';
 import type { CloudWatchClient } from '@aws-sdk/client-cloudwatch';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import type { AwsRegion } from 'cloud-cost-domain';
 import { SqsDlqAbandoned, SqsDlqAbandonedWastePolicy, type WastePolicy } from 'cloud-cost-domain';
 import { paginate, mapWithConcurrency, createAwsClientConfig } from 'shared-aws-infra-utils';
@@ -56,12 +57,13 @@ export class AwsSqsDlqAbandonedScanner extends CloudWatchIdleScanner<SQSClient, 
     private readonly accountId = 'unknown',
     policy: WastePolicy<SqsDlqAbandoned> = new SqsDlqAbandonedWastePolicy(),
     windowHours = DEFAULT_LOOKBACK_HOURS,
+    credentials?: AwsCredentialIdentityProvider,
   ) {
-    super(policy, windowHours);
+    super(policy, windowHours, undefined, credentials);
   }
 
   protected createPrimaryClient(region: AwsRegion): SQSClient {
-    return new SQSClient({ ...createAwsClientConfig(), region: region.code });
+    return new SQSClient({ ...createAwsClientConfig(this.credentials), region: region.code });
   }
 
   protected destroyPrimaryClient(client: SQSClient): void {

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-transit-gateway-idle.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-transit-gateway-idle.scanner.ts
@@ -5,6 +5,7 @@ import {
   type TransitGatewayAttachment as SdkTransitGatewayAttachment,
 } from '@aws-sdk/client-ec2';
 import type { CloudWatchClient } from '@aws-sdk/client-cloudwatch';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { createLogger } from 'shared-kernel';
 import type { AwsRegion, PricingPort } from 'cloud-cost-domain';
 import { TransitGatewayAttachment, TransitGatewayIdleAttachmentPolicy, type WastePolicy } from 'cloud-cost-domain';
@@ -39,12 +40,13 @@ export class AwsTransitGatewayIdleScanner extends CloudWatchIdleScanner<
     private readonly accountId = 'unknown',
     policy: WastePolicy<TransitGatewayAttachment> = new TransitGatewayIdleAttachmentPolicy(),
     windowHours = DEFAULT_LOOKBACK_HOURS,
+    credentials?: AwsCredentialIdentityProvider,
   ) {
-    super(policy, windowHours);
+    super(policy, windowHours, undefined, credentials);
   }
 
   protected createPrimaryClient(region: AwsRegion): EC2Client {
-    return new EC2Client({ ...createAwsClientConfig(), region: region.code });
+    return new EC2Client({ ...createAwsClientConfig(this.credentials), region: region.code });
   }
 
   protected destroyPrimaryClient(client: EC2Client): void {

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-vpn-connection-idle.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-vpn-connection-idle.scanner.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { EC2Client, DescribeVpnConnectionsCommand, type VpnConnection as SdkVpnConnection } from '@aws-sdk/client-ec2';
 import type { CloudWatchClient } from '@aws-sdk/client-cloudwatch';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { createLogger } from 'shared-kernel';
 import type { AwsRegion, PricingPort } from 'cloud-cost-domain';
 import { VpnConnection, VpnConnectionIdlePolicy, type WastePolicy } from 'cloud-cost-domain';
@@ -28,12 +29,13 @@ export class AwsVpnConnectionIdleScanner extends CloudWatchIdleScanner<EC2Client
     private readonly accountId = 'unknown',
     policy: WastePolicy<VpnConnection> = new VpnConnectionIdlePolicy(),
     windowHours = DEFAULT_LOOKBACK_HOURS,
+    credentials?: AwsCredentialIdentityProvider,
   ) {
-    super(policy, windowHours);
+    super(policy, windowHours, undefined, credentials);
   }
 
   protected createPrimaryClient(region: AwsRegion): EC2Client {
-    return new EC2Client({ ...createAwsClientConfig(), region: region.code });
+    return new EC2Client({ ...createAwsClientConfig(this.credentials), region: region.code });
   }
 
   protected destroyPrimaryClient(client: EC2Client): void {

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-workspaces-idle.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/aws-workspaces-idle.scanner.ts
@@ -5,6 +5,7 @@ import {
   DescribeWorkspacesConnectionStatusCommand,
   type Workspace as SdkWorkspace,
 } from '@aws-sdk/client-workspaces';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { Result, createLogger } from 'shared-kernel';
 import type { AwsRegion, WasteScannerPort, WastedResource } from 'cloud-cost-domain';
 import { Workspace, WorkspacesIdlePolicy } from 'cloud-cost-domain';
@@ -36,11 +37,12 @@ export class AwsWorkspacesIdleScanner implements WasteScannerPort {
   constructor(
     private readonly pricing: WorkSpacesBundlePricingSource,
     private readonly accountId = 'unknown',
+    private readonly credentials?: AwsCredentialIdentityProvider,
     private readonly policy = new WorkspacesIdlePolicy(),
   ) {}
 
   async scan(region: AwsRegion): Promise<Result<WastedResource[]>> {
-    const workspaces = new WorkSpacesClient({ ...createAwsClientConfig(), region: region.code });
+    const workspaces = new WorkSpacesClient({ ...createAwsClientConfig(this.credentials), region: region.code });
     try {
       const rawWorkspaces = await paginate<SdkWorkspace>(async (cursor) => {
         const r = await workspaces.send(new DescribeWorkspacesCommand({ NextToken: cursor }));

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/cloudwatch-idle.scanner.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/cloudwatch-idle.scanner.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import { CloudWatchClient } from '@aws-sdk/client-cloudwatch';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { Result } from 'shared-kernel';
 import type { AwsRegion, ResourceKind, WasteScannerPort, WastedResource, WastePolicy } from 'cloud-cost-domain';
 import { AwsAdapterError, mapWithConcurrency, createAwsClientConfig } from 'shared-aws-infra-utils';
@@ -29,11 +30,12 @@ export abstract class CloudWatchIdleScanner<TPrimaryClient, TRaw, TMetric, TEnti
     protected readonly policy: WastePolicy<TEntity>,
     protected readonly windowHours: number,
     protected readonly metricConcurrency = 5,
+    protected readonly credentials?: AwsCredentialIdentityProvider,
   ) {}
 
   async scan(region: AwsRegion): Promise<Result<WastedResource[]>> {
     const primary = this.createPrimaryClient(region);
-    const cw = new CloudWatchClient({ ...createAwsClientConfig(), region: region.code });
+    const cw = new CloudWatchClient({ ...createAwsClientConfig(this.credentials), region: region.code });
     try {
       const raw = await this.listResources(primary, region);
       if (raw.length === 0) return Result.ok([]);

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/scanner-contract.spec.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/scanners/scanner-contract.spec.ts
@@ -200,19 +200,24 @@ const ACCOUNT = '000000000000';
 const region = AwsRegion.create('us-east-1');
 
 /** Mirrors the registry's wiring (thresholds included), one factory per kind. */
+// Rule of thumb for the `undefined` slots below (the new `credentials?`
+// param added for --assume-role-arn, see assumeRole()/createAwsClientConfig):
+// "flat" scanners take it right after `accountId` (before `policy`);
+// `CloudWatchIdleScanner` subclasses take it as their own LAST param
+// (forwarded to the base class), so their existing calls are unaffected.
 const scannerFactories: Record<ResourceKind, () => WasteScannerPort> = {
-  'ebs-volume': () => new AwsEbsVolumeScanner(pricing, ACCOUNT, new EbsVolumeWastePolicy(po)),
-  'elastic-ip': () => new AwsElasticIpScanner(pricing, ACCOUNT, new ElasticIpWastePolicy(po)),
-  'rds-instance': () => new AwsRdsInstanceScanner(pricing, ACCOUNT, new RdsInstanceWastePolicy(po)),
-  'load-balancer': () => new AwsLoadBalancerScanner(pricing, ACCOUNT, new LoadBalancerWastePolicy(po)),
-  'ec2-instance': () => new AwsEc2InstanceScanner(pricing, ACCOUNT, new Ec2InstanceWastePolicy(po)),
-  'ebs-snapshot': () => new AwsEbsSnapshotScanner(pricing, ACCOUNT, new EbsSnapshotWastePolicy(po)),
+  'ebs-volume': () => new AwsEbsVolumeScanner(pricing, ACCOUNT, undefined, new EbsVolumeWastePolicy(po)),
+  'elastic-ip': () => new AwsElasticIpScanner(pricing, ACCOUNT, undefined, new ElasticIpWastePolicy(po)),
+  'rds-instance': () => new AwsRdsInstanceScanner(pricing, ACCOUNT, undefined, new RdsInstanceWastePolicy(po)),
+  'load-balancer': () => new AwsLoadBalancerScanner(pricing, ACCOUNT, undefined, new LoadBalancerWastePolicy(po)),
+  'ec2-instance': () => new AwsEc2InstanceScanner(pricing, ACCOUNT, undefined, new Ec2InstanceWastePolicy(po)),
+  'ebs-snapshot': () => new AwsEbsSnapshotScanner(pricing, ACCOUNT, undefined, new EbsSnapshotWastePolicy(po)),
   'nat-gateway': () => new AwsNatGatewayScanner(pricing, ACCOUNT, new NatGatewayWastePolicy(po)),
-  'ebs-gp2-upgrade': () => new AwsGp2UpgradeScanner(pricing, ACCOUNT, new EbsGp2UpgradePolicy(po)),
+  'ebs-gp2-upgrade': () => new AwsGp2UpgradeScanner(pricing, ACCOUNT, undefined, new EbsGp2UpgradePolicy(po)),
   'ebs-idle': () => new AwsEbsIdleScanner(pricing, ACCOUNT, new EbsIdlePolicy(po, 0)),
-  'log-group': () => new AwsLogGroupScanner(pricing, ACCOUNT, new LogGroupWastePolicy(po)),
-  'eni-orphaned': () => new AwsEniOrphanedScanner(ACCOUNT, new OrphanedEniWastePolicy(po)),
-  's3-no-lifecycle': () => new AwsS3NoLifecycleScanner(pricing, ACCOUNT, new S3NoLifecyclePolicy(po)),
+  'log-group': () => new AwsLogGroupScanner(pricing, ACCOUNT, undefined, new LogGroupWastePolicy(po)),
+  'eni-orphaned': () => new AwsEniOrphanedScanner(ACCOUNT, undefined, new OrphanedEniWastePolicy(po)),
+  's3-no-lifecycle': () => new AwsS3NoLifecycleScanner(pricing, ACCOUNT, undefined, new S3NoLifecyclePolicy(po)),
   'lambda-underutilized': () => new AwsLambdaUnderutilizedScanner(ACCOUNT, new LambdaUnderutilizedPolicy(po, 0)),
   'efs-unused': () => new AwsEfsUnusedScanner(pricing, ACCOUNT, new EfsUnusedPolicy(po, 0)),
   'dynamodb-overprovisioned': () =>
@@ -225,7 +230,7 @@ const scannerFactories: Record<ResourceKind, () => WasteScannerPort> = {
     new AwsKinesisIdleScanner(pricing, ACCOUNT, new KinesisProvisionedIdleStreamPolicy(po)),
   'sqs-dlq-abandoned': () => new AwsSqsDlqAbandonedScanner(ACCOUNT, new SqsDlqAbandonedWastePolicy(po)),
   'lambda-loggroup-orphaned': () =>
-    new AwsLambdaLogGroupOrphanedScanner(pricing, ACCOUNT, new LambdaLogGroupOrphanedPolicy(po)),
+    new AwsLambdaLogGroupOrphanedScanner(pricing, ACCOUNT, undefined, new LambdaLogGroupOrphanedPolicy(po)),
   'aurora-serverless-overprovisioned': () =>
     new AwsAuroraServerlessIdleScanner(pricing, ACCOUNT, new AuroraServerlessOverprovisionedPolicy(po, 50)),
   'ec2-underutilized': () => new AwsEc2UnderutilizedScanner(livePrices, ACCOUNT, new Ec2UnderutilizedPolicy(po, 5)),
@@ -238,28 +243,28 @@ const scannerFactories: Record<ResourceKind, () => WasteScannerPort> = {
     new AwsDocumentDbIdleScanner(livePrices, ACCOUNT, new DocumentDbIdleInstancePolicy(po)),
   'neptune-idle-instance': () => new AwsNeptuneIdleScanner(livePrices, ACCOUNT, new NeptuneIdleInstancePolicy(po)),
   'mq-idle-broker': () => new AwsMqIdleScanner(livePrices, ACCOUNT, new MqIdleBrokerPolicy(po)),
-  'workspaces-idle': () => new AwsWorkspacesIdleScanner(livePrices, ACCOUNT, new WorkspacesIdlePolicy(po)),
+  'workspaces-idle': () => new AwsWorkspacesIdleScanner(livePrices, ACCOUNT, undefined, new WorkspacesIdlePolicy(po)),
   'sagemaker-notebook-idle': () =>
     new AwsSageMakerNotebookIdleScanner(livePrices, ACCOUNT, new SageMakerNotebookIdlePolicy(po, 2)),
   'sagemaker-endpoint-idle': () =>
     new AwsSageMakerEndpointIdleScanner(livePrices, ACCOUNT, new SageMakerEndpointIdlePolicy(po)),
   'sagemaker-training-orphaned': () =>
-    new AwsSageMakerTrainingOrphanedScanner(pricing, ACCOUNT, new SageMakerTrainingOrphanedPolicy(po)),
+    new AwsSageMakerTrainingOrphanedScanner(pricing, ACCOUNT, undefined, new SageMakerTrainingOrphanedPolicy(po)),
   'environment-ghost': () =>
-    new AwsEnvironmentGhostScanner(ACCOUNT, new EnvironmentGhostPolicy(po, 7), undefined, undefined, 7),
+    new AwsEnvironmentGhostScanner(ACCOUNT, undefined, new EnvironmentGhostPolicy(po, 7), undefined, undefined, 7),
   'eks-node-overprovisioned': () =>
     new AwsEksNodeOverprovisionedScanner(livePrices, ACCOUNT, new EksNodeOverprovisionedPolicy(po, 30)),
-  'eks-orphan-pvc': () => new AwsEksOrphanPvcScanner(pricing, ACCOUNT, new EksOrphanPvcPolicy(po)),
-  'ami-unused': () => new AwsAmiUnusedScanner(pricing, ACCOUNT, new AmiUnusedPolicy(po)),
-  'ecr-image-untagged': () => new AwsEcrImageUntaggedScanner(pricing, ACCOUNT, new EcrImageUntaggedPolicy(po)),
+  'eks-orphan-pvc': () => new AwsEksOrphanPvcScanner(pricing, ACCOUNT, undefined, new EksOrphanPvcPolicy(po)),
+  'ami-unused': () => new AwsAmiUnusedScanner(pricing, ACCOUNT, undefined, new AmiUnusedPolicy(po)),
+  'ecr-image-untagged': () => new AwsEcrImageUntaggedScanner(pricing, ACCOUNT, undefined, new EcrImageUntaggedPolicy(po)),
   's3-multipart-upload-abandoned': () =>
-    new AwsS3MultipartUploadAbandonedScanner(pricing, ACCOUNT, new S3MultipartUploadAbandonedPolicy(po)),
+    new AwsS3MultipartUploadAbandonedScanner(pricing, ACCOUNT, undefined, new S3MultipartUploadAbandonedPolicy(po)),
   'rds-manual-snapshot-old': () =>
-    new AwsRdsManualSnapshotOldScanner(pricing, ACCOUNT, new RdsManualSnapshotOldPolicy(po)),
+    new AwsRdsManualSnapshotOldScanner(pricing, ACCOUNT, undefined, new RdsManualSnapshotOldPolicy(po)),
   'secretsmanager-unused': () =>
-    new AwsSecretsManagerUnusedScanner(pricing, ACCOUNT, new SecretsManagerUnusedPolicy(po)),
+    new AwsSecretsManagerUnusedScanner(pricing, ACCOUNT, undefined, new SecretsManagerUnusedPolicy(po)),
   'codepipeline-pipeline-stale': () =>
-    new AwsCodepipelinePipelineStaleScanner(pricing, ACCOUNT, new CodepipelinePipelineStalePolicy(po)),
+    new AwsCodepipelinePipelineStaleScanner(pricing, ACCOUNT, undefined, new CodepipelinePipelineStalePolicy(po)),
 };
 
 const byId = (a: { id: string }, b: { id: string }) => a.id.localeCompare(b.id);

--- a/libs/cost-analytics/infrastructure/aws-adapter/package.json
+++ b/libs/cost-analytics/infrastructure/aws-adapter/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-cost-explorer": "^3.1095.0",
+    "@smithy/types": "^4.9.0",
     "cost-analytics-domain": "workspace:*",
     "shared-aws-infra-utils": "workspace:*",
     "shared-kernel": "workspace:*",

--- a/libs/cost-analytics/infrastructure/aws-adapter/src/cost-explorer/aws-cost-explorer.adapter.ts
+++ b/libs/cost-analytics/infrastructure/aws-adapter/src/cost-explorer/aws-cost-explorer.adapter.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import { CostExplorerClient, GetCostAndUsageCommand, type ResultByTime } from '@aws-sdk/client-cost-explorer';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { Result } from 'shared-kernel';
 import type { CostByService, CostExplorerPort, CostPeriodBucket } from 'cost-analytics-domain';
 import { AwsAdapterError, createAwsClientConfig } from 'shared-aws-infra-utils';
@@ -14,12 +15,14 @@ const METRIC = 'UnblendedCost';
 const COST_EXPLORER_REGION = 'us-east-1';
 
 export class AwsCostExplorerAdapter implements CostExplorerPort {
+  constructor(private readonly credentials?: AwsCredentialIdentityProvider) {}
+
   async getCostAndUsage(params: {
     startDate: string;
     endDate: string;
     granularity: 'DAILY' | 'MONTHLY';
   }): Promise<Result<CostPeriodBucket[]>> {
-    const client = new CostExplorerClient({ ...createAwsClientConfig(), region: COST_EXPLORER_REGION });
+    const client = new CostExplorerClient({ ...createAwsClientConfig(this.credentials), region: COST_EXPLORER_REGION });
     try {
       const results: ResultByTime[] = [];
       let nextPageToken: string | undefined;

--- a/libs/dead-resources/infrastructure/aws-adapter/package.json
+++ b/libs/dead-resources/infrastructure/aws-adapter/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/client-s3": "^3.1095.0",
     "@aws-sdk/client-sfn": "^3.1095.0",
     "@aws-sdk/client-sns": "^3.1095.0",
+    "@smithy/types": "^4.9.0",
     "dead-resources-domain": "workspace:*",
     "shared-aws-infra-utils": "workspace:*",
     "shared-kernel": "workspace:*",

--- a/libs/dead-resources/infrastructure/aws-adapter/src/scanners/aws-acm-certificate-unused.scanner.ts
+++ b/libs/dead-resources/infrastructure/aws-adapter/src/scanners/aws-acm-certificate-unused.scanner.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import { ACMClient, ListCertificatesCommand, type CertificateSummary } from '@aws-sdk/client-acm';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { Result } from 'shared-kernel';
 import type { AwsRegion, DeadResourceScannerPort, DeadResource } from 'dead-resources-domain';
 import { AcmCertificateUnused, AcmCertificateUnusedPolicy } from 'dead-resources-domain';
@@ -19,11 +20,12 @@ export class AwsAcmCertificateUnusedScanner implements DeadResourceScannerPort {
 
   constructor(
     private readonly accountId = 'unknown',
+    private readonly credentials?: AwsCredentialIdentityProvider,
     private readonly policy = new AcmCertificateUnusedPolicy(),
   ) {}
 
   async scan(region: AwsRegion): Promise<Result<DeadResource[]>> {
-    const client = new ACMClient({ ...createAwsClientConfig(), region: region.code });
+    const client = new ACMClient({ ...createAwsClientConfig(this.credentials), region: region.code });
     try {
       const rawCerts = await paginate<CertificateSummary>(async (cursor) => {
         const r = await client.send(new ListCertificatesCommand({ NextToken: cursor }));

--- a/libs/dead-resources/infrastructure/aws-adapter/src/scanners/aws-cloudformation-stack-stuck.scanner.ts
+++ b/libs/dead-resources/infrastructure/aws-adapter/src/scanners/aws-cloudformation-stack-stuck.scanner.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import { CloudFormationClient, DescribeStacksCommand, type Stack } from '@aws-sdk/client-cloudformation';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { Result } from 'shared-kernel';
 import type { AwsRegion, DeadResourceScannerPort, DeadResource } from 'dead-resources-domain';
 import { CloudformationStackStuck, CloudformationStackStuckPolicy } from 'dead-resources-domain';
@@ -21,11 +22,12 @@ export class AwsCloudformationStackStuckScanner implements DeadResourceScannerPo
 
   constructor(
     private readonly accountId = 'unknown',
+    private readonly credentials?: AwsCredentialIdentityProvider,
     private readonly policy = new CloudformationStackStuckPolicy(),
   ) {}
 
   async scan(region: AwsRegion): Promise<Result<DeadResource[]>> {
-    const client = new CloudFormationClient({ ...createAwsClientConfig(), region: region.code });
+    const client = new CloudFormationClient({ ...createAwsClientConfig(this.credentials), region: region.code });
     try {
       const rawStacks = await paginate<Stack>(async (cursor) => {
         const r = await client.send(new DescribeStacksCommand({ NextToken: cursor }));

--- a/libs/dead-resources/infrastructure/aws-adapter/src/scanners/aws-cloudwatch-alarm-orphaned.scanner.ts
+++ b/libs/dead-resources/infrastructure/aws-adapter/src/scanners/aws-cloudwatch-alarm-orphaned.scanner.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import { CloudWatchClient, DescribeAlarmsCommand, type MetricAlarm } from '@aws-sdk/client-cloudwatch';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { Result } from 'shared-kernel';
 import type { AwsRegion, DeadResourceScannerPort, DeadResource } from 'dead-resources-domain';
 import { CloudwatchAlarmOrphaned, CloudwatchAlarmOrphanedPolicy } from 'dead-resources-domain';
@@ -21,11 +22,12 @@ export class AwsCloudwatchAlarmOrphanedScanner implements DeadResourceScannerPor
 
   constructor(
     private readonly accountId = 'unknown',
+    private readonly credentials?: AwsCredentialIdentityProvider,
     private readonly policy = new CloudwatchAlarmOrphanedPolicy(),
   ) {}
 
   async scan(region: AwsRegion): Promise<Result<DeadResource[]>> {
-    const client = new CloudWatchClient({ ...createAwsClientConfig(), region: region.code });
+    const client = new CloudWatchClient({ ...createAwsClientConfig(this.credentials), region: region.code });
     try {
       const rawAlarms = await paginate<MetricAlarm>(async (cursor) => {
         const r = await client.send(new DescribeAlarmsCommand({ StateValue: 'INSUFFICIENT_DATA', NextToken: cursor }));

--- a/libs/dead-resources/infrastructure/aws-adapter/src/scanners/aws-ec2-keypair-unused.scanner.ts
+++ b/libs/dead-resources/infrastructure/aws-adapter/src/scanners/aws-ec2-keypair-unused.scanner.ts
@@ -7,6 +7,7 @@ import {
   type Instance,
   type Reservation,
 } from '@aws-sdk/client-ec2';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { Result, createLogger } from 'shared-kernel';
 import type { AwsRegion, DeadResourceScannerPort, DeadResource } from 'dead-resources-domain';
 import { Ec2KeyPairUnused, Ec2KeyPairUnusedPolicy } from 'dead-resources-domain';
@@ -28,11 +29,12 @@ export class AwsEc2KeyPairUnusedScanner implements DeadResourceScannerPort {
 
   constructor(
     private readonly accountId = 'unknown',
+    private readonly credentials?: AwsCredentialIdentityProvider,
     private readonly policy = new Ec2KeyPairUnusedPolicy(),
   ) {}
 
   async scan(region: AwsRegion): Promise<Result<DeadResource[]>> {
-    const client = new EC2Client({ ...createAwsClientConfig(), region: region.code });
+    const client = new EC2Client({ ...createAwsClientConfig(this.credentials), region: region.code });
     try {
       const [keyPairsResponse, instances] = await Promise.all([
         client.send(new DescribeKeyPairsCommand({})),

--- a/libs/dead-resources/infrastructure/aws-adapter/src/scanners/aws-ec2-ri-expiring-soon.scanner.ts
+++ b/libs/dead-resources/infrastructure/aws-adapter/src/scanners/aws-ec2-ri-expiring-soon.scanner.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import { EC2Client, DescribeReservedInstancesCommand, type ReservedInstances } from '@aws-sdk/client-ec2';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { Result } from 'shared-kernel';
 import type { AwsRegion, DeadResourceScannerPort, DeadResource } from 'dead-resources-domain';
 import { Ec2RiExpiringSoon, Ec2RiExpiringSoonPolicy } from 'dead-resources-domain';
@@ -23,11 +24,12 @@ export class AwsEc2RiExpiringSoonScanner implements DeadResourceScannerPort {
 
   constructor(
     private readonly accountId = 'unknown',
+    private readonly credentials?: AwsCredentialIdentityProvider,
     private readonly policy = new Ec2RiExpiringSoonPolicy(),
   ) {}
 
   async scan(region: AwsRegion): Promise<Result<DeadResource[]>> {
-    const client = new EC2Client({ ...createAwsClientConfig(), region: region.code });
+    const client = new EC2Client({ ...createAwsClientConfig(this.credentials), region: region.code });
     try {
       const response = await client.send(
         new DescribeReservedInstancesCommand({ Filters: [{ Name: 'state', Values: ['active'] }] }),

--- a/libs/dead-resources/infrastructure/aws-adapter/src/scanners/aws-ec2-security-group-unused.scanner.ts
+++ b/libs/dead-resources/infrastructure/aws-adapter/src/scanners/aws-ec2-security-group-unused.scanner.ts
@@ -6,6 +6,7 @@ import {
   type SecurityGroup,
   type NetworkInterface,
 } from '@aws-sdk/client-ec2';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { Result } from 'shared-kernel';
 import type { AwsRegion, DeadResourceScannerPort, DeadResource } from 'dead-resources-domain';
 import { Ec2SecurityGroupUnused, Ec2SecurityGroupUnusedPolicy } from 'dead-resources-domain';
@@ -24,11 +25,12 @@ export class AwsEc2SecurityGroupUnusedScanner implements DeadResourceScannerPort
 
   constructor(
     private readonly accountId = 'unknown',
+    private readonly credentials?: AwsCredentialIdentityProvider,
     private readonly policy = new Ec2SecurityGroupUnusedPolicy(),
   ) {}
 
   async scan(region: AwsRegion): Promise<Result<DeadResource[]>> {
-    const client = new EC2Client({ ...createAwsClientConfig(), region: region.code });
+    const client = new EC2Client({ ...createAwsClientConfig(this.credentials), region: region.code });
     try {
       const [rawGroups, enis] = await Promise.all([
         paginate<SecurityGroup>(async (cursor) => {

--- a/libs/dead-resources/infrastructure/aws-adapter/src/scanners/aws-ecr-repository-empty.scanner.ts
+++ b/libs/dead-resources/infrastructure/aws-adapter/src/scanners/aws-ecr-repository-empty.scanner.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import { ECRClient, DescribeRepositoriesCommand, DescribeImagesCommand, type Repository } from '@aws-sdk/client-ecr';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { Result, createLogger } from 'shared-kernel';
 import type { AwsRegion, DeadResourceScannerPort, DeadResource } from 'dead-resources-domain';
 import { EcrRepositoryEmpty, EcrRepositoryEmptyPolicy } from 'dead-resources-domain';
@@ -25,11 +26,12 @@ export class AwsEcrRepositoryEmptyScanner implements DeadResourceScannerPort {
 
   constructor(
     private readonly accountId = 'unknown',
+    private readonly credentials?: AwsCredentialIdentityProvider,
     private readonly policy = new EcrRepositoryEmptyPolicy(),
   ) {}
 
   async scan(region: AwsRegion): Promise<Result<DeadResource[]>> {
-    const client = new ECRClient({ ...createAwsClientConfig(), region: region.code });
+    const client = new ECRClient({ ...createAwsClientConfig(this.credentials), region: region.code });
     try {
       const rawRepos = await paginate<Repository>(async (cursor) => {
         const r = await client.send(new DescribeRepositoriesCommand({ nextToken: cursor }));

--- a/libs/dead-resources/infrastructure/aws-adapter/src/scanners/aws-eventbridge-rule-no-targets.scanner.ts
+++ b/libs/dead-resources/infrastructure/aws-adapter/src/scanners/aws-eventbridge-rule-no-targets.scanner.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import { EventBridgeClient, ListRulesCommand, ListTargetsByRuleCommand, type Rule } from '@aws-sdk/client-eventbridge';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { Result } from 'shared-kernel';
 import type { AwsRegion, DeadResourceScannerPort, DeadResource } from 'dead-resources-domain';
 import { EventbridgeRuleNoTargets, EventbridgeRuleNoTargetsPolicy } from 'dead-resources-domain';
@@ -23,11 +24,12 @@ export class AwsEventbridgeRuleNoTargetsScanner implements DeadResourceScannerPo
 
   constructor(
     private readonly accountId = 'unknown',
+    private readonly credentials?: AwsCredentialIdentityProvider,
     private readonly policy = new EventbridgeRuleNoTargetsPolicy(),
   ) {}
 
   async scan(region: AwsRegion): Promise<Result<DeadResource[]>> {
-    const client = new EventBridgeClient({ ...createAwsClientConfig(), region: region.code });
+    const client = new EventBridgeClient({ ...createAwsClientConfig(this.credentials), region: region.code });
     try {
       const rawRules = await paginate<Rule>(async (cursor) => {
         const r = await client.send(new ListRulesCommand({ NextToken: cursor }));

--- a/libs/dead-resources/infrastructure/aws-adapter/src/scanners/aws-iam-access-key-stale.scanner.ts
+++ b/libs/dead-resources/infrastructure/aws-adapter/src/scanners/aws-iam-access-key-stale.scanner.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import { IAMClient, ListUsersCommand, ListAccessKeysCommand, type User, type AccessKeyMetadata } from '@aws-sdk/client-iam';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { Result } from 'shared-kernel';
 import type { AwsRegion, DeadResourceScannerPort, DeadResource } from 'dead-resources-domain';
 import { IamAccessKeyStale, IamAccessKeyStalePolicy } from 'dead-resources-domain';
@@ -27,11 +28,12 @@ export class AwsIamAccessKeyStaleScanner implements DeadResourceScannerPort {
 
   constructor(
     private readonly accountId = 'unknown',
+    private readonly credentials?: AwsCredentialIdentityProvider,
     private readonly policy = new IamAccessKeyStalePolicy(),
   ) {}
 
   async scan(_region: AwsRegion): Promise<Result<DeadResource[]>> {
-    const client = new IAMClient({ ...createAwsClientConfig(), region: IAM_ENDPOINT_REGION });
+    const client = new IAMClient({ ...createAwsClientConfig(this.credentials), region: IAM_ENDPOINT_REGION });
     try {
       const rawUsers = await paginate<User>(async (cursor) => {
         const r = await client.send(new ListUsersCommand({ Marker: cursor }));

--- a/libs/dead-resources/infrastructure/aws-adapter/src/scanners/aws-iam-instance-profile-unattached.scanner.ts
+++ b/libs/dead-resources/infrastructure/aws-adapter/src/scanners/aws-iam-instance-profile-unattached.scanner.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { IAMClient, ListInstanceProfilesCommand, type InstanceProfile } from '@aws-sdk/client-iam';
 import { EC2Client, DescribeRegionsCommand, DescribeInstancesCommand, type Reservation, type Instance } from '@aws-sdk/client-ec2';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { Result, createLogger } from 'shared-kernel';
 import type { AwsRegion, DeadResourceScannerPort, DeadResource } from 'dead-resources-domain';
 import { IamInstanceProfileUnattached, IamInstanceProfileUnattachedPolicy } from 'dead-resources-domain';
@@ -44,12 +45,13 @@ export class AwsIamInstanceProfileUnattachedScanner implements DeadResourceScann
 
   constructor(
     private readonly accountId = 'unknown',
+    private readonly credentials?: AwsCredentialIdentityProvider,
     private readonly policy = new IamInstanceProfileUnattachedPolicy(),
   ) {}
 
   async scan(_region: AwsRegion): Promise<Result<DeadResource[]>> {
-    const iamClient = new IAMClient({ ...createAwsClientConfig(), region: IAM_ENDPOINT_REGION });
-    const regionDiscoveryClient = new EC2Client({ ...createAwsClientConfig(), region: IAM_ENDPOINT_REGION });
+    const iamClient = new IAMClient({ ...createAwsClientConfig(this.credentials), region: IAM_ENDPOINT_REGION });
+    const regionDiscoveryClient = new EC2Client({ ...createAwsClientConfig(this.credentials), region: IAM_ENDPOINT_REGION });
     try {
       const [rawProfiles, regionsResponse] = await Promise.all([
         paginate<InstanceProfile>(async (cursor) => {
@@ -63,7 +65,7 @@ export class AwsIamInstanceProfileUnattachedScanner implements DeadResourceScann
 
       const inUseArns = new Set<string>();
       await mapWithConcurrency(enabledRegionCodes, REGION_SCAN_CONCURRENCY, async (regionCode) => {
-        const client = new EC2Client({ ...createAwsClientConfig(), region: regionCode });
+        const client = new EC2Client({ ...createAwsClientConfig(this.credentials), region: regionCode });
         try {
           const instances = await paginate<Reservation, Instance>(
             async (cursor) => {

--- a/libs/dead-resources/infrastructure/aws-adapter/src/scanners/aws-iam-policy-unattached.scanner.ts
+++ b/libs/dead-resources/infrastructure/aws-adapter/src/scanners/aws-iam-policy-unattached.scanner.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import { IAMClient, ListPoliciesCommand, type Policy } from '@aws-sdk/client-iam';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { Result } from 'shared-kernel';
 import type { AwsRegion, DeadResourceScannerPort, DeadResource } from 'dead-resources-domain';
 import { IamPolicyUnattached, IamPolicyUnattachedPolicy } from 'dead-resources-domain';
@@ -23,11 +24,12 @@ export class AwsIamPolicyUnattachedScanner implements DeadResourceScannerPort {
 
   constructor(
     private readonly accountId = 'unknown',
+    private readonly credentials?: AwsCredentialIdentityProvider,
     private readonly policy = new IamPolicyUnattachedPolicy(),
   ) {}
 
   async scan(_region: AwsRegion): Promise<Result<DeadResource[]>> {
-    const client = new IAMClient({ ...createAwsClientConfig(), region: IAM_ENDPOINT_REGION });
+    const client = new IAMClient({ ...createAwsClientConfig(this.credentials), region: IAM_ENDPOINT_REGION });
     try {
       const rawPolicies = await paginate<Policy>(async (cursor) => {
         const r = await client.send(new ListPoliciesCommand({ Scope: 'Local', Marker: cursor }));

--- a/libs/dead-resources/infrastructure/aws-adapter/src/scanners/aws-iam-role-unused.scanner.ts
+++ b/libs/dead-resources/infrastructure/aws-adapter/src/scanners/aws-iam-role-unused.scanner.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import { IAMClient, ListRolesCommand, type Role } from '@aws-sdk/client-iam';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { Result } from 'shared-kernel';
 import type { AwsRegion, DeadResourceScannerPort, DeadResource } from 'dead-resources-domain';
 import { IamRoleUnused, IamRoleUnusedPolicy } from 'dead-resources-domain';
@@ -24,11 +25,12 @@ export class AwsIamRoleUnusedScanner implements DeadResourceScannerPort {
 
   constructor(
     private readonly accountId = 'unknown',
+    private readonly credentials?: AwsCredentialIdentityProvider,
     private readonly policy = new IamRoleUnusedPolicy(),
   ) {}
 
   async scan(_region: AwsRegion): Promise<Result<DeadResource[]>> {
-    const client = new IAMClient({ ...createAwsClientConfig(), region: IAM_ENDPOINT_REGION });
+    const client = new IAMClient({ ...createAwsClientConfig(this.credentials), region: IAM_ENDPOINT_REGION });
     try {
       const rawRoles = await paginate<Role>(async (cursor) => {
         const r = await client.send(new ListRolesCommand({ Marker: cursor }));

--- a/libs/dead-resources/infrastructure/aws-adapter/src/scanners/aws-iam-user-inactive.scanner.ts
+++ b/libs/dead-resources/infrastructure/aws-adapter/src/scanners/aws-iam-user-inactive.scanner.ts
@@ -6,6 +6,7 @@ import {
   GetAccessKeyLastUsedCommand,
   type User,
 } from '@aws-sdk/client-iam';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { Result } from 'shared-kernel';
 import type { AwsRegion, DeadResourceScannerPort, DeadResource } from 'dead-resources-domain';
 import { IamUserInactive, IamUserInactivePolicy } from 'dead-resources-domain';
@@ -48,11 +49,12 @@ export class AwsIamUserInactiveScanner implements DeadResourceScannerPort {
 
   constructor(
     private readonly accountId = 'unknown',
+    private readonly credentials?: AwsCredentialIdentityProvider,
     private readonly policy = new IamUserInactivePolicy(),
   ) {}
 
   async scan(_region: AwsRegion): Promise<Result<DeadResource[]>> {
-    const client = new IAMClient({ ...createAwsClientConfig(), region: IAM_ENDPOINT_REGION });
+    const client = new IAMClient({ ...createAwsClientConfig(this.credentials), region: IAM_ENDPOINT_REGION });
     try {
       const rawUsers = await paginate<User>(async (cursor) => {
         const r = await client.send(new ListUsersCommand({ Marker: cursor }));

--- a/libs/dead-resources/infrastructure/aws-adapter/src/scanners/aws-logs-loggroup-empty.scanner.ts
+++ b/libs/dead-resources/infrastructure/aws-adapter/src/scanners/aws-logs-loggroup-empty.scanner.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import { CloudWatchLogsClient, DescribeLogGroupsCommand, type LogGroup } from '@aws-sdk/client-cloudwatch-logs';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { Result } from 'shared-kernel';
 import type { AwsRegion, DeadResourceScannerPort, DeadResource } from 'dead-resources-domain';
 import { LogsLogGroupEmpty, LogsLogGroupEmptyPolicy } from 'dead-resources-domain';
@@ -18,11 +19,12 @@ export class AwsLogsLogGroupEmptyScanner implements DeadResourceScannerPort {
 
   constructor(
     private readonly accountId = 'unknown',
+    private readonly credentials?: AwsCredentialIdentityProvider,
     private readonly policy = new LogsLogGroupEmptyPolicy(),
   ) {}
 
   async scan(region: AwsRegion): Promise<Result<DeadResource[]>> {
-    const client = new CloudWatchLogsClient({ ...createAwsClientConfig(), region: region.code });
+    const client = new CloudWatchLogsClient({ ...createAwsClientConfig(this.credentials), region: region.code });
     try {
       const rawGroups = await paginate<LogGroup>(async (cursor) => {
         const r = await client.send(new DescribeLogGroupsCommand({ nextToken: cursor }));

--- a/libs/dead-resources/infrastructure/aws-adapter/src/scanners/aws-route53-hostedzone-empty.scanner.ts
+++ b/libs/dead-resources/infrastructure/aws-adapter/src/scanners/aws-route53-hostedzone-empty.scanner.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import { Route53Client, ListHostedZonesCommand, type HostedZone } from '@aws-sdk/client-route-53';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { Result } from 'shared-kernel';
 import type { AwsRegion, DeadResourceScannerPort, DeadResource } from 'dead-resources-domain';
 import { Route53HostedZoneEmpty, Route53HostedZoneEmptyPolicy } from 'dead-resources-domain';
@@ -26,11 +27,12 @@ export class AwsRoute53HostedZoneEmptyScanner implements DeadResourceScannerPort
 
   constructor(
     private readonly accountId = 'unknown',
+    private readonly credentials?: AwsCredentialIdentityProvider,
     private readonly policy = new Route53HostedZoneEmptyPolicy(),
   ) {}
 
   async scan(_region: AwsRegion): Promise<Result<DeadResource[]>> {
-    const client = new Route53Client({ ...createAwsClientConfig(), region: ROUTE53_ENDPOINT_REGION });
+    const client = new Route53Client({ ...createAwsClientConfig(this.credentials), region: ROUTE53_ENDPOINT_REGION });
     try {
       const rawZones = await paginate<HostedZone>(async (cursor) => {
         const r = await client.send(new ListHostedZonesCommand({ Marker: cursor }));

--- a/libs/dead-resources/infrastructure/aws-adapter/src/scanners/aws-s3-bucket-empty.scanner.ts
+++ b/libs/dead-resources/infrastructure/aws-adapter/src/scanners/aws-s3-bucket-empty.scanner.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import { S3Client, ListBucketsCommand, ListObjectsV2Command, type Bucket } from '@aws-sdk/client-s3';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { Result, createLogger } from 'shared-kernel';
 import type { AwsRegion, DeadResourceScannerPort, DeadResource } from 'dead-resources-domain';
 import { S3BucketEmpty, S3BucketEmptyPolicy } from 'dead-resources-domain';
@@ -31,12 +32,13 @@ export class AwsS3BucketEmptyScanner implements DeadResourceScannerPort {
 
   constructor(
     private readonly accountId = 'unknown',
+    private readonly credentials?: AwsCredentialIdentityProvider,
     private readonly policy = new S3BucketEmptyPolicy(),
   ) {}
 
   async scan(_region: AwsRegion): Promise<Result<DeadResource[]>> {
     const client = new S3Client({
-      ...createAwsClientConfig(),
+      ...createAwsClientConfig(this.credentials),
       region: S3_ENDPOINT_REGION,
       followRegionRedirects: true,
     });

--- a/libs/dead-resources/infrastructure/aws-adapter/src/scanners/aws-sns-topic-unsubscribed.scanner.ts
+++ b/libs/dead-resources/infrastructure/aws-adapter/src/scanners/aws-sns-topic-unsubscribed.scanner.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import { SNSClient, ListTopicsCommand, ListSubscriptionsByTopicCommand, type Topic } from '@aws-sdk/client-sns';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { Result } from 'shared-kernel';
 import type { AwsRegion, DeadResourceScannerPort, DeadResource } from 'dead-resources-domain';
 import { SnsTopicUnsubscribed, SnsTopicUnsubscribedPolicy } from 'dead-resources-domain';
@@ -23,11 +24,12 @@ export class AwsSnsTopicUnsubscribedScanner implements DeadResourceScannerPort {
 
   constructor(
     private readonly accountId = 'unknown',
+    private readonly credentials?: AwsCredentialIdentityProvider,
     private readonly policy = new SnsTopicUnsubscribedPolicy(),
   ) {}
 
   async scan(region: AwsRegion): Promise<Result<DeadResource[]>> {
-    const client = new SNSClient({ ...createAwsClientConfig(), region: region.code });
+    const client = new SNSClient({ ...createAwsClientConfig(this.credentials), region: region.code });
     try {
       const rawTopics = await paginate<Topic>(async (cursor) => {
         const r = await client.send(new ListTopicsCommand({ NextToken: cursor }));

--- a/libs/dead-resources/infrastructure/aws-adapter/src/scanners/aws-stepfunctions-statemachine-unused.scanner.ts
+++ b/libs/dead-resources/infrastructure/aws-adapter/src/scanners/aws-stepfunctions-statemachine-unused.scanner.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import { SFNClient, ListStateMachinesCommand, ListExecutionsCommand, type StateMachineListItem } from '@aws-sdk/client-sfn';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { Result } from 'shared-kernel';
 import type { AwsRegion, DeadResourceScannerPort, DeadResource } from 'dead-resources-domain';
 import { StepfunctionsStatemachineUnused, StepfunctionsStatemachineUnusedPolicy } from 'dead-resources-domain';
@@ -23,11 +24,12 @@ export class AwsStepfunctionsStatemachineUnusedScanner implements DeadResourceSc
 
   constructor(
     private readonly accountId = 'unknown',
+    private readonly credentials?: AwsCredentialIdentityProvider,
     private readonly policy = new StepfunctionsStatemachineUnusedPolicy(),
   ) {}
 
   async scan(region: AwsRegion): Promise<Result<DeadResource[]>> {
-    const client = new SFNClient({ ...createAwsClientConfig(), region: region.code });
+    const client = new SFNClient({ ...createAwsClientConfig(this.credentials), region: region.code });
     try {
       const rawMachines = await paginate<StateMachineListItem>(async (cursor) => {
         const r = await client.send(new ListStateMachinesCommand({ nextToken: cursor }));

--- a/libs/dead-resources/infrastructure/aws-adapter/src/scanners/dead-resources-contract.spec.ts
+++ b/libs/dead-resources/infrastructure/aws-adapter/src/scanners/dead-resources-contract.spec.ts
@@ -148,25 +148,28 @@ const ACCOUNT = '000000000000';
 // ("global" for the two IAM kinds), never parsed or passed to `scan()`.
 const region = AwsRegion.create('us-east-1');
 
+// The `undefined` right after ACCOUNT below is the new `credentials?` param
+// (for --assume-role-arn, see assumeRole()/createAwsClientConfig) — every
+// scanner in this domain is the "flat" shape, so it sits before `policy`.
 const scannerFactories: Record<DeadResourceKind, () => DeadResourceScannerPort> = {
-  'ec2-keypair-unused': () => new AwsEc2KeyPairUnusedScanner(ACCOUNT, new Ec2KeyPairUnusedPolicy(po)),
-  'ec2-ri-expiring-soon': () => new AwsEc2RiExpiringSoonScanner(ACCOUNT, new Ec2RiExpiringSoonPolicy(po, 999_999)),
-  'iam-user-inactive': () => new AwsIamUserInactiveScanner(ACCOUNT, new IamUserInactivePolicy(po, 0)),
-  'iam-policy-unattached': () => new AwsIamPolicyUnattachedScanner(ACCOUNT, new IamPolicyUnattachedPolicy(po)),
-  'iam-role-unused': () => new AwsIamRoleUnusedScanner(ACCOUNT, new IamRoleUnusedPolicy(po, 0)),
-  'iam-access-key-stale': () => new AwsIamAccessKeyStaleScanner(ACCOUNT, new IamAccessKeyStalePolicy(po)),
-  'ec2-security-group-unused': () => new AwsEc2SecurityGroupUnusedScanner(ACCOUNT, new Ec2SecurityGroupUnusedPolicy(po)),
-  'logs-loggroup-empty': () => new AwsLogsLogGroupEmptyScanner(ACCOUNT, new LogsLogGroupEmptyPolicy(po)),
-  'acm-certificate-unused': () => new AwsAcmCertificateUnusedScanner(ACCOUNT, new AcmCertificateUnusedPolicy(po)),
-  'route53-hostedzone-empty': () => new AwsRoute53HostedZoneEmptyScanner(ACCOUNT, new Route53HostedZoneEmptyPolicy(po)),
-  'cloudformation-stack-stuck': () => new AwsCloudformationStackStuckScanner(ACCOUNT, new CloudformationStackStuckPolicy(po)),
-  's3-bucket-empty': () => new AwsS3BucketEmptyScanner(ACCOUNT, new S3BucketEmptyPolicy(po)),
-  'cloudwatch-alarm-orphaned': () => new AwsCloudwatchAlarmOrphanedScanner(ACCOUNT, new CloudwatchAlarmOrphanedPolicy(po)),
-  'sns-topic-unsubscribed': () => new AwsSnsTopicUnsubscribedScanner(ACCOUNT, new SnsTopicUnsubscribedPolicy(po)),
-  'iam-instance-profile-unattached': () => new AwsIamInstanceProfileUnattachedScanner(ACCOUNT, new IamInstanceProfileUnattachedPolicy(po)),
-  'eventbridge-rule-no-targets': () => new AwsEventbridgeRuleNoTargetsScanner(ACCOUNT, new EventbridgeRuleNoTargetsPolicy(po)),
-  'ecr-repository-empty': () => new AwsEcrRepositoryEmptyScanner(ACCOUNT, new EcrRepositoryEmptyPolicy(po)),
-  'stepfunctions-statemachine-unused': () => new AwsStepfunctionsStatemachineUnusedScanner(ACCOUNT, new StepfunctionsStatemachineUnusedPolicy(po)),
+  'ec2-keypair-unused': () => new AwsEc2KeyPairUnusedScanner(ACCOUNT, undefined, new Ec2KeyPairUnusedPolicy(po)),
+  'ec2-ri-expiring-soon': () => new AwsEc2RiExpiringSoonScanner(ACCOUNT, undefined, new Ec2RiExpiringSoonPolicy(po, 999_999)),
+  'iam-user-inactive': () => new AwsIamUserInactiveScanner(ACCOUNT, undefined, new IamUserInactivePolicy(po, 0)),
+  'iam-policy-unattached': () => new AwsIamPolicyUnattachedScanner(ACCOUNT, undefined, new IamPolicyUnattachedPolicy(po)),
+  'iam-role-unused': () => new AwsIamRoleUnusedScanner(ACCOUNT, undefined, new IamRoleUnusedPolicy(po, 0)),
+  'iam-access-key-stale': () => new AwsIamAccessKeyStaleScanner(ACCOUNT, undefined, new IamAccessKeyStalePolicy(po)),
+  'ec2-security-group-unused': () => new AwsEc2SecurityGroupUnusedScanner(ACCOUNT, undefined, new Ec2SecurityGroupUnusedPolicy(po)),
+  'logs-loggroup-empty': () => new AwsLogsLogGroupEmptyScanner(ACCOUNT, undefined, new LogsLogGroupEmptyPolicy(po)),
+  'acm-certificate-unused': () => new AwsAcmCertificateUnusedScanner(ACCOUNT, undefined, new AcmCertificateUnusedPolicy(po)),
+  'route53-hostedzone-empty': () => new AwsRoute53HostedZoneEmptyScanner(ACCOUNT, undefined, new Route53HostedZoneEmptyPolicy(po)),
+  'cloudformation-stack-stuck': () => new AwsCloudformationStackStuckScanner(ACCOUNT, undefined, new CloudformationStackStuckPolicy(po)),
+  's3-bucket-empty': () => new AwsS3BucketEmptyScanner(ACCOUNT, undefined, new S3BucketEmptyPolicy(po)),
+  'cloudwatch-alarm-orphaned': () => new AwsCloudwatchAlarmOrphanedScanner(ACCOUNT, undefined, new CloudwatchAlarmOrphanedPolicy(po)),
+  'sns-topic-unsubscribed': () => new AwsSnsTopicUnsubscribedScanner(ACCOUNT, undefined, new SnsTopicUnsubscribedPolicy(po)),
+  'iam-instance-profile-unattached': () => new AwsIamInstanceProfileUnattachedScanner(ACCOUNT, undefined, new IamInstanceProfileUnattachedPolicy(po)),
+  'eventbridge-rule-no-targets': () => new AwsEventbridgeRuleNoTargetsScanner(ACCOUNT, undefined, new EventbridgeRuleNoTargetsPolicy(po)),
+  'ecr-repository-empty': () => new AwsEcrRepositoryEmptyScanner(ACCOUNT, undefined, new EcrRepositoryEmptyPolicy(po)),
+  'stepfunctions-statemachine-unused': () => new AwsStepfunctionsStatemachineUnusedScanner(ACCOUNT, undefined, new StepfunctionsStatemachineUnusedPolicy(po)),
 };
 
 const byId = (a: { id: string }, b: { id: string }) => a.id.localeCompare(b.id);

--- a/libs/resource-security/infrastructure/aws-adapter/package.json
+++ b/libs/resource-security/infrastructure/aws-adapter/package.json
@@ -38,6 +38,7 @@
     "@aws-sdk/client-iam": "^3.1095.0",
     "@aws-sdk/client-rds": "^3.1095.0",
     "@aws-sdk/client-s3": "^3.1095.0",
+    "@smithy/types": "^4.9.0",
     "resource-security-domain": "workspace:*",
     "shared-aws-infra-utils": "workspace:*",
     "shared-kernel": "workspace:*",

--- a/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-cloudtrail-not-multiregion.scanner.ts
+++ b/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-cloudtrail-not-multiregion.scanner.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import { CloudTrailClient, DescribeTrailsCommand } from '@aws-sdk/client-cloudtrail';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { Result } from 'shared-kernel';
 import type { AwsRegion, ResourceSecurityScannerPort, SecurityFinding } from 'resource-security-domain';
 import { CloudtrailNotMultiregion, CloudtrailNotMultiregionPolicy } from 'resource-security-domain';
@@ -15,11 +16,12 @@ export class AwsCloudtrailNotMultiregionScanner implements ResourceSecurityScann
 
   constructor(
     private readonly accountId = 'unknown',
+    private readonly credentials?: AwsCredentialIdentityProvider,
     private readonly policy = new CloudtrailNotMultiregionPolicy(),
   ) {}
 
   async scan(_region: AwsRegion): Promise<Result<SecurityFinding[]>> {
-    const client = new CloudTrailClient({ ...createAwsClientConfig(), region: CLOUDTRAIL_ENDPOINT_REGION });
+    const client = new CloudTrailClient({ ...createAwsClientConfig(this.credentials), region: CLOUDTRAIL_ENDPOINT_REGION });
     try {
       const { trailList } = await client.send(new DescribeTrailsCommand({ includeShadowTrails: true }));
       const now = new Date();

--- a/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-ec2-default-security-group-permissive.scanner.ts
+++ b/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-ec2-default-security-group-permissive.scanner.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import { EC2Client, DescribeSecurityGroupsCommand, type SecurityGroup } from '@aws-sdk/client-ec2';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { Result } from 'shared-kernel';
 import type { AwsRegion, ResourceSecurityScannerPort, SecurityFinding } from 'resource-security-domain';
 import { Ec2DefaultSecurityGroupPermissive, Ec2DefaultSecurityGroupPermissivePolicy } from 'resource-security-domain';
@@ -15,11 +16,12 @@ export class AwsEc2DefaultSecurityGroupPermissiveScanner implements ResourceSecu
 
   constructor(
     private readonly accountId = 'unknown',
+    private readonly credentials?: AwsCredentialIdentityProvider,
     private readonly policy = new Ec2DefaultSecurityGroupPermissivePolicy(),
   ) {}
 
   async scan(region: AwsRegion): Promise<Result<SecurityFinding[]>> {
-    const client = new EC2Client({ ...createAwsClientConfig(), region: region.code });
+    const client = new EC2Client({ ...createAwsClientConfig(this.credentials), region: region.code });
     try {
       const rawGroups = await paginate<SecurityGroup>(async (cursor) => {
         const r = await client.send(

--- a/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-ec2-security-group-open-ingress.scanner.ts
+++ b/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-ec2-security-group-open-ingress.scanner.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import { EC2Client, DescribeSecurityGroupsCommand, type SecurityGroup, type IpPermission } from '@aws-sdk/client-ec2';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { Result } from 'shared-kernel';
 import type { AwsRegion, ResourceSecurityScannerPort, SecurityFinding } from 'resource-security-domain';
 import { Ec2SecurityGroupOpenIngress, Ec2SecurityGroupOpenIngressPolicy } from 'resource-security-domain';
@@ -48,11 +49,12 @@ export class AwsEc2SecurityGroupOpenIngressScanner implements ResourceSecuritySc
 
   constructor(
     private readonly accountId = 'unknown',
+    private readonly credentials?: AwsCredentialIdentityProvider,
     private readonly policy = new Ec2SecurityGroupOpenIngressPolicy(),
   ) {}
 
   async scan(region: AwsRegion): Promise<Result<SecurityFinding[]>> {
-    const client = new EC2Client({ ...createAwsClientConfig(), region: region.code });
+    const client = new EC2Client({ ...createAwsClientConfig(this.credentials), region: region.code });
     try {
       const rawGroups = await paginate<SecurityGroup>(async (cursor) => {
         const r = await client.send(new DescribeSecurityGroupsCommand({ NextToken: cursor }));

--- a/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-ec2-snapshot-public.scanner.ts
+++ b/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-ec2-snapshot-public.scanner.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import { EC2Client, DescribeSnapshotsCommand, DescribeSnapshotAttributeCommand, type Snapshot } from '@aws-sdk/client-ec2';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { Result } from 'shared-kernel';
 import type { AwsRegion, ResourceSecurityScannerPort, SecurityFinding } from 'resource-security-domain';
 import { Ec2SnapshotPublic, Ec2SnapshotPublicPolicy } from 'resource-security-domain';
@@ -17,11 +18,12 @@ export class AwsEc2SnapshotPublicScanner implements ResourceSecurityScannerPort 
 
   constructor(
     private readonly accountId = 'unknown',
+    private readonly credentials?: AwsCredentialIdentityProvider,
     private readonly policy = new Ec2SnapshotPublicPolicy(),
   ) {}
 
   async scan(region: AwsRegion): Promise<Result<SecurityFinding[]>> {
-    const client = new EC2Client({ ...createAwsClientConfig(), region: region.code });
+    const client = new EC2Client({ ...createAwsClientConfig(this.credentials), region: region.code });
     try {
       const rawSnapshots = await paginate<Snapshot>(async (cursor) => {
         const r = await client.send(new DescribeSnapshotsCommand({ OwnerIds: ['self'], NextToken: cursor }));

--- a/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-ec2-volume-unencrypted.scanner.ts
+++ b/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-ec2-volume-unencrypted.scanner.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import { EC2Client, DescribeVolumesCommand, type Volume } from '@aws-sdk/client-ec2';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { Result } from 'shared-kernel';
 import type { AwsRegion, ResourceSecurityScannerPort, SecurityFinding } from 'resource-security-domain';
 import { Ec2VolumeUnencrypted, Ec2VolumeUnencryptedPolicy } from 'resource-security-domain';
@@ -13,11 +14,12 @@ export class AwsEc2VolumeUnencryptedScanner implements ResourceSecurityScannerPo
 
   constructor(
     private readonly accountId = 'unknown',
+    private readonly credentials?: AwsCredentialIdentityProvider,
     private readonly policy = new Ec2VolumeUnencryptedPolicy(),
   ) {}
 
   async scan(region: AwsRegion): Promise<Result<SecurityFinding[]>> {
-    const client = new EC2Client({ ...createAwsClientConfig(), region: region.code });
+    const client = new EC2Client({ ...createAwsClientConfig(this.credentials), region: region.code });
     try {
       const rawVolumes = await paginate<Volume>(async (cursor) => {
         const r = await client.send(new DescribeVolumesCommand({ NextToken: cursor }));

--- a/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-iam-access-key-rotation-overdue.scanner.ts
+++ b/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-iam-access-key-rotation-overdue.scanner.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import { IAMClient, ListUsersCommand, ListAccessKeysCommand, type User, type AccessKeyMetadata } from '@aws-sdk/client-iam';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { Result } from 'shared-kernel';
 import type { AwsRegion, ResourceSecurityScannerPort, SecurityFinding } from 'resource-security-domain';
 import { IamAccessKeyRotationOverdue, IamAccessKeyRotationOverduePolicy } from 'resource-security-domain';
@@ -19,11 +20,12 @@ export class AwsIamAccessKeyRotationOverdueScanner implements ResourceSecuritySc
 
   constructor(
     private readonly accountId = 'unknown',
+    private readonly credentials?: AwsCredentialIdentityProvider,
     private readonly policy = new IamAccessKeyRotationOverduePolicy(),
   ) {}
 
   async scan(_region: AwsRegion): Promise<Result<SecurityFinding[]>> {
-    const client = new IAMClient({ ...createAwsClientConfig(), region: IAM_ENDPOINT_REGION });
+    const client = new IAMClient({ ...createAwsClientConfig(this.credentials), region: IAM_ENDPOINT_REGION });
     try {
       const rawUsers = await paginate<User>(async (cursor) => {
         const r = await client.send(new ListUsersCommand({ Marker: cursor }));

--- a/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-iam-password-policy-weak.scanner.ts
+++ b/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-iam-password-policy-weak.scanner.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import { IAMClient, GetAccountPasswordPolicyCommand } from '@aws-sdk/client-iam';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { Result } from 'shared-kernel';
 import type { AwsRegion, ResourceSecurityScannerPort, SecurityFinding } from 'resource-security-domain';
 import { IamPasswordPolicyWeak, IamPasswordPolicyWeakPolicy } from 'resource-security-domain';
@@ -17,11 +18,12 @@ export class AwsIamPasswordPolicyWeakScanner implements ResourceSecurityScannerP
 
   constructor(
     private readonly accountId = 'unknown',
+    private readonly credentials?: AwsCredentialIdentityProvider,
     private readonly policy = new IamPasswordPolicyWeakPolicy(),
   ) {}
 
   async scan(_region: AwsRegion): Promise<Result<SecurityFinding[]>> {
-    const client = new IAMClient({ ...createAwsClientConfig(), region: IAM_ENDPOINT_REGION });
+    const client = new IAMClient({ ...createAwsClientConfig(this.credentials), region: IAM_ENDPOINT_REGION });
     try {
       const now = new Date();
       let finding: IamPasswordPolicyWeak;

--- a/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-iam-root-access-key-active.scanner.ts
+++ b/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-iam-root-access-key-active.scanner.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import { IAMClient, GetAccountSummaryCommand } from '@aws-sdk/client-iam';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { Result } from 'shared-kernel';
 import type { AwsRegion, ResourceSecurityScannerPort, SecurityFinding } from 'resource-security-domain';
 import { IamRootAccessKeyActive, IamRootAccessKeyActivePolicy } from 'resource-security-domain';
@@ -14,11 +15,12 @@ export class AwsIamRootAccessKeyActiveScanner implements ResourceSecurityScanner
 
   constructor(
     private readonly accountId = 'unknown',
+    private readonly credentials?: AwsCredentialIdentityProvider,
     private readonly policy = new IamRootAccessKeyActivePolicy(),
   ) {}
 
   async scan(_region: AwsRegion): Promise<Result<SecurityFinding[]>> {
-    const client = new IAMClient({ ...createAwsClientConfig(), region: IAM_ENDPOINT_REGION });
+    const client = new IAMClient({ ...createAwsClientConfig(this.credentials), region: IAM_ENDPOINT_REGION });
     try {
       const { SummaryMap } = await client.send(new GetAccountSummaryCommand({}));
       const now = new Date();

--- a/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-iam-root-mfa-disabled.scanner.ts
+++ b/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-iam-root-mfa-disabled.scanner.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import { IAMClient, GetAccountSummaryCommand } from '@aws-sdk/client-iam';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { Result } from 'shared-kernel';
 import type { AwsRegion, ResourceSecurityScannerPort, SecurityFinding } from 'resource-security-domain';
 import { IamRootMfaDisabled, IamRootMfaDisabledPolicy } from 'resource-security-domain';
@@ -19,11 +20,12 @@ export class AwsIamRootMfaDisabledScanner implements ResourceSecurityScannerPort
 
   constructor(
     private readonly accountId = 'unknown',
+    private readonly credentials?: AwsCredentialIdentityProvider,
     private readonly policy = new IamRootMfaDisabledPolicy(),
   ) {}
 
   async scan(_region: AwsRegion): Promise<Result<SecurityFinding[]>> {
-    const client = new IAMClient({ ...createAwsClientConfig(), region: IAM_ENDPOINT_REGION });
+    const client = new IAMClient({ ...createAwsClientConfig(this.credentials), region: IAM_ENDPOINT_REGION });
     try {
       const { SummaryMap } = await client.send(new GetAccountSummaryCommand({}));
       const now = new Date();

--- a/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-iam-user-mfa-disabled.scanner.ts
+++ b/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-iam-user-mfa-disabled.scanner.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import { IAMClient, ListUsersCommand, ListMFADevicesCommand, type User } from '@aws-sdk/client-iam';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { Result } from 'shared-kernel';
 import type { AwsRegion, ResourceSecurityScannerPort, SecurityFinding } from 'resource-security-domain';
 import { IamUserMfaDisabled, IamUserMfaDisabledPolicy } from 'resource-security-domain';
@@ -18,11 +19,12 @@ export class AwsIamUserMfaDisabledScanner implements ResourceSecurityScannerPort
 
   constructor(
     private readonly accountId = 'unknown',
+    private readonly credentials?: AwsCredentialIdentityProvider,
     private readonly policy = new IamUserMfaDisabledPolicy(),
   ) {}
 
   async scan(_region: AwsRegion): Promise<Result<SecurityFinding[]>> {
-    const client = new IAMClient({ ...createAwsClientConfig(), region: IAM_ENDPOINT_REGION });
+    const client = new IAMClient({ ...createAwsClientConfig(this.credentials), region: IAM_ENDPOINT_REGION });
     try {
       const rawUsers = await paginate<User>(async (cursor) => {
         const r = await client.send(new ListUsersCommand({ Marker: cursor }));

--- a/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-rds-instance-publicly-accessible.scanner.ts
+++ b/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-rds-instance-publicly-accessible.scanner.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import { RDSClient, DescribeDBInstancesCommand, type DBInstance } from '@aws-sdk/client-rds';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { Result } from 'shared-kernel';
 import type { AwsRegion, ResourceSecurityScannerPort, SecurityFinding } from 'resource-security-domain';
 import { RdsInstancePubliclyAccessible, RdsInstancePubliclyAccessiblePolicy } from 'resource-security-domain';
@@ -13,11 +14,12 @@ export class AwsRdsInstancePubliclyAccessibleScanner implements ResourceSecurity
 
   constructor(
     private readonly accountId = 'unknown',
+    private readonly credentials?: AwsCredentialIdentityProvider,
     private readonly policy = new RdsInstancePubliclyAccessiblePolicy(),
   ) {}
 
   async scan(region: AwsRegion): Promise<Result<SecurityFinding[]>> {
-    const client = new RDSClient({ ...createAwsClientConfig(), region: region.code });
+    const client = new RDSClient({ ...createAwsClientConfig(this.credentials), region: region.code });
     try {
       const rawInstances = await paginate<DBInstance>(async (cursor) => {
         const r = await client.send(new DescribeDBInstancesCommand({ Marker: cursor }));

--- a/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-rds-instance-unencrypted.scanner.ts
+++ b/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-rds-instance-unencrypted.scanner.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import { RDSClient, DescribeDBInstancesCommand, type DBInstance } from '@aws-sdk/client-rds';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { Result } from 'shared-kernel';
 import type { AwsRegion, ResourceSecurityScannerPort, SecurityFinding } from 'resource-security-domain';
 import { RdsInstanceUnencrypted, RdsInstanceUnencryptedPolicy } from 'resource-security-domain';
@@ -13,11 +14,12 @@ export class AwsRdsInstanceUnencryptedScanner implements ResourceSecurityScanner
 
   constructor(
     private readonly accountId = 'unknown',
+    private readonly credentials?: AwsCredentialIdentityProvider,
     private readonly policy = new RdsInstanceUnencryptedPolicy(),
   ) {}
 
   async scan(region: AwsRegion): Promise<Result<SecurityFinding[]>> {
-    const client = new RDSClient({ ...createAwsClientConfig(), region: region.code });
+    const client = new RDSClient({ ...createAwsClientConfig(this.credentials), region: region.code });
     try {
       const rawInstances = await paginate<DBInstance>(async (cursor) => {
         const r = await client.send(new DescribeDBInstancesCommand({ Marker: cursor }));

--- a/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-s3-bucket-encryption-missing.scanner.ts
+++ b/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-s3-bucket-encryption-missing.scanner.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import { S3Client, ListBucketsCommand, GetBucketEncryptionCommand } from '@aws-sdk/client-s3';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { Result, createLogger } from 'shared-kernel';
 import type { AwsRegion, ResourceSecurityScannerPort, SecurityFinding } from 'resource-security-domain';
 import { S3BucketEncryptionMissing, S3BucketEncryptionMissingPolicy } from 'resource-security-domain';
@@ -21,11 +22,12 @@ export class AwsS3BucketEncryptionMissingScanner implements ResourceSecurityScan
 
   constructor(
     private readonly accountId = 'unknown',
+    private readonly credentials?: AwsCredentialIdentityProvider,
     private readonly policy = new S3BucketEncryptionMissingPolicy(),
   ) {}
 
   async scan(_region: AwsRegion): Promise<Result<SecurityFinding[]>> {
-    const client = new S3Client({ ...createAwsClientConfig(), region: 'us-east-1' });
+    const client = new S3Client({ ...createAwsClientConfig(this.credentials), region: 'us-east-1' });
     try {
       const { Buckets } = await client.send(new ListBucketsCommand({}));
       const bucketNames = (Buckets ?? []).map((b) => b.Name).filter((n): n is string => !!n);

--- a/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-s3-bucket-public.scanner.ts
+++ b/libs/resource-security/infrastructure/aws-adapter/src/scanners/aws-s3-bucket-public.scanner.ts
@@ -6,6 +6,7 @@ import {
   GetBucketPolicyStatusCommand,
   GetBucketAclCommand,
 } from '@aws-sdk/client-s3';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { Result, createLogger } from 'shared-kernel';
 import type { AwsRegion, ResourceSecurityScannerPort, SecurityFinding } from 'resource-security-domain';
 import { S3BucketPublic, S3BucketPublicPolicy } from 'resource-security-domain';
@@ -57,11 +58,12 @@ export class AwsS3BucketPublicScanner implements ResourceSecurityScannerPort {
 
   constructor(
     private readonly accountId = 'unknown',
+    private readonly credentials?: AwsCredentialIdentityProvider,
     private readonly policy = new S3BucketPublicPolicy(),
   ) {}
 
   async scan(_region: AwsRegion): Promise<Result<SecurityFinding[]>> {
-    const client = new S3Client({ ...createAwsClientConfig(), region: 'us-east-1' });
+    const client = new S3Client({ ...createAwsClientConfig(this.credentials), region: 'us-east-1' });
     try {
       const { Buckets } = await client.send(new ListBucketsCommand({}));
       const bucketNames = (Buckets ?? []).map((b) => b.Name).filter((n): n is string => !!n);

--- a/libs/shared/aws-infra-utils/package.json
+++ b/libs/shared/aws-infra-utils/package.json
@@ -71,7 +71,9 @@
     }
   },
   "dependencies": {
+    "@aws-sdk/credential-providers": "^3.1095.0",
     "@smithy/node-http-handler": "^4.9.11",
+    "@smithy/types": "^4.9.0",
     "shared-kernel": "workspace:*",
     "tslib": "^2.8.1"
   }

--- a/libs/shared/aws-infra-utils/src/errors/assume-role.error.spec.ts
+++ b/libs/shared/aws-infra-utils/src/errors/assume-role.error.spec.ts
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+import { AssumeRoleError } from './assume-role.error';
+
+describe('AssumeRoleError', () => {
+  it('wraps the cause with the target role ARN in the message', () => {
+    const err = new AssumeRoleError('arn:aws:iam::222222222222:role/CloudriftReadOnly', new Error('AccessDenied'));
+
+    expect(err.roleArn).toBe('arn:aws:iam::222222222222:role/CloudriftReadOnly');
+    expect(err.message).toBe('Failed to assume role arn:aws:iam::222222222222:role/CloudriftReadOnly: AccessDenied');
+    expect(err.cause.message).toBe('AccessDenied');
+  });
+
+  it('normalizes a non-Error cause into a real Error', () => {
+    const err = new AssumeRoleError('arn:aws:iam::222222222222:role/CloudriftReadOnly', 'access denied');
+
+    expect(err.cause).toBeInstanceOf(Error);
+    expect(err.cause.message).toBe('access denied');
+  });
+});

--- a/libs/shared/aws-infra-utils/src/errors/assume-role.error.ts
+++ b/libs/shared/aws-infra-utils/src/errors/assume-role.error.ts
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+import { InfrastructureError } from 'shared-kernel';
+
+export class AssumeRoleError extends InfrastructureError {
+  override readonly cause: Error;
+
+  constructor(
+    readonly roleArn: string,
+    cause: unknown,
+  ) {
+    const normalizedCause = cause instanceof Error ? cause : new Error(String(cause));
+    super('ASSUME_ROLE_ERROR', `Failed to assume role ${roleArn}: ${normalizedCause.message}`);
+    this.cause = normalizedCause;
+  }
+}

--- a/libs/shared/aws-infra-utils/src/index.ts
+++ b/libs/shared/aws-infra-utils/src/index.ts
@@ -2,4 +2,6 @@
 export { createAwsClientConfig } from './utils/client-config';
 export { paginate } from './utils/paginate';
 export { mapWithConcurrency } from './utils/map-with-concurrency';
+export { assumeRole } from './utils/assume-role';
 export { AwsAdapterError } from './errors/aws-adapter.error';
+export { AssumeRoleError } from './errors/assume-role.error';

--- a/libs/shared/aws-infra-utils/src/utils/assume-role.spec.ts
+++ b/libs/shared/aws-infra-utils/src/utils/assume-role.spec.ts
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+import { fromTemporaryCredentials } from '@aws-sdk/credential-providers';
+import { assumeRole } from './assume-role';
+import { AssumeRoleError } from '../errors/assume-role.error';
+
+jest.mock('@aws-sdk/credential-providers');
+
+describe('assumeRole', () => {
+  const mockFromTemporaryCredentials = fromTemporaryCredentials as jest.Mock;
+
+  afterEach(() => {
+    mockFromTemporaryCredentials.mockReset();
+  });
+
+  it('builds a credentials provider from the given role ARN and external ID, and resolves it eagerly', async () => {
+    const resolved = { accessKeyId: 'AKIA...', secretAccessKey: 'secret', sessionToken: 'token' };
+    const provider = jest.fn().mockResolvedValue(resolved);
+    mockFromTemporaryCredentials.mockReturnValue(provider);
+
+    const result = await assumeRole('arn:aws:iam::222222222222:role/CloudriftReadOnly', 'my-external-id');
+
+    expect(mockFromTemporaryCredentials).toHaveBeenCalledWith({
+      params: {
+        RoleArn: 'arn:aws:iam::222222222222:role/CloudriftReadOnly',
+        ExternalId: 'my-external-id',
+        RoleSessionName: 'cloudrift-scan',
+      },
+    });
+    expect(provider).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ ok: true, value: provider });
+  });
+
+  it('works without an external ID', async () => {
+    const provider = jest.fn().mockResolvedValue({});
+    mockFromTemporaryCredentials.mockReturnValue(provider);
+
+    await assumeRole('arn:aws:iam::222222222222:role/CloudriftReadOnly');
+
+    expect(mockFromTemporaryCredentials).toHaveBeenCalledWith({
+      params: {
+        RoleArn: 'arn:aws:iam::222222222222:role/CloudriftReadOnly',
+        ExternalId: undefined,
+        RoleSessionName: 'cloudrift-scan',
+      },
+    });
+  });
+
+  it('fails loudly instead of returning an unresolved provider when the role cannot be assumed', async () => {
+    const provider = jest.fn().mockRejectedValue(new Error('AccessDenied: not authorized to perform sts:AssumeRole'));
+    mockFromTemporaryCredentials.mockReturnValue(provider);
+
+    const result = await assumeRole('arn:aws:iam::222222222222:role/CloudriftReadOnly');
+
+    expect(result.ok).toBe(false);
+    expect(!result.ok && result.error).toBeInstanceOf(AssumeRoleError);
+    expect(!result.ok && result.error.message).toContain('AccessDenied');
+  });
+
+  it('uses a custom role session name when given', async () => {
+    const provider = jest.fn().mockResolvedValue({});
+    mockFromTemporaryCredentials.mockReturnValue(provider);
+
+    await assumeRole('arn:aws:iam::222222222222:role/CloudriftReadOnly', undefined, 'my-session');
+
+    expect(mockFromTemporaryCredentials).toHaveBeenCalledWith(
+      expect.objectContaining({ params: expect.objectContaining({ RoleSessionName: 'my-session' }) }),
+    );
+  });
+});

--- a/libs/shared/aws-infra-utils/src/utils/assume-role.ts
+++ b/libs/shared/aws-infra-utils/src/utils/assume-role.ts
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+import { fromTemporaryCredentials } from '@aws-sdk/credential-providers';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
+import { Result } from 'shared-kernel';
+import { AssumeRoleError } from '../errors/assume-role.error';
+
+const DEFAULT_ROLE_SESSION_NAME = 'cloudrift-scan';
+
+/**
+ * Assumes an IAM role via STS for cross-account scanning. Resolves the
+ * credentials eagerly (invokes the provider once here) so an invalid ARN,
+ * a denied trust policy, or a wrong external ID fails loudly right away —
+ * this must never silently fall back to ambient credentials, which would
+ * scan the wrong account without telling anyone.
+ */
+export async function assumeRole(
+  roleArn: string,
+  externalId?: string,
+  roleSessionName: string = DEFAULT_ROLE_SESSION_NAME,
+): Promise<Result<AwsCredentialIdentityProvider>> {
+  const credentials = fromTemporaryCredentials({
+    params: {
+      RoleArn: roleArn,
+      ExternalId: externalId,
+      RoleSessionName: roleSessionName,
+    },
+  });
+
+  try {
+    await credentials();
+    return Result.ok(credentials);
+  } catch (err) {
+    return Result.fail(new AssumeRoleError(roleArn, err));
+  }
+}

--- a/libs/shared/aws-infra-utils/src/utils/client-config.spec.ts
+++ b/libs/shared/aws-infra-utils/src/utils/client-config.spec.ts
@@ -58,6 +58,15 @@ describe('createAwsClientConfig', () => {
     expect(a.requestHandler).not.toBe(b.requestHandler);
     expect((NodeHttpHandler as jest.Mock).mock.calls.length).toBe(before + 2);
   });
+
+  it('omits the credentials key entirely when none is passed, preserving the SDK default provider chain', () => {
+    expect(createAwsClientConfig()).not.toHaveProperty('credentials');
+  });
+
+  it('passes through a given credentials provider (--assume-role-arn cross-account scanning)', () => {
+    const credentials = jest.fn();
+    expect(createAwsClientConfig(credentials).credentials).toBe(credentials);
+  });
 });
 
 describe('createAwsClientConfig with CLOUDRIFT_HTTP_KEEPALIVE=false', () => {

--- a/libs/shared/aws-infra-utils/src/utils/client-config.ts
+++ b/libs/shared/aws-infra-utils/src/utils/client-config.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import { NodeHttpHandler } from '@smithy/node-http-handler';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { createLogger } from 'shared-kernel';
 
 const httpLog = createLogger('cloudrift:http');
@@ -64,12 +65,17 @@ const keepAlive = process.env.CLOUDRIFT_HTTP_KEEPALIVE !== 'false';
  * a normal SDK error, retried up to `maxAttempts` like any other failure, and
  * ultimately caught by each scanner's existing `try/catch` → `Result.fail`.
  *
+ * `credentials` is omitted whenever the caller doesn't pass one, so every
+ * existing call site keeps relying on the SDK's own default provider chain
+ * exactly as before — this parameter only matters for `--assume-role-arn`
+ * cross-account scanning (see `assumeRole()` in this same package).
+ *
  * Usage:
  * ```ts
  * const ec2 = new EC2Client({ ...createAwsClientConfig(), region: region.code });
  * ```
  */
-export function createAwsClientConfig() {
+export function createAwsClientConfig(credentials?: AwsCredentialIdentityProvider) {
   return {
     maxAttempts: 3,
     requestHandler: new NodeHttpHandler({
@@ -88,5 +94,6 @@ export function createAwsClientConfig() {
       logger: smithyLogger,
       httpsAgent: { keepAlive },
     }),
-  } as const;
+    ...(credentials ? { credentials } : {}),
+  };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -236,6 +236,9 @@ importers:
       '@smithy/node-http-handler':
         specifier: ^4.9.11
         version: 4.9.11
+      '@smithy/types':
+        specifier: ^4.9.0
+        version: 4.16.1
       chalk:
         specifier: ^4.1.2
         version: 4.1.2
@@ -287,6 +290,9 @@ importers:
       resource-security-infrastructure-aws-adapter:
         specifier: workspace:*
         version: link:../../libs/resource-security/infrastructure/aws-adapter
+      shared-aws-infra-utils:
+        specifier: workspace:*
+        version: link:../../libs/shared/aws-infra-utils
       shared-kernel:
         specifier: workspace:*
         version: link:../../libs/shared/kernel
@@ -404,6 +410,9 @@ importers:
       '@aws-sdk/client-workspaces':
         specifier: ^3.1095.0
         version: 3.1095.0
+      '@smithy/types':
+        specifier: ^4.9.0
+        version: 4.16.1
       cloud-cost-domain:
         specifier: workspace:*
         version: link:../../domain
@@ -443,6 +452,9 @@ importers:
       '@aws-sdk/client-cost-explorer':
         specifier: ^3.1095.0
         version: 3.1095.0
+      '@smithy/types':
+        specifier: ^4.9.0
+        version: 4.16.1
       cost-analytics-domain:
         specifier: workspace:*
         version: link:../../domain
@@ -521,6 +533,9 @@ importers:
       '@aws-sdk/client-sns':
         specifier: ^3.1095.0
         version: 3.1095.0
+      '@smithy/types':
+        specifier: ^4.9.0
+        version: 4.16.1
       dead-resources-domain:
         specifier: workspace:*
         version: link:../../domain
@@ -599,6 +614,9 @@ importers:
       '@aws-sdk/client-s3':
         specifier: ^3.1095.0
         version: 3.1095.0
+      '@smithy/types':
+        specifier: ^4.9.0
+        version: 4.16.1
       resource-security-domain:
         specifier: workspace:*
         version: link:../../domain
@@ -614,9 +632,15 @@ importers:
 
   libs/shared/aws-infra-utils:
     dependencies:
+      '@aws-sdk/credential-providers':
+        specifier: ^3.1095.0
+        version: 3.1097.0
       '@smithy/node-http-handler':
         specifier: ^4.9.11
         version: 4.9.11
+      '@smithy/types':
+        specifier: ^4.9.0
+        version: 4.16.1
       shared-kernel:
         specifier: workspace:*
         version: link:../kernel
@@ -806,36 +830,80 @@ packages:
     resolution: {integrity: sha512-KVtQRtc00ES/y+Sc3vYXeP6pCIcNlBJCZOwvqSy8ZpVGmbM5+IG+AfhuTKQ2oXmIVqZJewaGMMpzPkywC6xg0w==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/core@3.977.2':
+    resolution: {integrity: sha512-8sT/M5vDcagx5/iM0Bfx7f6i3mfVOQkA34+GTMwp0lIWZb6ma+bjkzDS/r9yqU2yTPBqqMBFPT3+d9kUuuNDJA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-cognito-identity@3.972.62':
+    resolution: {integrity: sha512-+Y6NEZKWGCzp793DFBPl9bTvrnO1j8/QG6pAk3VGaWcHyEve5WwmgF9sfFhxhN71hfBAPKxPsA6fDNOdNXG4Gw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-env@3.972.61':
     resolution: {integrity: sha512-qihs2ekMb89Nxd2JenCgVFhjbkb3EIo7HEBCBzyZACKVJdrLUZBLOmAE3xr0Sayml8n/jZSzwO/IufIiIzO7PQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.63':
+    resolution: {integrity: sha512-VSS9dftt7r7GiZ4gs8z0PNaMLVAaSj/MXVr6WQBtsrQQB9miJo7I6lQuJND1/ugFwK9x7OHCYZDkLSYh0FIZtA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-http@3.972.63':
     resolution: {integrity: sha512-yfozsS8wkWZEi/n6IsrodcFKBWZ0iNAezhJbTReMNc0z1Px17qdeAeuL1/wziCAmCZyXiW7QzP75ggJkBQv8jQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-http@3.972.65':
+    resolution: {integrity: sha512-SH/ec7p1J0CfC28+ypH38IwGENd7tQEvTpmuRSlinthiGxKlwzJbXGXxIMAhn0/lpxnIxudNmCsw3Cy0PDRoAg==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-ini@3.973.6':
     resolution: {integrity: sha512-jGLTW1bj148GL/6/IMlfY2fMYS9FtHOG+NahkFD4y0qkzYudNUahelxryY68/HGMslYuHClk1XaS/3b3eJzEkg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.973.8':
+    resolution: {integrity: sha512-alkQpDUHsjHGVXvlV0XFXpPfh9+aTMmN6UYRky0Qky8SbvdxoQdDHftT4uugq8XShP6WtDQW7bo5YQ0SfNSxRQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-login@3.972.68':
     resolution: {integrity: sha512-w6tNci6g7RqFpLhj1f5xseBvaNojb4Pkgp5Jp5apl9hrJtaf2AA+rX9+qlhlWUK6kcyAFYPA7emO+55zj+S98Q==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-login@3.972.70':
+    resolution: {integrity: sha512-JlUjK6bYJAxN9PkWWCI/TiOYEdvXNKq61x2DTaEKxRMxAOYNk2LX8m4wVtDFxTZwyXx7Tpmxb49dNprkW/uqXQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-node@3.972.72':
     resolution: {integrity: sha512-blQ7F5QGzylnzeh5549zQLoCAiMHkXFLjFovEMaVy4b2X8JhUu+u9NXro1hyK95YHdVFNmBHKs2hIHtZchxKlQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.74':
+    resolution: {integrity: sha512-V+7pzT0OzROL2uKcQ2+MpnfwKONvozYojmdn8RguAMX9o48gtSVvt+7aCkwWCH2thDXOnUPCN6qn4kiFDelZWA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-process@3.972.61':
     resolution: {integrity: sha512-xzRuj+fUVO4nkafKQJVKAF97kGpeQbfjuwmRrtGZNf42/1dkmcz6o7dswBy7alY0htQn5sCL1GWQYEykviWZkA==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-process@3.972.63':
+    resolution: {integrity: sha512-lPt2oGMcvP3uPhhxX5EquHrzBI/ZgJce+CHKcOGZl2ZQAXLLSxu7k/Cgo0HIktyi9dmDFljbOkj4XAnXD93YVQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-sso@3.973.5':
     resolution: {integrity: sha512-fZRjjWhLFelsDoOYjqShQTrIGYC3Pf9Mx9Czf+1ikfQDgktxjze33dVo1q1/ZQ+T0qbtejVoHNHrfD5aJVpv/w==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-sso@3.973.7':
+    resolution: {integrity: sha512-FR2b+7QNXP/q+eslVzrCjGKvso8Lcr/B18BvFyD2iLNhq42XSo+wnh8FfX6mtqgaVsL1vuB27uGXuY+xUTa7pg==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-web-identity@3.972.67':
     resolution: {integrity: sha512-FTNZ05gkPBA6CKbU3N4zPgybV+stdazwMOya75CmGdcJL7p8Fw/BdHP8WVxJd0mvzyPK2cg/C3gli58Ir4HgCw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.69':
+    resolution: {integrity: sha512-RWNTKGXRkzMJe8bgIAdlz9q0N97m7fThD9KOjBt2CSY+/xnIbrA1/Dnm/ZEz8ZeQ1Of5D+fLaPeoD3lGt6AU4Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-providers@3.1097.0':
+    resolution: {integrity: sha512-US/mjIRfRz5g1G/KbaZ3SgswZ+PfGqoXR29ZqwOT+ZAMXCwR/8SIZB1iMN7ngV6+olSbaBsF9RMXhKnTccYJaA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/dynamodb-codec@3.973.35':
@@ -874,12 +942,20 @@ packages:
     resolution: {integrity: sha512-2MJfseVG/aXvIyOIBlYA/Oaf6qFDdsu4D8RKsEUdOQpVuLaor0BdxIBBtJLBNQQEe6Ku3YMvLljwb1MwVUpzRw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/nested-clients@3.997.37':
+    resolution: {integrity: sha512-vfDmA6APjX1LWxvt6/zcAmTCgRXCj35M+bC9Ujmy40QxYs9Fa9bE7oblOB3ODZ4mdN9R5osU0hTzoJjJlQqqTg==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/signature-v4-multi-region@3.996.42':
     resolution: {integrity: sha512-DBV4naZP6HYBlAvPpoQzOP12Wvfou/5rN8yJPXjBTBylU5qwCbh/tXr2MddHoIjgoRkEl/eS+IljiUqvmwey1Q==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/token-providers@3.1095.0':
     resolution: {integrity: sha512-65SudS6y4nzaYHybtqcpm3sHe5jLhdMn68HRKS1nUx690BtQeaAQOoujQ+dpOjBATIVGVgKKjEP8tR+U06QJQA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1097.0':
+    resolution: {integrity: sha512-EIsdmy/f5IGc5r01RjKWNvrbBra6z0xudQM0D6Wf8DeGuPoRlubkLqr7VgWijFucO4kg0mtev9H3RX/ZOubUhg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/types@3.974.2':
@@ -5504,6 +5580,25 @@ snapshots:
       bowser: 2.14.1
       tslib: 2.8.1
 
+  '@aws-sdk/core@3.977.2':
+    dependencies:
+      '@aws-sdk/types': 3.974.2
+      '@aws-sdk/xml-builder': 3.972.37
+      '@aws/lambda-invoke-store': 0.3.0
+      '@smithy/core': 3.30.0
+      '@smithy/signature-v4': 5.6.10
+      '@smithy/types': 4.16.1
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-cognito-identity@3.972.62':
+    dependencies:
+      '@aws-sdk/nested-clients': 3.997.37
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.30.0
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-env@3.972.61':
     dependencies:
       '@aws-sdk/core': 3.977.1
@@ -5512,9 +5607,27 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-env@3.972.63':
+    dependencies:
+      '@aws-sdk/core': 3.977.2
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.30.0
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-http@3.972.63':
     dependencies:
       '@aws-sdk/core': 3.977.1
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.30.0
+      '@smithy/fetch-http-handler': 5.6.11
+      '@smithy/node-http-handler': 4.9.11
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.65':
+    dependencies:
+      '@aws-sdk/core': 3.977.2
       '@aws-sdk/types': 3.974.2
       '@smithy/core': 3.30.0
       '@smithy/fetch-http-handler': 5.6.11
@@ -5538,10 +5651,35 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-ini@3.973.8':
+    dependencies:
+      '@aws-sdk/core': 3.977.2
+      '@aws-sdk/credential-provider-env': 3.972.63
+      '@aws-sdk/credential-provider-http': 3.972.65
+      '@aws-sdk/credential-provider-login': 3.972.70
+      '@aws-sdk/credential-provider-process': 3.972.63
+      '@aws-sdk/credential-provider-sso': 3.973.7
+      '@aws-sdk/credential-provider-web-identity': 3.972.69
+      '@aws-sdk/nested-clients': 3.997.37
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.30.0
+      '@smithy/credential-provider-imds': 4.4.14
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-login@3.972.68':
     dependencies:
       '@aws-sdk/core': 3.977.1
       '@aws-sdk/nested-clients': 3.997.35
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.30.0
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.70':
+    dependencies:
+      '@aws-sdk/core': 3.977.2
+      '@aws-sdk/nested-clients': 3.997.37
       '@aws-sdk/types': 3.974.2
       '@smithy/core': 3.30.0
       '@smithy/types': 4.16.1
@@ -5561,9 +5699,31 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-node@3.972.74':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.63
+      '@aws-sdk/credential-provider-http': 3.972.65
+      '@aws-sdk/credential-provider-ini': 3.973.8
+      '@aws-sdk/credential-provider-process': 3.972.63
+      '@aws-sdk/credential-provider-sso': 3.973.7
+      '@aws-sdk/credential-provider-web-identity': 3.972.69
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.30.0
+      '@smithy/credential-provider-imds': 4.4.14
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-process@3.972.61':
     dependencies:
       '@aws-sdk/core': 3.977.1
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.30.0
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.63':
+    dependencies:
+      '@aws-sdk/core': 3.977.2
       '@aws-sdk/types': 3.974.2
       '@smithy/core': 3.30.0
       '@smithy/types': 4.16.1
@@ -5579,12 +5739,50 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-sso@3.973.7':
+    dependencies:
+      '@aws-sdk/core': 3.977.2
+      '@aws-sdk/nested-clients': 3.997.37
+      '@aws-sdk/token-providers': 3.1097.0
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.30.0
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-web-identity@3.972.67':
     dependencies:
       '@aws-sdk/core': 3.977.1
       '@aws-sdk/nested-clients': 3.997.35
       '@aws-sdk/types': 3.974.2
       '@smithy/core': 3.30.0
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.69':
+    dependencies:
+      '@aws-sdk/core': 3.977.2
+      '@aws-sdk/nested-clients': 3.997.37
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.30.0
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-providers@3.1097.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.2
+      '@aws-sdk/credential-provider-cognito-identity': 3.972.62
+      '@aws-sdk/credential-provider-env': 3.972.63
+      '@aws-sdk/credential-provider-http': 3.972.65
+      '@aws-sdk/credential-provider-ini': 3.973.8
+      '@aws-sdk/credential-provider-login': 3.972.70
+      '@aws-sdk/credential-provider-node': 3.972.74
+      '@aws-sdk/credential-provider-process': 3.972.63
+      '@aws-sdk/credential-provider-sso': 3.973.7
+      '@aws-sdk/credential-provider-web-identity': 3.972.69
+      '@aws-sdk/nested-clients': 3.997.37
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.30.0
+      '@smithy/credential-provider-imds': 4.4.14
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
@@ -5659,6 +5857,17 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
+  '@aws-sdk/nested-clients@3.997.37':
+    dependencies:
+      '@aws-sdk/core': 3.977.2
+      '@aws-sdk/signature-v4-multi-region': 3.996.42
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.30.0
+      '@smithy/fetch-http-handler': 5.6.11
+      '@smithy/node-http-handler': 4.9.11
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/signature-v4-multi-region@3.996.42':
     dependencies:
       '@aws-sdk/types': 3.974.2
@@ -5670,6 +5879,15 @@ snapshots:
     dependencies:
       '@aws-sdk/core': 3.977.1
       '@aws-sdk/nested-clients': 3.997.35
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.30.0
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1097.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.2
+      '@aws-sdk/nested-clients': 3.997.37
       '@aws-sdk/types': 3.974.2
       '@smithy/core': 3.30.0
       '@smithy/types': 4.16.1


### PR DESCRIPTION
## Summary

- Adds `--assume-role-arn <arn>` (optionally `--external-id <id>`) to all five scanning/reporting commands (`analyze`, `cost`, `trend`, `dead-resources`, `resource-security`), so a scan can target an AWS account other than the one the ambient credentials belong to.
- New `assumeRole()` in `shared-aws-infra-utils` resolves the STS-assumed credentials **eagerly** (invokes the provider once, right away) so a bad role ARN, a denied trust policy, or a wrong `--external-id` fails loudly at the top of the command — never a silent fallback to the caller's own credentials.
- Credentials threaded as an optional parameter through every scanner in `cloud-cost`/`dead-resources`/`resource-security`, `resolveAwsAccountId()` (so the reported account ID reflects the *assumed* identity), `AwsPricingApiAdapter`, and `AwsCostExplorerAdapter`. Omitting the flag is a strict no-op — every call site keeps using the SDK's default credential chain exactly as before.
- `sts:AssumeRole` added to the IAM policy cloudrift prints (`iam-policy` command / `get_required_iam_permissions` MCP tool) — this is the action the **calling** principal needs; the target role's own trust policy (documented with a sample) is the user's responsibility.
- Docs: `docs/en(it)/usage.md`, `iam-permissions.md`, `technical-choices.md` updated with the new flags, a cross-account example (including a shell-loop pattern for sweeping several accounts), and the required trust policy. New [ADR-0096](docs/adr/0096-cross-account-scanning-assume-role.md) records the decision and the alternatives considered (named AWS profiles, a built-in multi-account "sweep" mode — deferred, not built).

## Test plan

- [x] `nx run-many -t typecheck,lint,test` — all green across every affected project (cli, shared-aws-infra-utils, cloud-cost/dead-resources/resource-security/cost-analytics infra adapters)
- [x] New unit specs for `assumeRole()` / `AssumeRoleError`
- [ ] Manual smoke test: `cloudrift analyze --assume-role-arn <arn> --external-id <id>` against a real cross-account role
