### PR TITLE
Add Terraform analysis wizard mode, delegating to cloudrift-iac-detector

### DIFF
--- a/apps/cli/src/wizard/entry.wizard.ts
+++ b/apps/cli/src/wizard/entry.wizard.ts
@@ -11,6 +11,13 @@ import { promptScannerSelection } from './scanner-selection.wizard';
 import { promptDeadResourceSelection } from './dead-resource-selection.wizard';
 import { promptResourceSecuritySelection } from './resource-security-selection.wizard';
 import { promptWasteOutput, promptDeadResourcesOutput, promptResourceSecurityOutput, promptCostTrendOutput } from './output-format.wizard';
+import {
+  resolveCloudriftIacDetectorBinary,
+  playHandoffTransition,
+  delegateToCloudriftIacDetector,
+} from './terraform-handoff.wizard';
+
+type Outro = (message?: string) => void;
 
 /**
  * The interactive entry point: shown when `cloudrift` is run with no
@@ -19,6 +26,12 @@ import { promptWasteOutput, promptDeadResourcesOutput, promptResourceSecurityOut
  * calls that command's own function directly — no duplicated business
  * logic, this is purely an input-gathering layer. Explicit subcommands with
  * flags (CI/scripts) never go through here.
+ *
+ * A thin dispatcher: each mode's own input-gathering + command call lives in
+ * its own `run*Mode()` function below, so this function stays a flat
+ * mode → handler mapping instead of one long if-chain growing a branch per
+ * mode (six now, more later) — kept it that way once six modes made the
+ * single function noticeably harder to scan in one pass.
  */
 export async function runEntryWizard(): Promise<void> {
   const { intro, outro } = await import('@clack/prompts');
@@ -29,85 +42,110 @@ export async function runEntryWizard(): Promise<void> {
   const mode = await promptMode();
   if (mode === undefined) return;
 
-  if (mode === 'waste') {
-    const regions = await promptRegions();
-    if (regions === undefined) return;
+  switch (mode) {
+    case 'waste':
+      return runWasteMode(outro);
+    case 'dead-resources':
+      return runDeadResourcesMode(outro);
+    case 'resource-security':
+      return runResourceSecurityMode(outro);
+    case 'terraform':
+      return runTerraformMode(outro);
+    case 'cost':
+    case 'trend':
+      return runCostTrendMode(mode, outro);
+  }
+}
 
-    const scanners = await promptScannerSelection();
-    if (scanners === undefined) return;
+async function runWasteMode(outro: Outro): Promise<void> {
+  const regions = await promptRegions();
+  if (regions === undefined) return;
 
-    const output = await promptWasteOutput();
-    if (output === undefined) return;
+  const scanners = await promptScannerSelection();
+  if (scanners === undefined) return;
 
-    outro('Starting scan...');
-    await analyzeWasteCommand({
-      regions,
-      scanners,
-      format: output.format,
-      pdf: output.savePdf ? true : undefined,
-      json: output.saveJson ? true : undefined,
-      csv: output.saveCsv ? true : undefined,
-    });
+  const output = await promptWasteOutput();
+  if (output === undefined) return;
+
+  outro('Starting scan...');
+  await analyzeWasteCommand({
+    regions,
+    scanners,
+    format: output.format,
+    pdf: output.savePdf ? true : undefined,
+    json: output.saveJson ? true : undefined,
+    csv: output.saveCsv ? true : undefined,
+  });
+}
+
+async function runDeadResourcesMode(outro: Outro): Promise<void> {
+  const regions = await promptRegions();
+  if (regions === undefined) return;
+
+  const scannerKinds = await promptDeadResourceSelection();
+  if (scannerKinds === undefined) return;
+
+  const output = await promptDeadResourcesOutput();
+  if (output === undefined) return;
+
+  outro('Starting scan...');
+  await deadResourcesCommand({
+    regions,
+    scannerKinds,
+    format: output.format,
+    pdf: output.savePdf ? true : undefined,
+    csv: output.saveCsv ? true : undefined,
+  });
+}
+
+async function runResourceSecurityMode(outro: Outro): Promise<void> {
+  const regions = await promptRegions();
+  if (regions === undefined) return;
+
+  const scannerKinds = await promptResourceSecuritySelection();
+  if (scannerKinds === undefined) return;
+
+  const output = await promptResourceSecurityOutput();
+  if (output === undefined) return;
+
+  outro('Starting scan...');
+  await resourceSecurityCommand({
+    regions,
+    scannerKinds,
+    format: output.format,
+    pdf: output.savePdf ? true : undefined,
+    csv: output.saveCsv ? true : undefined,
+  });
+}
+
+async function runTerraformMode(outro: Outro): Promise<void> {
+  const binaryPath = resolveCloudriftIacDetectorBinary();
+  if (binaryPath === undefined) {
+    outro(
+      "cloudrift-iac-detector wasn't found on your PATH. It's a separate Pro package — check your cloudrift Pro license for installation instructions, then run `cloudrift` again.",
+    );
     return;
   }
 
-  if (mode === 'dead-resources') {
-    const regions = await promptRegions();
-    if (regions === undefined) return;
+  await playHandoffTransition();
+  const exitCode = await delegateToCloudriftIacDetector(binaryPath);
+  process.exitCode = exitCode;
+}
 
-    const scannerKinds = await promptDeadResourceSelection();
-    if (scannerKinds === undefined) return;
-
-    const output = await promptDeadResourcesOutput();
-    if (output === undefined) return;
-
-    outro('Starting scan...');
-    await deadResourcesCommand({
-      regions,
-      scannerKinds,
-      format: output.format,
-      pdf: output.savePdf ? true : undefined,
-      csv: output.saveCsv ? true : undefined,
-    });
-    return;
-  }
-
-  if (mode === 'resource-security') {
-    const regions = await promptRegions();
-    if (regions === undefined) return;
-
-    const scannerKinds = await promptResourceSecuritySelection();
-    if (scannerKinds === undefined) return;
-
-    const output = await promptResourceSecurityOutput();
-    if (output === undefined) return;
-
-    outro('Starting scan...');
-    await resourceSecurityCommand({
-      regions,
-      scannerKinds,
-      format: output.format,
-      pdf: output.savePdf ? true : undefined,
-      csv: output.saveCsv ? true : undefined,
-    });
-    return;
-  }
-
+async function runCostTrendMode(mode: 'cost' | 'trend', outro: Outro): Promise<void> {
   const output = await promptCostTrendOutput();
   if (output === undefined) return;
 
   outro('Fetching from AWS Cost Explorer...');
+  const options = {
+    format: output.format,
+    pdf: output.savePdf ? true : undefined,
+    csv: output.saveCsv ? true : undefined,
+  };
+
   if (mode === 'cost') {
-    await costCommand({
-      format: output.format,
-      pdf: output.savePdf ? true : undefined,
-      csv: output.saveCsv ? true : undefined,
-    });
+    await costCommand(options);
   } else {
-    await trendCommand({
-      format: output.format,
-      pdf: output.savePdf ? true : undefined,
-      csv: output.saveCsv ? true : undefined,
-    });
+    await trendCommand(options);
   }
 }

--- a/apps/cli/src/wizard/mode-picker.wizard.ts
+++ b/apps/cli/src/wizard/mode-picker.wizard.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-export type WizardMode = 'waste' | 'cost' | 'trend' | 'dead-resources' | 'resource-security';
+export type WizardMode = 'waste' | 'cost' | 'trend' | 'dead-resources' | 'resource-security' | 'terraform';
 
 /**
  * Top-level "what do you want to do" choice — the entry point for the
@@ -8,6 +8,12 @@ export type WizardMode = 'waste' | 'cost' | 'trend' | 'dead-resources' | 'resour
  * subcommands (`cloudrift analyze`/`cost`/`trend`/`dead-resources`/
  * `resource-security`, with flags) are unaffected and keep working exactly
  * as before for CI/scripts.
+ *
+ * `terraform` is the odd one out: it doesn't call a command function in
+ * this package at all, it hands off to the separate, proprietary
+ * `cloudrift-iac-detector` binary (see ADR-0097 and
+ * `terraform-handoff.wizard.ts`) — the only mode here that can be missing
+ * from the user's machine entirely.
  *
  * Returns `undefined` if the user cancels (Ctrl+C).
  */
@@ -37,6 +43,11 @@ export async function promptMode(): Promise<WizardMode | undefined> {
         value: 'resource-security',
         label: 'Scan for security-posture risks',
         hint: 'free — IAM/MFA, open ingress, public storage, encryption, audit',
+      },
+      {
+        value: 'terraform',
+        label: 'Terraform source analysis',
+        hint: 'Pro — separate cloudrift-iac-detector package: orphans, duplicates, dead code, auto-fix',
       },
     ],
   });

