### PR TITLE
fix(cloud-cost-pricing): use files, not include, for prices.json

### DIFF
--- a/libs/shared/cloud-cost-pricing/tsconfig.lib.json
+++ b/libs/shared/cloud-cost-pricing/tsconfig.lib.json
@@ -9,7 +9,8 @@
     "types": ["node"],
     "resolveJsonModule": true
   },
-  "include": ["src/**/*.ts", "src/**/*.json"],
+  "include": ["src/**/*.ts"],
+  "files": ["src/prices.json"],
   "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"],
   "references": [
     {


### PR DESCRIPTION
## Summary
- Follow-up to #90: TypeScript's `include` glob expansion never matches `.json` files (verified empirically — even an explicit `src/**/*.json` pattern doesn't add it to the parsed config's `fileNames`), only an explicit `files` array entry does.
- This didn't break regular CI (`lint`/`typecheck`/`test`/`build` all passed on #90 as merged) since ts-jest and a standalone `tsc --build` on the leaf project both tolerate the json import via plain module resolution. It does break `build-pkg`'s declaration-bundling step (`TS6307`) and a full composite cross-project build from any dependent project (`TS6305`, since `cloud-cost-domain` references this package).

## Test plan
- [x] `pnpm nx reset` + `pnpm nx run-many --target=lint,typecheck,test,build --all --parallel` — all 18 projects green
- [x] `pnpm nx run cloud-cost-pricing:publish-pkg` succeeds end-to-end
- [x] `@ellevas/cloud-cost-pricing@0.0.1` published to GitHub Packages and verified importable (`StaticPriceTableAdapter` returns real prices, e.g. `nat-gateway` → 32.4)