--- a/apps/cli/src/wizard/terraform-handoff.wizard.ts
+++ b/apps/cli/src/wizard/terraform-handoff.wizard.ts
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+import { existsSync } from 'node:fs';
+import { delimiter, join } from 'node:path';
+import { spawn } from 'node:child_process';
+import chalk from 'chalk';
+
+const BINARY_NAME = 'cloudrift-iac-detector';
+// Windows resolves a bare PATH entry against these extensions, in order
+// (PATHEXT), before falling back to an extension-less match; POSIX only
+// ever needs the bare name.
+const WINDOWS_EXTENSIONS = ['.cmd', '.exe', '.bat'];
+
+/**
+ * Resolves the separate, proprietary `cloudrift-iac-detector` package's
+ * binary on `PATH`, the same way a shell would — no package-manager or
+ * registry lookup, since cloudrift core (public, OSS) can never depend on
+ * or embed that package (see ADR-00XX: it's a paid Pro add-on, a completely
+ * separate repo/product; see ADR-0097). Presence-on-PATH is the only signal available:
+ * if the user installed it, this finds it; if not, there's nothing else to
+ * check.
+ *
+ * Returns the absolute path to the binary, or `undefined` if not found.
+ */
+export function resolveCloudriftIacDetectorBinary(): string | undefined {
+  const pathDirs = (process.env.PATH ?? '').split(delimiter).filter((dir) => dir.length > 0);
+  const candidateNames = process.platform === 'win32' ? WINDOWS_EXTENSIONS.map((ext) => BINARY_NAME + ext) : [BINARY_NAME];
+
+  for (const dir of pathDirs) {
+    for (const name of candidateNames) {
+      const candidate = join(dir, name);
+      if (existsSync(candidate)) return candidate;
+    }
+  }
+
+  return undefined;
+}
+
+const FRAME_MS = 90;
+const BAR_WIDTH = 24;
+// One "pixel" per frame — the bar fills left to right, 8-bit-loading-screen
+// style, using block characters instead of a smooth spinner.
+const FILLED = '█';
+const EMPTY = '░';
+const PALETTE = [chalk.magenta, chalk.cyan, chalk.yellow, chalk.green] as const;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Short retro-styled loading-bar transition shown between picking
+ * "Terraform source analysis (Pro)" and handing control over to the
+ * separate `cloudrift-iac-detector` process. Purely cosmetic — its only
+ * job is to make an otherwise-instant process handoff feel like an
+ * intentional transition between two products, not a stall. Renders with
+ * `\r` in-place redraws (classic terminal progress-bar technique), so it
+ * leaves a single settled line behind rather than a scroll of frames.
+ */
+export async function playHandoffTransition(): Promise<void> {
+  for (let filled = 0; filled <= BAR_WIDTH; filled++) {
+    const color = PALETTE[filled % PALETTE.length];
+    const bar = color(FILLED.repeat(filled)) + chalk.dim(EMPTY.repeat(BAR_WIDTH - filled));
+    process.stdout.write(`\r  ${chalk.bold('cloudrift')} ${chalk.dim('→')} ${chalk.bold('cloudrift-iac-detector')}  [${bar}]`);
+    await sleep(FRAME_MS);
+  }
+  process.stdout.write(`\n\n  ${chalk.green('▸')} Handing off to the Terraform Pro engine...\n\n`);
+}
+
+/**
+ * Spawns the resolved `cloudrift-iac-detector` binary with inherited stdio,
+ * so its own wizard (or whatever it prints) takes over the terminal exactly
+ * as if the user had run it directly. Resolves with its exit code once the
+ * child process closes — the caller propagates that as its own
+ * `process.exitCode`, so a failure inside the Pro CLI is visible the same
+ * way any other command failure here would be.
+ */
+export function delegateToCloudriftIacDetector(binaryPath: string): Promise<number> {
+  return new Promise((resolve) => {
+    const child = spawn(binaryPath, [], { stdio: 'inherit' });
+    child.on('close', (code) => resolve(code ?? 0));
+  });
+}

--- a/docs/adr/0097-terraform-analysis-wizard-handoff.md
+++ b/docs/adr/0097-terraform-analysis-wizard-handoff.md
@@ -1,0 +1,40 @@
+# ADR-0097: Wizard mode delegating to the separate `cloudrift-iac-detector` Pro package
+
+- **Status:** Accepted (2026-07-30)
+
+## Context
+
+`cloudrift-iac-detector` is a separate, proprietary repository (Terraform-source waste analysis, drift/zombie detection — a paid Pro add-on) with no code-sharing relationship to this repo: this repo is public/Apache-2.0, that one is entirely private/commercially licensed. It ships as its own npm package/binary and, as of its own ADR-0031, has just grown a bare-invocation wizard mirroring this repo's (ADR-0071/0041).
+
+The ask: give this wizard's mode picker a dedicated entry for Terraform source analysis, so a user discovering it here doesn't need to already know the separate product exists. Three shapes were discussed with the user and **full delegation** was chosen:
+
+1. **Full delegation (chosen):** detect the `cloudrift-iac-detector` binary on `PATH`; if present, hand off the terminal to it entirely (its own wizard takes over). Zero coupling — every command that package adds later works here automatically, no matching PR ever needed in this repo.
+2. Flag forwarding: this wizard asks Terraform-specific questions itself and calls the other CLI with specific flags. Rejected — would make this public repo's wizard know the private CLI's exact flag surface, needing a PR here for every future command over there.
+3. Informational entry only, no execution. Rejected — too weak on its own; the user wants a working handoff, not just a pointer.
+
+Neither package can import the other's code: this repo can never depend on proprietary code (nothing here can require a private package to build), and the Pro package can't be embedded here without ceasing to be separately licensed. Process-level delegation (detect-on-PATH, then spawn with inherited stdio) is the same seam `git` (`git-<subcommand>` executables), `docker` (CLI plugins), and `kubectl` (plugins) use at an identical OSS/commercial-extension boundary.
+
+## Decision
+
+New `WizardMode` value `'terraform'` in `mode-picker.wizard.ts`: *"Terraform source analysis"*, hinted `Pro — separate cloudrift-iac-detector package: orphans, duplicates, dead code, auto-fix"` right in the option, so the boundary is visible before it's picked (same convention as the existing Cost Explorer hints on `cost`/`trend`).
+
+New `terraform-handoff.wizard.ts`:
+
+- **`resolveCloudriftIacDetectorBinary()`** — resolves the binary on `PATH` the same way a shell would: walks `process.env.PATH`'s directories, checking for `cloudrift-iac-detector` (plus `.cmd`/`.exe`/`.bat` on Windows via `PATHEXT`-equivalent extensions). No registry/package-manager lookup — presence-on-PATH is the only signal this repo can ever have about the other product's installation state.
+- **`playHandoffTransition()`** — a short (~2.2s) retro loading-bar animation (`█`/`░` blocks, cycling colors via the existing `chalk` dependency, `\r` in-place redraw) between picking the mode and the actual handoff. Purely cosmetic: makes an otherwise-instant process handoff read as an intentional transition between two products rather than a stall or a glitch.
+- **`delegateToCloudriftIacDetector(binaryPath)`** — `child_process.spawn(binaryPath, [], { stdio: 'inherit' })`, resolving with the child's real exit code once it closes. Inherited stdio means the Pro CLI's own wizard (or any output) takes over the terminal exactly as if the user had run it directly — this repo does not parse or reformat anything it prints.
+
+`entry.wizard.ts`: `mode === 'terraform'` resolves the binary; if missing, prints a short message pointing at the user's Pro license for installation instructions (no invented URL — this repo has no visibility into how that package is actually distributed) and returns to a clean exit, same "no partial action" discipline as every other cancel path. If found, plays the transition, delegates, and propagates the child's exit code as `process.exitCode` — a failure inside the Pro CLI surfaces the same way any other command failure here would.
+
+Verified end-to-end with a fake `cloudrift-iac-detector` script on `PATH` (temporary, not committed): confirmed `resolveCloudriftIacDetectorBinary()` finds it and returns `undefined` when absent, and `delegateToCloudriftIacDetector()` correctly propagates a non-zero exit code from the spawned process. `playHandoffTransition()` (pure animation, no logic) and the `entry.wizard.ts`/`mode-picker.wizard.ts` wiring are left untested, consistent with this repo's standing choice not to unit-test `wizard/*.wizard.ts` files (thin prompt-orchestration UI, no branching logic of its own beyond what's already covered by the functions it calls).
+
+## Alternatives Considered
+
+- **Publish a shared "wizard extension" plugin protocol** (e.g. scan `node_modules` for packages matching a naming convention, like ESLint/Babel plugin discovery) instead of hardcoding one `PATH` check. Rejected for now — over-engineered for a single known integration; nothing today needs a second Pro package to plug into this wizard, and a real plugin contract is easy to extract later from this concrete instance if that need appears (YAGNI).
+- **A private npm registry dependency** (this repo installs `cloudrift-iac-detector` as an npm dependency, auth-gated). Rejected — every free/OSS user would need registry credentials just to `npm install` this repo, or the dependency would need to be optional with awkward fallback handling; process delegation avoids that entirely.
+
+## Consequences
+
+This repo's wizard now has one mode (`terraform`) whose successful path never touches this repo's own command functions or AWS/Cost-Explorer code at all — it's a pure handoff. Any future second Pro/commercial extension would follow the exact same `resolve → transition → delegate` shape; if a second one actually materializes, that's the trigger to reconsider the plugin-discovery alternative above rather than hand-writing a third near-identical `*-handoff.wizard.ts`.
+
+Adding this sixth mode pushed `runEntryWizard()`'s original single-function if-chain (one branch per mode, ADR-0071) past the point of being easy to scan in one pass. Refactored in the same PR into a flat `switch (mode)` dispatcher plus one `run<Mode>Mode()` function per branch (`runWasteMode`, `runDeadResourcesMode`, `runResourceSecurityMode`, `runTerraformMode`, `runCostTrendMode`) — same behavior, verified against the same end-to-end pty smoke test used above, just no longer one function growing a branch per mode indefinitely.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -109,6 +109,7 @@ Each entry follows: Context → Decision → Alternatives Considered → Consequ
 | [0073](0073-brand-mark-pixel-art-pipeline.md) | Brand mark generated from the real logo via an offline pixel-art sampling pipeline | Accepted |
 | [0087](0087-precommit-hooks-eslint-only-no-prettier.md) | Pre-commit hooks via husky + lint-staged, `eslint --fix` only — no `prettier --write` | Accepted |
 | [0096](0096-cross-account-scanning-assume-role.md) | Cross-account scanning via `--assume-role-arn` (STS AssumeRole) | Accepted |
+| [0097](0097-terraform-analysis-wizard-handoff.md) | Wizard mode delegating to the separate `cloudrift-iac-detector` Pro package | Accepted |
 
 ## Reporting
 


### PR DESCRIPTION
## Summary
- New wizard mode "Terraform source analysis" (hinted `Pro`, same convention as the existing Cost Explorer per-request hints) detects the separate, proprietary `cloudrift-iac-detector` binary on `PATH` and hands the terminal off to it — a retro loading-bar transition, then `spawn(..., { stdio: 'inherit' })`, propagating its real exit code. No logic from that package is duplicated or embedded here (can't be — it's a separate commercially-licensed repo); if the binary isn't found, points the user at their Pro license for install instructions instead of failing silently.
- `runEntryWizard()` refactored from one if-chain (one branch per mode) into a flat `switch` dispatcher + one `run<Mode>Mode()` function per mode — six modes had made the single function noticeably harder to scan in one pass; same behavior, re-verified end-to-end after the refactor.
- Full rationale in `docs/adr/0097-terraform-analysis-wizard-handoff.md`.

## Test plan
- [x] `pnpm nx run-many --target=lint,typecheck,test,build --projects=cli` — all green (242 tests)
- [x] `resolveCloudriftIacDetectorBinary()` / `delegateToCloudriftIacDetector()` verified against a temporary fake binary on `PATH` (found-on-PATH, not-found, and real exit-code propagation) — not committed, matches this repo's standing choice not to unit-test `wizard/*.wizard.ts`
- [x] Full interactive path verified twice (before and after the dispatcher refactor) via a real pty (`expect`): mode picker → loading-bar transition → the fake binary actually runs and its output reaches the terminal