### PR TITLE
feat(cli): history --compare and --html (scan-to-scan diff + trend chart)

### DIFF
--- a/apps/cli/src/commands/history-comparison.spec.ts
+++ b/apps/cli/src/commands/history-comparison.spec.ts
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: Apache-2.0
+import type { WasteReportDto } from 'cloud-cost-application';
+import type { DeadResourcesReportDto } from 'dead-resources-application';
+import { compareCloudCostSnapshots, compareHygieneSnapshots } from './history-comparison';
+
+function wasteReport(overrides: Partial<WasteReportDto> = {}): WasteReportDto {
+  return {
+    meta: { accountId: '123456789012', regions: ['us-east-1'], generatedAt: '2026-07-01T00:00:00.000Z', pricesAsOf: '2026-06', pricesStale: false },
+    disclaimer: '',
+    contact: { email: '', linkedin: '' },
+    totalWasteMonthlyUsd: 0,
+    totalWasteAnnualUsd: 0,
+    totalOptimizationMonthlyUsd: 0,
+    wasteCount: 0,
+    optimizationCount: 0,
+    breakdown: [],
+    findings: [],
+    scanErrors: [],
+    ...overrides,
+  };
+}
+
+function finding(id: string, monthlyCostUsd: number) {
+  return {
+    id,
+    kind: 'ebs-volume' as const,
+    category: 'waste' as const,
+    estimated: false,
+    region: 'us-east-1',
+    accountId: '123456789012',
+    detectedAt: '2026-06-01T00:00:00.000Z',
+    wasteReason: 'unattached',
+    description: '',
+    monthlyCostUsd,
+    tags: {},
+  };
+}
+
+describe('compareCloudCostSnapshots', () => {
+  it('computes the total delta and presumed-resolved sum for findings that disappeared', () => {
+    const older = wasteReport({
+      meta: { accountId: '123456789012', regions: ['us-east-1'], generatedAt: '2026-07-25T00:00:00.000Z', pricesAsOf: '2026-06', pricesStale: false },
+      totalWasteMonthlyUsd: 25,
+      findings: [finding('vol-1', 15), finding('vol-2', 10)],
+    });
+    const newer = wasteReport({
+      meta: { accountId: '123456789012', regions: ['us-east-1'], generatedAt: '2026-07-30T00:00:00.000Z', pricesAsOf: '2026-06', pricesStale: false },
+      totalWasteMonthlyUsd: 10,
+      findings: [finding('vol-2', 10)],
+    });
+
+    const result = compareCloudCostSnapshots(older, newer);
+
+    expect(result.olderTotalWasteMonthlyUsd).toBe(25);
+    expect(result.newerTotalWasteMonthlyUsd).toBe(10);
+    expect(result.deltaUsd).toBe(-15);
+    expect(result.deltaPercent).toBeCloseTo(-60);
+    expect(result.presumedResolvedMonthlyUsd).toBe(15);
+    expect(result.resolvedFindings).toEqual([{ id: 'vol-1', kind: 'ebs-volume', monthlyCostUsd: 15 }]);
+    expect(result.newFindings).toEqual([]);
+    expect(result.regionsChanged).toBe(false);
+  });
+
+  it('reports new findings that appeared since the older snapshot', () => {
+    const older = wasteReport({ totalWasteMonthlyUsd: 0, findings: [] });
+    const newer = wasteReport({ totalWasteMonthlyUsd: 8, findings: [finding('vol-new', 8)] });
+
+    const result = compareCloudCostSnapshots(older, newer);
+
+    expect(result.newFindings).toEqual([{ id: 'vol-new', kind: 'ebs-volume', monthlyCostUsd: 8 }]);
+    expect(result.presumedResolvedMonthlyUsd).toBe(0);
+  });
+
+  it('returns a null deltaPercent when the older total was $0 (division by zero has no meaningful percentage)', () => {
+    const older = wasteReport({ totalWasteMonthlyUsd: 0 });
+    const newer = wasteReport({ totalWasteMonthlyUsd: 12 });
+
+    expect(compareCloudCostSnapshots(older, newer).deltaPercent).toBeNull();
+  });
+
+  it('flags when the two runs scanned different regions', () => {
+    const older = wasteReport({ meta: { accountId: '123456789012', regions: ['us-east-1'], generatedAt: '2026-07-25T00:00:00.000Z', pricesAsOf: '2026-06', pricesStale: false } });
+    const newer = wasteReport({ meta: { accountId: '123456789012', regions: ['us-east-1', 'eu-west-1'], generatedAt: '2026-07-30T00:00:00.000Z', pricesAsOf: '2026-06', pricesStale: false } });
+
+    expect(compareCloudCostSnapshots(older, newer).regionsChanged).toBe(true);
+  });
+
+  it('does not flag regionsChanged when the same regions are scanned in a different order', () => {
+    const older = wasteReport({ meta: { accountId: '123456789012', regions: ['eu-west-1', 'us-east-1'], generatedAt: '2026-07-25T00:00:00.000Z', pricesAsOf: '2026-06', pricesStale: false } });
+    const newer = wasteReport({ meta: { accountId: '123456789012', regions: ['us-east-1', 'eu-west-1'], generatedAt: '2026-07-30T00:00:00.000Z', pricesAsOf: '2026-06', pricesStale: false } });
+
+    expect(compareCloudCostSnapshots(older, newer).regionsChanged).toBe(false);
+  });
+});
+
+describe('compareHygieneSnapshots', () => {
+  function report(overrides: Partial<DeadResourcesReportDto> = {}): DeadResourcesReportDto {
+    return {
+      meta: { accountId: '123456789012', regions: ['us-east-1'], generatedAt: '2026-07-01T00:00:00.000Z' },
+      disclaimer: '',
+      countBySeverity: { info: 0, warning: 0, critical: 0 },
+      findings: [],
+      scanErrors: [],
+      ...overrides,
+    };
+  }
+
+  function hygieneFinding(id: string, severity: 'info' | 'warning' | 'critical') {
+    return { id, kind: 'ec2-keypair-unused', region: 'us-east-1', accountId: '123456789012', detectedAt: '2026-06-01T00:00:00.000Z', tags: {}, hygieneReason: 'unused', severity };
+  }
+
+  it('reports resolved/new findings and both severity breakdowns', () => {
+    const older = report({
+      countBySeverity: { info: 2, warning: 0, critical: 0 },
+      findings: [hygieneFinding('kp-1', 'info'), hygieneFinding('kp-2', 'info')],
+    });
+    const newer = report({
+      countBySeverity: { info: 1, warning: 0, critical: 0 },
+      findings: [hygieneFinding('kp-2', 'info')],
+    });
+
+    const result = compareHygieneSnapshots('dead-resources', older, newer);
+
+    expect(result.domain).toBe('dead-resources');
+    expect(result.olderCountBySeverity).toEqual({ info: 2, warning: 0, critical: 0 });
+    expect(result.newerCountBySeverity).toEqual({ info: 1, warning: 0, critical: 0 });
+    expect(result.resolvedFindings).toEqual([{ id: 'kp-1', kind: 'ec2-keypair-unused', severity: 'info' }]);
+    expect(result.newFindings).toEqual([]);
+  });
+});

--- a/apps/cli/src/commands/history-comparison.ts
+++ b/apps/cli/src/commands/history-comparison.ts
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: Apache-2.0
+import type { WasteReportDto } from 'cloud-cost-application';
+
+interface FindingDelta<T> {
+  readonly resolved: T[];
+  readonly ongoing: T[];
+  readonly new: T[];
+}
+
+/** Findings present in `older` but not `newer` are `resolved`; the reverse is `new`; present in both is `ongoing`. */
+function diffFindingsById<T extends { id: string }>(older: readonly T[], newer: readonly T[]): FindingDelta<T> {
+  const olderIds = new Set(older.map((f) => f.id));
+  const newerIds = new Set(newer.map((f) => f.id));
+  return {
+    resolved: older.filter((f) => !newerIds.has(f.id)),
+    ongoing: newer.filter((f) => olderIds.has(f.id)),
+    new: newer.filter((f) => !olderIds.has(f.id)),
+  };
+}
+
+function regionsDiffer(older: { regions: string[] }, newer: { regions: string[] }): boolean {
+  const a = [...older.regions].sort();
+  const b = [...newer.regions].sort();
+  return a.length !== b.length || a.some((region, i) => region !== b[i]);
+}
+
+export interface CloudCostComparison {
+  readonly domain: 'cloud-cost';
+  readonly olderGeneratedAt: string;
+  readonly newerGeneratedAt: string;
+  readonly olderTotalWasteMonthlyUsd: number;
+  readonly newerTotalWasteMonthlyUsd: number;
+  readonly deltaUsd: number;
+  /** null when the older total was $0 — a percentage change from zero isn't meaningful. */
+  readonly deltaPercent: number | null;
+  /**
+   * Sum of the `monthlyCostUsd` of findings present in the older snapshot but
+   * absent from the newer one. Labeled "presumed" deliberately: cloudrift is
+   * read-only and never remediates anything, so it cannot know *why* a
+   * finding disappeared (fixed by the user, resource deleted for an
+   * unrelated reason, or simply out of scope this run) — see `regionsChanged`.
+   */
+  readonly presumedResolvedMonthlyUsd: number;
+  readonly resolvedFindings: ReadonlyArray<{ id: string; kind: string; monthlyCostUsd: number }>;
+  readonly newFindings: ReadonlyArray<{ id: string; kind: string; monthlyCostUsd: number }>;
+  /** True if the two compared runs scanned different regions — a resolved/new finding may just reflect that, not real change. */
+  readonly regionsChanged: boolean;
+}
+
+export function compareCloudCostSnapshots(older: WasteReportDto, newer: WasteReportDto): CloudCostComparison {
+  const delta = diffFindingsById(older.findings, newer.findings);
+  const deltaUsd = newer.totalWasteMonthlyUsd - older.totalWasteMonthlyUsd;
+
+  return {
+    domain: 'cloud-cost',
+    olderGeneratedAt: older.meta.generatedAt,
+    newerGeneratedAt: newer.meta.generatedAt,
+    olderTotalWasteMonthlyUsd: older.totalWasteMonthlyUsd,
+    newerTotalWasteMonthlyUsd: newer.totalWasteMonthlyUsd,
+    deltaUsd,
+    deltaPercent: older.totalWasteMonthlyUsd !== 0 ? (deltaUsd / older.totalWasteMonthlyUsd) * 100 : null,
+    presumedResolvedMonthlyUsd: delta.resolved.reduce((sum, f) => sum + f.monthlyCostUsd, 0),
+    resolvedFindings: delta.resolved.map((f) => ({ id: f.id, kind: f.kind, monthlyCostUsd: f.monthlyCostUsd })),
+    newFindings: delta.new.map((f) => ({ id: f.id, kind: f.kind, monthlyCostUsd: f.monthlyCostUsd })),
+    regionsChanged: regionsDiffer(older.meta, newer.meta),
+  };
+}
+
+export interface HygieneComparison {
+  readonly domain: 'dead-resources' | 'resource-security';
+  readonly olderGeneratedAt: string;
+  readonly newerGeneratedAt: string;
+  readonly olderCountBySeverity: Record<string, number>;
+  readonly newerCountBySeverity: Record<string, number>;
+  readonly resolvedFindings: ReadonlyArray<{ id: string; kind: string; severity: string }>;
+  readonly newFindings: ReadonlyArray<{ id: string; kind: string; severity: string }>;
+  readonly regionsChanged: boolean;
+}
+
+/**
+ * Structural shape `compareHygieneSnapshots` actually needs — deliberately
+ * narrower than either full DTO (no `hygieneReason`/`riskReason`).
+ */
+interface HygieneReportLike {
+  readonly meta: { readonly generatedAt: string; readonly regions: string[] };
+  readonly countBySeverity: Record<string, number>;
+  readonly findings: ReadonlyArray<{ id: string; kind: string; severity: string }>;
+}
+
+/**
+ * Same shape as `compareCloudCostSnapshots`, but for the two severity-based
+ * (no `$/month`) domains — `dead-resources` and `resource-security` share an
+ * identical DTO shape except the reason field name, which isn't needed here.
+ *
+ * `older`/`newer` share one type parameter `T` (not a union of the two DTOs)
+ * on purpose: a union would make `older.findings`/`newer.findings` two
+ * *independently* unioned array types, and passing one to the other's
+ * generic slot in `diffFindingsById` fails to type-check (TS can't infer a
+ * single `T` for `readonly T[]` from a `readonly (A | B)[]` argument caused
+ * by two unrelated unions). Binding both parameters to the same `T` forces
+ * every call site to pass a matched pair of the *same* concrete DTO — which
+ * is also the only comparison that ever makes semantic sense.
+ */
+export function compareHygieneSnapshots<T extends HygieneReportLike>(
+  domain: 'dead-resources' | 'resource-security',
+  older: T,
+  newer: T,
+): HygieneComparison {
+  const delta = diffFindingsById(older.findings, newer.findings);
+
+  return {
+    domain,
+    olderGeneratedAt: older.meta.generatedAt,
+    newerGeneratedAt: newer.meta.generatedAt,
+    olderCountBySeverity: older.countBySeverity,
+    newerCountBySeverity: newer.countBySeverity,
+    resolvedFindings: delta.resolved.map((f) => ({ id: f.id, kind: f.kind, severity: f.severity })),
+    newFindings: delta.new.map((f) => ({ id: f.id, kind: f.kind, severity: f.severity })),
+    regionsChanged: regionsDiffer(older.meta, newer.meta),
+  };
+}
+
+export type HistoryComparison = CloudCostComparison | HygieneComparison;

--- a/apps/cli/src/commands/history.command.spec.ts
+++ b/apps/cli/src/commands/history.command.spec.ts
@@ -19,15 +19,23 @@ const SAMPLE_RECORDS: TrendSnapshotRecord[] = [
 
 function makeDeps(opts: { resolvedAccountId?: string; records?: TrendSnapshotRecord[] } = {}): HistoryDeps & {
   readSnapshotsArgs: unknown[];
+  writeHtmlReportArgs: Array<[string, string]>;
 } {
   const calls: unknown[] = [];
+  const htmlCalls: Array<[string, string]> = [];
   return {
     resolveAccountId: async () => opts.resolvedAccountId,
     readSnapshots: (async (accountId: string, options?: unknown) => {
       calls.push([accountId, options]);
       return opts.records ?? SAMPLE_RECORDS;
     }) as HistoryDeps['readSnapshots'],
+    // Never touch the real filesystem in a unit test — same reasoning as
+    // mocking `shared-trend-store` in the scan commands' specs.
+    writeHtmlReport: async (path: string, html: string) => {
+      htmlCalls.push([path, html]);
+    },
     readSnapshotsArgs: calls,
+    writeHtmlReportArgs: htmlCalls,
   };
 }
 
@@ -102,5 +110,102 @@ describe('historyCommand', () => {
     await historyCommand({}, deps);
 
     expect(stdout).toContain('No trend history yet');
+  });
+
+  function wastePayload(totalWasteMonthlyUsd: number, findingIds: string[]) {
+    return JSON.stringify({
+      meta: { accountId: '123456789012', regions: ['us-east-1'], generatedAt: '2026-07-01T00:00:00.000Z' },
+      totalWasteMonthlyUsd,
+      findings: findingIds.map((id) => ({ id, kind: 'ebs-volume', monthlyCostUsd: totalWasteMonthlyUsd / (findingIds.length || 1) })),
+    });
+  }
+
+  const compareRecords = [
+    { id: 3, domain: 'cloud-cost' as const, generatedAt: '2026-07-30T00:00:00.000Z', payload: wastePayload(10, ['vol-2']) },
+    { id: 2, domain: 'cloud-cost' as const, generatedAt: '2026-07-29T00:00:00.000Z', payload: wastePayload(20, ['vol-1', 'vol-2']) },
+    { id: 1, domain: 'cloud-cost' as const, generatedAt: '2026-07-28T00:00:00.000Z', payload: wastePayload(25, ['vol-1', 'vol-2', 'vol-3']) },
+  ];
+
+  describe('--compare', () => {
+    it('rejects --compare without --domain', async () => {
+      const deps = makeDeps();
+      await historyCommand({ compare: '1' }, deps);
+      expect(stderr).toContain('--compare requires --domain');
+    });
+
+    it('rejects a non-positive --compare value', async () => {
+      const deps = makeDeps();
+      await historyCommand({ compare: '0', domain: 'cloud-cost' }, deps);
+      expect(stderr).toContain('--compare must be a positive integer');
+    });
+
+    it('fails cleanly when there is not enough history to compare that far back', async () => {
+      const deps = makeDeps({ resolvedAccountId: '123456789012', records: compareRecords });
+      await historyCommand({ compare: '5', domain: 'cloud-cost' }, deps);
+      expect(stderr).toContain('Not enough history to compare 5 run(s) back');
+    });
+
+    it('compares the latest run against n runs back for cloud-cost', async () => {
+      const deps = makeDeps({ resolvedAccountId: '123456789012', records: compareRecords });
+      await historyCommand({ compare: '2', domain: 'cloud-cost' }, deps);
+
+      expect(deps.readSnapshotsArgs).toEqual([['123456789012', { domain: 'cloud-cost', limit: 3 }]]);
+      expect(stdout).toContain('$25.00 → $10.00');
+      expect(stdout).toContain('Presumed resolved');
+    });
+
+    it('prints the comparison as JSON when --format json is given', async () => {
+      const deps = makeDeps({ resolvedAccountId: '123456789012', records: compareRecords });
+      await historyCommand({ compare: '1', domain: 'cloud-cost', format: 'json' }, deps);
+
+      const printed = JSON.parse(stdout);
+      expect(printed.domain).toBe('cloud-cost');
+      expect(printed.olderTotalWasteMonthlyUsd).toBe(20);
+      expect(printed.newerTotalWasteMonthlyUsd).toBe(10);
+    });
+  });
+
+  describe('--html', () => {
+    it('rejects --html without --domain', async () => {
+      const deps = makeDeps({ resolvedAccountId: '123456789012' });
+      await historyCommand({ html: true }, deps);
+      expect(stderr).toContain('--html requires --domain');
+      expect(deps.writeHtmlReportArgs).toHaveLength(0);
+    });
+
+    it('writes an HTML report to the default path when no filename is given', async () => {
+      const deps = makeDeps({ resolvedAccountId: '123456789012', records: compareRecords });
+      await historyCommand({ html: true, domain: 'cloud-cost' }, deps);
+
+      expect(deps.writeHtmlReportArgs).toHaveLength(1);
+      const [path, html] = deps.writeHtmlReportArgs[0];
+      expect(path).toContain('cloudrift-history-cloud-cost-');
+      expect(html).toContain('<!doctype html>');
+      expect(stderr).toContain('HTML report saved to');
+    });
+
+    it('writes to the explicit filename when one is given', async () => {
+      const deps = makeDeps({ resolvedAccountId: '123456789012', records: compareRecords });
+      await historyCommand({ html: 'my-report.html', domain: 'cloud-cost' }, deps);
+
+      const [path] = deps.writeHtmlReportArgs[0];
+      expect(path).toContain('my-report.html');
+    });
+
+    it('does not block the normal list output on stdout', async () => {
+      const deps = makeDeps({ resolvedAccountId: '123456789012', records: compareRecords });
+      await historyCommand({ html: true, domain: 'cloud-cost' }, deps);
+
+      expect(stdout).toContain('cloud-cost');
+      expect(deps.writeHtmlReportArgs).toHaveLength(1);
+    });
+
+    it('also works alongside --compare', async () => {
+      const deps = makeDeps({ resolvedAccountId: '123456789012', records: compareRecords });
+      await historyCommand({ compare: '2', domain: 'cloud-cost', html: true }, deps);
+
+      expect(stdout).toContain('$25.00');
+      expect(deps.writeHtmlReportArgs).toHaveLength(1);
+    });
   });
 });

--- a/apps/cli/src/commands/history.command.ts
+++ b/apps/cli/src/commands/history.command.ts
@@ -1,10 +1,19 @@
 // SPDX-License-Identifier: Apache-2.0
 import chalk from 'chalk';
+import { dirname, resolve } from 'path';
+import { mkdir, writeFile } from 'fs/promises';
 import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { resolveAwsAccountId } from 'cloud-cost-infrastructure-aws-adapter';
-import { readTrendSnapshots, type TrendDomain } from 'shared-trend-store';
+import type { WasteReportDto } from 'cloud-cost-application';
+import type { DeadResourcesReportDto } from 'dead-resources-application';
+import type { ResourceSecurityReportDto } from 'resource-security-application';
+import { readTrendSnapshots, type TrendDomain, type TrendSnapshotRecord } from 'shared-trend-store';
 import { formatTrendHistoryAsTable } from '../formatters/trend-history.table-formatter';
 import { formatTrendHistoryAsJson } from '../formatters/trend-history.json-formatter';
+import { formatHistoryComparisonAsTable } from '../formatters/history-comparison.table-formatter';
+import { formatHistoryComparisonAsJson } from '../formatters/history-comparison.json-formatter';
+import { generateHistoryReportHtml } from '../formatters/history-report.html-formatter';
+import { compareCloudCostSnapshots, compareHygieneSnapshots, type HistoryComparison } from './history-comparison';
 import { isOutputFormat } from '../output-format';
 import { resolveCredentials } from './resolve-options';
 import { reportCliError as fail } from './report-cli-error';
@@ -16,23 +25,55 @@ function isTrendDomain(value: string): value is TrendDomain {
   return (HISTORY_DOMAINS as readonly string[]).includes(value);
 }
 
+/**
+ * Dispatches on `domain` with a concrete (never union'd) DTO cast in each
+ * branch — `compareHygieneSnapshots`'s `older`/`newer` share one type
+ * parameter, so both arguments in a single call must resolve to the exact
+ * same concrete type; casting each independently to the
+ * `DeadResourcesReportDto | ResourceSecurityReportDto` union here would
+ * reintroduce the same inference problem that generic exists to avoid.
+ */
+function buildComparison(domain: TrendDomain, older: TrendSnapshotRecord, newer: TrendSnapshotRecord): HistoryComparison {
+  switch (domain) {
+    case 'cloud-cost':
+      return compareCloudCostSnapshots(JSON.parse(older.payload) as WasteReportDto, JSON.parse(newer.payload) as WasteReportDto);
+    case 'dead-resources':
+      return compareHygieneSnapshots('dead-resources', JSON.parse(older.payload) as DeadResourcesReportDto, JSON.parse(newer.payload) as DeadResourcesReportDto);
+    case 'resource-security':
+      return compareHygieneSnapshots(
+        'resource-security',
+        JSON.parse(older.payload) as ResourceSecurityReportDto,
+        JSON.parse(newer.payload) as ResourceSecurityReportDto,
+      );
+  }
+}
+
 export interface HistoryCommandOptions {
   accountId?: string;
   assumeRoleArn?: string;
   externalId?: string;
   domain?: string;
   limit?: string;
+  compare?: string;
+  html?: string | boolean;
   format?: string;
 }
 
 export interface HistoryDeps {
   resolveAccountId(credentials?: AwsCredentialIdentityProvider): Promise<string | undefined>;
   readSnapshots: typeof readTrendSnapshots;
+  writeHtmlReport: (path: string, html: string) => Promise<void>;
+}
+
+async function writeHtmlReportToDisk(path: string, html: string): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, html);
 }
 
 export const defaultHistoryDeps: HistoryDeps = {
   resolveAccountId: resolveAwsAccountId,
   readSnapshots: readTrendSnapshots,
+  writeHtmlReport: writeHtmlReportToDisk,
 };
 
 /**
@@ -41,6 +82,17 @@ export const defaultHistoryDeps: HistoryDeps = {
  * `resource-security` each append a full snapshot to on every run — a local
  * scan history, never uploaded anywhere (see ADR-0099). Read-only: the only
  * AWS call is the STS lookup used to resolve which account's file to open.
+ *
+ * `--compare <n>` switches to a two-run diff instead of the plain list:
+ * the latest snapshot vs. the one `n` runs back, for one domain at a time.
+ * For `cloud-cost` this includes a "presumed resolved" dollar figure — an
+ * inference (findings gone between the two runs), not a confirmed saving,
+ * since cloudrift never remediates anything itself (see `history-comparison.ts`).
+ *
+ * `--html [filename]` additionally writes a self-contained HTML report (inline
+ * SVG line chart + table view, no chart-library dependency) of one domain's
+ * metric over every stored run — independent of `--compare`/stdout `--format`,
+ * same "additional file artifact" convention as `--pdf`/`--csv` elsewhere.
  */
 export async function historyCommand(
   options: HistoryCommandOptions,
@@ -64,6 +116,18 @@ export async function historyCommand(
     limit = parsed;
   }
 
+  let compareN: number | undefined;
+  if (options.compare !== undefined) {
+    if (options.domain === undefined || !isTrendDomain(options.domain)) {
+      return fail('--compare requires --domain (cloud-cost, dead-resources, or resource-security) to know which report shape to compare.');
+    }
+    const parsed = Number(options.compare);
+    if (!Number.isInteger(parsed) || parsed <= 0) {
+      return fail(`--compare must be a positive integer (how many runs back to compare against), got "${options.compare}".`);
+    }
+    compareN = parsed;
+  }
+
   const credentialsResult = await resolveCredentials(options);
   if (!credentialsResult.ok) return fail(credentialsResult.error.message);
   const credentials = credentialsResult.value;
@@ -73,10 +137,34 @@ export async function historyCommand(
     console.error(chalk.dim('  Could not resolve the AWS account ID via STS — pass --account-id to set it explicitly.'));
   }
 
-  const records = await deps.readSnapshots(accountId, {
-    domain: options.domain as TrendDomain | undefined,
-    limit,
-  });
+  if (options.html !== undefined && options.html !== false && (options.domain === undefined || !isTrendDomain(options.domain))) {
+    return fail('--html requires --domain (cloud-cost, dead-resources, or resource-security) to know which metric to chart.');
+  }
 
-  console.log(format === 'json' ? formatTrendHistoryAsJson(records) : formatTrendHistoryAsTable(records));
+  if (compareN !== undefined) {
+    const domain = options.domain as TrendDomain;
+    const records = await deps.readSnapshots(accountId, { domain, limit: compareN + 1 });
+    if (records.length < compareN + 1) {
+      return fail(`Not enough history to compare ${compareN} run(s) back — only ${records.length} snapshot(s) on record for "${domain}".`);
+    }
+    const comparison = buildComparison(domain, records[compareN], records[0]);
+    console.log(format === 'json' ? formatHistoryComparisonAsJson(comparison) : formatHistoryComparisonAsTable(comparison));
+  } else {
+    const records = await deps.readSnapshots(accountId, {
+      domain: options.domain as TrendDomain | undefined,
+      limit,
+    });
+    console.log(format === 'json' ? formatTrendHistoryAsJson(records) : formatTrendHistoryAsTable(records));
+  }
+
+  if (options.html !== undefined && options.html !== false) {
+    const domain = options.domain as TrendDomain;
+    const htmlRecords = await deps.readSnapshots(accountId, { domain, limit: limit ?? 100 });
+    const html = generateHistoryReportHtml(htmlRecords, domain, accountId);
+    const day = new Date().toISOString().split('T')[0].replaceAll('-', '_');
+    const outputPath =
+      typeof options.html === 'string' ? resolve(process.cwd(), options.html) : resolve(process.cwd(), 'reports', `cloudrift-history-${domain}-${day}.html`);
+    await deps.writeHtmlReport(outputPath, html);
+    console.error(chalk.green(`  HTML report saved to ${outputPath}`));
+  }
 }

--- a/apps/cli/src/formatters/history-comparison.json-formatter.ts
+++ b/apps/cli/src/formatters/history-comparison.json-formatter.ts
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+import type { HistoryComparison } from '../commands/history-comparison';
+
+export function formatHistoryComparisonAsJson(comparison: HistoryComparison): string {
+  return JSON.stringify(comparison, null, 2);
+}

--- a/apps/cli/src/formatters/history-comparison.table-formatter.spec.ts
+++ b/apps/cli/src/formatters/history-comparison.table-formatter.spec.ts
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+import type { CloudCostComparison, HygieneComparison } from '../commands/history-comparison';
+import { formatHistoryComparisonAsTable } from './history-comparison.table-formatter';
+
+function cloudCostComparison(overrides: Partial<CloudCostComparison> = {}): CloudCostComparison {
+  return {
+    domain: 'cloud-cost',
+    olderGeneratedAt: '2026-07-25T00:00:00.000Z',
+    newerGeneratedAt: '2026-07-30T00:00:00.000Z',
+    olderTotalWasteMonthlyUsd: 25,
+    newerTotalWasteMonthlyUsd: 10,
+    deltaUsd: -15,
+    deltaPercent: -60,
+    presumedResolvedMonthlyUsd: 15,
+    resolvedFindings: [{ id: 'vol-1', kind: 'ebs-volume', monthlyCostUsd: 15 }],
+    newFindings: [],
+    regionsChanged: false,
+    ...overrides,
+  };
+}
+
+function hygieneComparison(overrides: Partial<HygieneComparison> = {}): HygieneComparison {
+  return {
+    domain: 'dead-resources',
+    olderGeneratedAt: '2026-07-25T00:00:00.000Z',
+    newerGeneratedAt: '2026-07-30T00:00:00.000Z',
+    olderCountBySeverity: { info: 2, warning: 0, critical: 0 },
+    newerCountBySeverity: { info: 1, warning: 0, critical: 0 },
+    resolvedFindings: [{ id: 'kp-1', kind: 'ec2-keypair-unused', severity: 'info' }],
+    newFindings: [],
+    regionsChanged: false,
+    ...overrides,
+  };
+}
+
+describe('formatHistoryComparisonAsTable', () => {
+  it('renders the cloud-cost comparison with the resolved finding and presumed-resolved total', () => {
+    const output = formatHistoryComparisonAsTable(cloudCostComparison());
+    expect(output).toContain('Comparing 2026-07-25 → 2026-07-30');
+    expect(output).toContain('$25.00 → $10.00');
+    expect(output).toContain('Presumed resolved: $15.00/mo');
+    expect(output).toContain('ebs-volume vol-1');
+  });
+
+  it('renders new findings and omits the presumed-resolved line when nothing resolved', () => {
+    const output = formatHistoryComparisonAsTable(
+      cloudCostComparison({ resolvedFindings: [], presumedResolvedMonthlyUsd: 0, newFindings: [{ id: 'vol-new', kind: 'ebs-volume', monthlyCostUsd: 8 }] }),
+    );
+    expect(output).toContain('No findings resolved');
+    expect(output).toContain('New waste since then: 1 finding(s)');
+  });
+
+  it('flags a region mismatch caveat', () => {
+    const output = formatHistoryComparisonAsTable(cloudCostComparison({ regionsChanged: true }));
+    expect(output).toContain('scanned different regions');
+  });
+
+  it('renders a hygiene-domain comparison with severity breakdown', () => {
+    const output = formatHistoryComparisonAsTable(hygieneComparison());
+    expect(output).toContain('Findings: 2 → 1');
+    expect(output).toContain('critical 0→0');
+    expect(output).toContain('Resolved: 1 finding(s)');
+    expect(output).toContain('ec2-keypair-unused kp-1');
+  });
+
+  it('renders new hygiene findings', () => {
+    const output = formatHistoryComparisonAsTable(hygieneComparison({ resolvedFindings: [], newFindings: [{ id: 'kp-3', kind: 'ec2-keypair-unused', severity: 'warning' }] }));
+    expect(output).toContain('New: 1 finding(s)');
+  });
+});

--- a/apps/cli/src/formatters/history-comparison.table-formatter.ts
+++ b/apps/cli/src/formatters/history-comparison.table-formatter.ts
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Apache-2.0
+import chalk from 'chalk';
+import type { CloudCostComparison, HistoryComparison, HygieneComparison } from '../commands/history-comparison';
+
+function formatUsd(value: number): string {
+  const sign = value > 0 ? '+' : '';
+  return `${sign}$${value.toFixed(2)}`;
+}
+
+function formatPercent(value: number): string {
+  const sign = value > 0 ? '+' : '';
+  return `${sign}${value.toFixed(1)}%`;
+}
+
+function deltaColorFor(deltaUsd: number): (text: string) => string {
+  if (deltaUsd > 0) return chalk.red;
+  if (deltaUsd < 0) return chalk.green;
+  return chalk.dim;
+}
+
+function sumSeverities(counts: Record<string, number>): number {
+  return Object.values(counts).reduce((sum, n) => sum + n, 0);
+}
+
+export function formatHistoryComparisonAsTable(comparison: HistoryComparison): string {
+  const olderDate = comparison.olderGeneratedAt.split('T')[0];
+  const newerDate = comparison.newerGeneratedAt.split('T')[0];
+
+  const lines: string[] = [chalk.bold(`\n  Comparing ${olderDate} → ${newerDate}\n`)];
+  lines.push(...(comparison.domain === 'cloud-cost' ? formatCloudCostSection(comparison) : formatHygieneSection(comparison)));
+
+  if (comparison.regionsChanged) {
+    lines.push(chalk.yellow('\n  ⚠ The two runs scanned different regions — this comparison may not be apples-to-apples.'));
+  }
+
+  return lines.join('\n') + '\n';
+}
+
+function formatCloudCostSection(comparison: CloudCostComparison): string[] {
+  const lines: string[] = [];
+  const percent = comparison.deltaPercent === null ? '' : ` (${formatPercent(comparison.deltaPercent)})`;
+  const delta = deltaColorFor(comparison.deltaUsd)(formatUsd(comparison.deltaUsd) + percent);
+  lines.push(`  Monthly waste: $${comparison.olderTotalWasteMonthlyUsd.toFixed(2)} → $${comparison.newerTotalWasteMonthlyUsd.toFixed(2)}  ${delta}`);
+
+  if (comparison.resolvedFindings.length > 0) {
+    lines.push(chalk.green(`\n  Presumed resolved: $${comparison.presumedResolvedMonthlyUsd.toFixed(2)}/mo across ${comparison.resolvedFindings.length} finding(s) no longer present`));
+    for (const f of comparison.resolvedFindings) {
+      lines.push(`    - ${f.kind} ${f.id} ($${f.monthlyCostUsd.toFixed(2)}/mo)`);
+    }
+  } else {
+    lines.push(chalk.dim('\n  No findings resolved since the older run.'));
+  }
+
+  if (comparison.newFindings.length > 0) {
+    lines.push(chalk.yellow(`\n  New waste since then: ${comparison.newFindings.length} finding(s)`));
+    for (const f of comparison.newFindings) {
+      lines.push(`    - ${f.kind} ${f.id} ($${f.monthlyCostUsd.toFixed(2)}/mo)`);
+    }
+  }
+
+  return lines;
+}
+
+function formatHygieneSection(comparison: HygieneComparison): string[] {
+  const older = comparison.olderCountBySeverity;
+  const newer = comparison.newerCountBySeverity;
+  const lines: string[] = [
+    `  Findings: ${sumSeverities(older)} → ${sumSeverities(newer)}` +
+      `  (critical ${older.critical ?? 0}→${newer.critical ?? 0},` +
+      ` warning ${older.warning ?? 0}→${newer.warning ?? 0},` +
+      ` info ${older.info ?? 0}→${newer.info ?? 0})`,
+  ];
+
+  if (comparison.resolvedFindings.length > 0) {
+    lines.push(chalk.green(`\n  Resolved: ${comparison.resolvedFindings.length} finding(s) no longer present`));
+    for (const f of comparison.resolvedFindings) {
+      lines.push(`    - ${f.kind} ${f.id} (${f.severity})`);
+    }
+  } else {
+    lines.push(chalk.dim('\n  No findings resolved since the older run.'));
+  }
+
+  if (comparison.newFindings.length > 0) {
+    lines.push(chalk.yellow(`\n  New: ${comparison.newFindings.length} finding(s)`));
+    for (const f of comparison.newFindings) {
+      lines.push(`    - ${f.kind} ${f.id} (${f.severity})`);
+    }
+  }
+
+  return lines;
+}

--- a/apps/cli/src/formatters/history-report.html-formatter.spec.ts
+++ b/apps/cli/src/formatters/history-report.html-formatter.spec.ts
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+import type { TrendSnapshotRecord } from 'shared-trend-store';
+import { generateHistoryReportHtml } from './history-report.html-formatter';
+
+function wasteRecord(id: number, generatedAt: string, totalWasteMonthlyUsd: number, findingIds: string[]): TrendSnapshotRecord {
+  return {
+    id,
+    domain: 'cloud-cost',
+    generatedAt,
+    payload: JSON.stringify({
+      meta: { accountId: '123456789012', regions: ['us-east-1'], generatedAt },
+      totalWasteMonthlyUsd,
+      findings: findingIds.map((fid) => ({ id: fid, kind: 'ebs-volume', monthlyCostUsd: totalWasteMonthlyUsd / (findingIds.length || 1) })),
+    }),
+  };
+}
+
+function hygieneRecord(id: number, generatedAt: string, countBySeverity: Record<string, number>): TrendSnapshotRecord {
+  return {
+    id,
+    domain: 'dead-resources',
+    generatedAt,
+    payload: JSON.stringify({
+      meta: { accountId: '123456789012', regions: ['us-east-1'], generatedAt },
+      countBySeverity,
+      findings: [],
+    }),
+  };
+}
+
+describe('generateHistoryReportHtml', () => {
+  it('produces a self-contained HTML document with a chart, summary, and table for cloud-cost', () => {
+    const records = [
+      wasteRecord(2, '2026-07-30T00:00:00.000Z', 10, ['vol-2']),
+      wasteRecord(1, '2026-07-25T00:00:00.000Z', 25, ['vol-1', 'vol-2']),
+    ];
+
+    const html = generateHistoryReportHtml(records, 'cloud-cost', '123456789012');
+
+    expect(html).toContain('<!doctype html>');
+    expect(html).toContain('<svg');
+    expect(html).toContain('viz-line');
+    expect(html).toContain('viz-area');
+    expect(html).toContain('prefers-color-scheme: dark');
+    expect(html).toContain('$25.00');
+    expect(html).toContain('$10.00');
+    expect(html).toContain('presumed resolved');
+    expect(html).toContain('<table class="viz-table">');
+    expect(html).toContain('2026-07-25');
+    expect(html).toContain('2026-07-30');
+  });
+
+  it('produces a hygiene report using finding counts instead of dollars', () => {
+    const records = [
+      hygieneRecord(2, '2026-07-30T00:00:00.000Z', { info: 1, warning: 0, critical: 0 }),
+      hygieneRecord(1, '2026-07-25T00:00:00.000Z', { info: 2, warning: 0, critical: 0 }),
+    ];
+
+    const html = generateHistoryReportHtml(records, 'dead-resources', '123456789012');
+
+    expect(html).toContain('Resolved');
+    expect(html).toContain('Findings');
+    expect(html).not.toContain('presumed resolved');
+  });
+
+  it('renders without a chart when there is only one snapshot, but still shows the table', () => {
+    const records = [wasteRecord(1, '2026-07-30T00:00:00.000Z', 10, ['vol-1'])];
+    const html = generateHistoryReportHtml(records, 'cloud-cost', '123456789012');
+
+    expect(html).toContain('<table class="viz-table">');
+    expect(html).not.toContain('presumed resolved');
+  });
+
+  it('renders gracefully with zero snapshots', () => {
+    const html = generateHistoryReportHtml([], 'cloud-cost', '123456789012');
+    expect(html).toContain('<!doctype html>');
+    expect(html).toContain('<tbody></tbody>');
+  });
+
+  it('HTML-escapes the account ID to prevent injection via a spoofed --account-id', () => {
+    const html = generateHistoryReportHtml([], 'cloud-cost', '<script>alert(1)</script>');
+    expect(html).not.toContain('<script>alert(1)</script>');
+    expect(html).toContain('&lt;script&gt;');
+  });
+});

--- a/apps/cli/src/formatters/history-report.html-formatter.ts
+++ b/apps/cli/src/formatters/history-report.html-formatter.ts
@@ -1,0 +1,279 @@
+// SPDX-License-Identifier: Apache-2.0
+import type { TrendDomain, TrendSnapshotRecord } from 'shared-trend-store';
+import { compareCloudCostSnapshots, compareHygieneSnapshots } from '../commands/history-comparison';
+import type { WasteReportDto } from 'cloud-cost-application';
+import type { DeadResourcesReportDto } from 'dead-resources-application';
+import type { ResourceSecurityReportDto } from 'resource-security-application';
+
+interface DataPoint {
+  readonly date: string;
+  readonly value: number;
+}
+
+const CHART_WIDTH = 720;
+const CHART_HEIGHT = 320;
+const PADDING = { top: 24, right: 24, bottom: 40, left: 56 };
+const MAX_X_LABELS = 8;
+
+function escapeHtml(value: string): string {
+  return value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+
+function extractPoints(records: readonly TrendSnapshotRecord[], domain: TrendDomain): DataPoint[] {
+  // `records` arrives most-recent-first (readTrendSnapshots' own ordering); a
+  // chart reads left-to-right as oldest-to-newest, so reverse it here once.
+  const chronological = [...records].reverse();
+  return chronological.map((record) => {
+    const payload = JSON.parse(record.payload) as { totalWasteMonthlyUsd?: number; countBySeverity?: Record<string, number> };
+    const value =
+      domain === 'cloud-cost'
+        ? (payload.totalWasteMonthlyUsd ?? 0)
+        : Object.values(payload.countBySeverity ?? {}).reduce((sum, n) => sum + n, 0);
+    return { date: record.generatedAt.split('T')[0], value };
+  });
+}
+
+function niceMax(value: number): number {
+  if (value <= 0) return 1;
+  const magnitude = 10 ** Math.floor(Math.log10(value));
+  return Math.ceil(value / magnitude) * magnitude;
+}
+
+function buildChartSvg(points: DataPoint[], valueLabel: string, valuePrefix: string): string {
+  const plotWidth = CHART_WIDTH - PADDING.left - PADDING.right;
+  const plotHeight = CHART_HEIGHT - PADDING.top - PADDING.bottom;
+  const maxValue = niceMax(Math.max(...points.map((p) => p.value), 0));
+  const stepX = points.length > 1 ? plotWidth / (points.length - 1) : 0;
+
+  const xAt = (i: number) => PADDING.left + i * stepX;
+  const yAt = (value: number) => PADDING.top + plotHeight - (value / maxValue) * plotHeight;
+
+  const gridlineCount = 4;
+  const gridlines: string[] = [];
+  const yTicks: string[] = [];
+  for (let i = 0; i <= gridlineCount; i++) {
+    const value = (maxValue / gridlineCount) * i;
+    const y = yAt(value);
+    gridlines.push(`<line class="viz-gridline" x1="${PADDING.left}" y1="${y}" x2="${CHART_WIDTH - PADDING.right}" y2="${y}" />`);
+    yTicks.push(`<text class="viz-tick" x="${PADDING.left - 8}" y="${y}" text-anchor="end" dominant-baseline="middle">${valuePrefix}${Math.round(value).toLocaleString()}</text>`);
+  }
+
+  const labelEvery = Math.max(1, Math.ceil(points.length / MAX_X_LABELS));
+  const xTicks = points
+    .map((p, i) => (i % labelEvery === 0 || i === points.length - 1 ? `<text class="viz-tick" x="${xAt(i)}" y="${CHART_HEIGHT - PADDING.bottom + 20}" text-anchor="middle">${escapeHtml(p.date)}</text>` : ''))
+    .join('');
+
+  const linePath = points.map((p, i) => `${i === 0 ? 'M' : 'L'} ${xAt(i)} ${yAt(p.value)}`).join(' ');
+  const areaPath = `${linePath} L ${xAt(points.length - 1)} ${yAt(0)} L ${xAt(0)} ${yAt(0)} Z`;
+
+  const dots = points
+    .map(
+      (p, i) =>
+        `<circle class="viz-dot" data-index="${i}" cx="${xAt(i)}" cy="${yAt(p.value)}" r="5" />`,
+    )
+    .join('');
+
+  const last = points[points.length - 1];
+  const endLabel =
+    points.length > 0
+      ? `<text class="viz-end-label" x="${xAt(points.length - 1)}" y="${yAt(last.value) - 12}" text-anchor="end">${valuePrefix}${last.value.toLocaleString()}</text>`
+      : '';
+
+  return `
+<svg class="viz-svg" viewBox="0 0 ${CHART_WIDTH} ${CHART_HEIGHT}" role="img" aria-label="${escapeHtml(valueLabel)} over time">
+  ${gridlines.join('\n  ')}
+  <path class="viz-area" d="${areaPath}" />
+  <path class="viz-line" d="${linePath}" />
+  ${dots}
+  ${endLabel}
+  ${yTicks.join('\n  ')}
+  ${xTicks}
+  <line class="viz-crosshair" x1="0" y1="${PADDING.top}" x2="0" y2="${CHART_HEIGHT - PADDING.bottom}" style="display:none" />
+</svg>`;
+}
+
+function buildTableRows(records: readonly TrendSnapshotRecord[], domain: TrendDomain): string {
+  return records
+    .map((record) => {
+      const payload = JSON.parse(record.payload) as { totalWasteMonthlyUsd?: number; countBySeverity?: Record<string, number>; findings?: unknown[] };
+      const findingsCount = domain === 'cloud-cost' ? (payload.findings?.length ?? 0) : Object.values(payload.countBySeverity ?? {}).reduce((sum, n) => sum + n, 0);
+      const cost = domain === 'cloud-cost' ? `$${(payload.totalWasteMonthlyUsd ?? 0).toFixed(2)}` : '—';
+      return `<tr><td>${escapeHtml(record.generatedAt.split('T')[0])}</td><td>${escapeHtml(domain)}</td><td>${findingsCount}</td><td>${cost}</td></tr>`;
+    })
+    .join('\n');
+}
+
+function buildSummary(records: readonly TrendSnapshotRecord[], domain: TrendDomain): string {
+  if (records.length < 2) return '';
+  const newer = records[0];
+  const older = records[records.length - 1];
+
+  if (domain === 'cloud-cost') {
+    const comparison = compareCloudCostSnapshots(JSON.parse(older.payload) as WasteReportDto, JSON.parse(newer.payload) as WasteReportDto);
+    const deltaClass = comparison.deltaUsd > 0 ? 'viz-delta-bad' : comparison.deltaUsd < 0 ? 'viz-delta-good' : '';
+    return `<p class="viz-summary">Monthly waste: <strong>$${comparison.olderTotalWasteMonthlyUsd.toFixed(2)}</strong> → <strong>$${comparison.newerTotalWasteMonthlyUsd.toFixed(2)}</strong>
+      <span class="${deltaClass}">(${comparison.deltaUsd >= 0 ? '+' : ''}$${comparison.deltaUsd.toFixed(2)})</span>
+      — presumed resolved: <strong>$${comparison.presumedResolvedMonthlyUsd.toFixed(2)}/mo</strong> across ${comparison.resolvedFindings.length} finding(s) no longer present.
+      This is an inference (findings absent from the latest run), not a confirmed saving — cloudrift never remediates anything itself.</p>`;
+  }
+
+  const comparison = compareHygieneSnapshots(
+    domain,
+    JSON.parse(older.payload) as DeadResourcesReportDto | ResourceSecurityReportDto,
+    JSON.parse(newer.payload) as DeadResourcesReportDto | ResourceSecurityReportDto,
+  );
+  return `<p class="viz-summary">Resolved <strong>${comparison.resolvedFindings.length}</strong> finding(s), <strong>${comparison.newFindings.length}</strong> new, across the period shown.</p>`;
+}
+
+/**
+ * Self-contained HTML report for one domain's trend history: a single-series
+ * line chart (inline SVG, zero chart-library dependency) plus its
+ * table-view twin, per the project's dataviz conventions — hand-rolled SVG
+ * over a bundled charting library or a CDN script, consistent with why
+ * `pdfkit` was chosen over a headless browser (no heavy dependency, fully
+ * offline, nothing ever leaves the machine).
+ */
+export function generateHistoryReportHtml(records: readonly TrendSnapshotRecord[], domain: TrendDomain, accountId: string): string {
+  const points = extractPoints(records, domain);
+  const valueLabel = domain === 'cloud-cost' ? 'Monthly waste (USD)' : 'Findings';
+  const valuePrefix = domain === 'cloud-cost' ? '$' : '';
+  const chartSvg = points.length > 0 ? buildChartSvg(points, valueLabel, valuePrefix) : '';
+  const tableRows = buildTableRows(records, domain);
+  const summary = buildSummary(records, domain);
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>cloudrift — ${escapeHtml(domain)} history</title>
+<style>
+  .viz-root {
+    color-scheme: light;
+    --surface-1: #fcfcfb;
+    --page: #f9f9f7;
+    --text-primary: #0b0b0b;
+    --text-secondary: #52514e;
+    --text-muted: #898781;
+    --gridline: #e1e0d9;
+    --baseline: #c3c2b7;
+    --series-1: #2a78d6;
+    --good: #006300;
+    --bad: #d03b3b;
+    font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+    background: var(--page);
+    color: var(--text-primary);
+    margin: 0;
+    padding: 32px;
+  }
+  @media (prefers-color-scheme: dark) {
+    .viz-root {
+      color-scheme: dark;
+      --surface-1: #1a1a19;
+      --page: #0d0d0d;
+      --text-primary: #ffffff;
+      --text-secondary: #c3c2b7;
+      --text-muted: #898781;
+      --gridline: #2c2c2a;
+      --baseline: #383835;
+      --series-1: #3987e5;
+      --good: #0ca30c;
+      --bad: #e66767;
+    }
+  }
+  .viz-card { background: var(--surface-1); border-radius: 8px; padding: 24px; max-width: 800px; margin: 0 auto 24px; }
+  h1 { font-size: 20px; margin: 0 0 4px; }
+  .viz-subtitle { color: var(--text-secondary); font-size: 13px; margin: 0 0 20px; }
+  .viz-summary { color: var(--text-secondary); font-size: 14px; line-height: 1.5; }
+  .viz-summary strong { color: var(--text-primary); }
+  .viz-delta-good { color: var(--good); }
+  .viz-delta-bad { color: var(--bad); }
+  .viz-svg { width: 100%; height: auto; overflow: visible; }
+  .viz-gridline { stroke: var(--gridline); stroke-width: 1; }
+  .viz-line { fill: none; stroke: var(--series-1); stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; }
+  .viz-area { fill: var(--series-1); opacity: 0.1; stroke: none; }
+  .viz-dot { fill: var(--series-1); stroke: var(--surface-1); stroke-width: 2; }
+  .viz-end-label { fill: var(--text-primary); font-size: 13px; font-weight: 600; }
+  .viz-tick { fill: var(--text-muted); font-size: 11px; font-variant-numeric: tabular-nums; }
+  .viz-crosshair { stroke: var(--baseline); stroke-width: 1; }
+  .viz-tooltip {
+    position: absolute; display: none; pointer-events: none;
+    background: var(--surface-1); color: var(--text-primary);
+    border: 1px solid var(--gridline); border-radius: 4px; padding: 6px 10px;
+    font-size: 12px; box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+  }
+  .viz-tooltip .viz-tooltip-value { font-weight: 600; }
+  .viz-tooltip .viz-tooltip-date { color: var(--text-secondary); }
+  table.viz-table { width: 100%; border-collapse: collapse; margin-top: 24px; font-size: 13px; }
+  table.viz-table th, table.viz-table td { text-align: left; padding: 6px 8px; border-bottom: 1px solid var(--gridline); }
+  table.viz-table th { color: var(--text-muted); font-weight: 600; }
+  table.viz-table td:nth-child(3), table.viz-table td:nth-child(4) { font-variant-numeric: tabular-nums; }
+  .viz-chart-wrap { position: relative; }
+</style>
+</head>
+<body class="viz-root">
+  <div class="viz-card">
+    <h1>${escapeHtml(domain)} — local scan history</h1>
+    <p class="viz-subtitle">Account ${escapeHtml(accountId)} · ${records.length} run(s) on record · generated locally, never uploaded anywhere</p>
+    ${summary}
+    <div class="viz-chart-wrap">
+      ${chartSvg}
+      <div class="viz-tooltip"><div class="viz-tooltip-date"></div><div class="viz-tooltip-value"></div></div>
+    </div>
+    <table class="viz-table">
+      <thead><tr><th>Date</th><th>Domain</th><th>Findings</th><th>Monthly waste</th></tr></thead>
+      <tbody>${tableRows}</tbody>
+    </table>
+  </div>
+  <script>
+    (function () {
+      var points = ${JSON.stringify(points).replace(/</g, '\\u003c')};
+      var svg = document.querySelector('.viz-svg');
+      if (!svg || points.length === 0) return;
+      var crosshair = svg.querySelector('.viz-crosshair');
+      var tooltip = document.querySelector('.viz-tooltip');
+      var dateEl = tooltip.querySelector('.viz-tooltip-date');
+      var valueEl = tooltip.querySelector('.viz-tooltip-value');
+      var dots = Array.prototype.slice.call(svg.querySelectorAll('.viz-dot'));
+      var valuePrefix = ${JSON.stringify(valuePrefix)};
+
+      function showAt(index) {
+        var dot = dots[index];
+        if (!dot) return;
+        var cx = parseFloat(dot.getAttribute('cx'));
+        var cy = parseFloat(dot.getAttribute('cy'));
+        crosshair.setAttribute('x1', cx);
+        crosshair.setAttribute('x2', cx);
+        crosshair.style.display = 'block';
+        var point = points[index];
+        dateEl.textContent = point.date;
+        valueEl.textContent = valuePrefix + point.value.toLocaleString();
+        var rect = svg.getBoundingClientRect();
+        var scale = rect.width / ${CHART_WIDTH};
+        tooltip.style.left = (cx * scale + 12) + 'px';
+        tooltip.style.top = (cy * scale - 8) + 'px';
+        tooltip.style.display = 'block';
+      }
+
+      function hide() {
+        crosshair.style.display = 'none';
+        tooltip.style.display = 'none';
+      }
+
+      svg.addEventListener('mousemove', function (event) {
+        var rect = svg.getBoundingClientRect();
+        var scale = ${CHART_WIDTH} / rect.width;
+        var localX = (event.clientX - rect.left) * scale;
+        var nearest = 0;
+        var nearestDist = Infinity;
+        dots.forEach(function (dot, i) {
+          var dist = Math.abs(parseFloat(dot.getAttribute('cx')) - localX);
+          if (dist < nearestDist) { nearestDist = dist; nearest = i; }
+        });
+        showAt(nearest);
+      });
+      svg.addEventListener('mouseleave', hide);
+    })();
+  </script>
+</body>
+</html>`;
+}

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -227,6 +227,10 @@ program
   )
   .option('--domain <domain>', 'only show snapshots from this domain: cloud-cost, dead-resources, or resource-security')
   .option('--limit <n>', 'max snapshots to show, most recent first (default 100)')
+  .option('--compare <n>', 'compare the latest run against the one n runs back instead of listing (requires --domain)')
+  // See the `analyze` command's --pdf option above for why [filename] needs
+  // to be written as --html=./path.html when combined with other flags.
+  .option('--html [filename]', 'Also write a self-contained HTML report with a trend chart (optional filename, defaults to reports/cloudrift-history-<domain>-YYYY_MM_DD.html; requires --domain)')
   .option('--format <format>', 'stdout output format: table (default) or json', 'table')
   .action((options) => historyCommand(options));
 

--- a/docs/adr/0100-history-comparison-and-html-report.md
+++ b/docs/adr/0100-history-comparison-and-html-report.md
@@ -1,0 +1,36 @@
+# ADR-0100: `history --compare` and `history --html` — scan-to-scan comparison and an inline-SVG trend report
+
+- **Status:** Accepted (2026-07-30)
+
+## Context
+
+ADR-0099 built the write path and a plain list view for the local trend store. The next ask was to make that history actually useful to look at: "how much was I spending N scans ago vs. now?" and "how much has cloudrift saved me over time?" — plus a visual, chartable view of the same data.
+
+The second question is genuinely hard to answer honestly: cloudrift is read-only and never remediates anything (see the project's own disclaimer), so it has no way to know *why* a finding disappeared between two runs — the user fixed it, the resource was deleted for an unrelated reason, or it simply fell outside this run's `--regions`/`--scanners` selection. Any "savings" figure has to be presented as an inference, not a confirmed number.
+
+## Decision
+
+**`history --compare <n>`**: diffs the latest snapshot against the one `n` runs back, for one domain at a time (`--domain` required — the three domains have incompatible report shapes). New module `apps/cli/src/commands/history-comparison.ts`:
+
+- `compareCloudCostSnapshots(older, newer)` — the `$/month` domain. Reports `deltaUsd`/`deltaPercent` (null when the older total was $0), and a `presumedResolvedMonthlyUsd` figure: the sum of `monthlyCostUsd` for findings present in the older snapshot but absent from the newer one. Labeled "presumed" everywhere it's shown (CLI table, JSON, HTML) — this is this ADR's answer to the "how much have I saved" ask, framed as an estimate per this project's existing "Honest caveat" convention, not a confirmed number.
+- `compareHygieneSnapshots(domain, older, newer)` — `dead-resources`/`resource-security`, which have no dollar figure, only severity counts. Both functions also report `newFindings` (waste/risk that appeared since the older run) and a `regionsChanged` flag (the two runs scanned different region sets — a resolved/new finding may just reflect that, not real change).
+- `compareHygieneSnapshots`'s `older`/`newer` parameters share **one generic type parameter** (`<T extends HygieneReportLike>`), not a union of the two DTOs. A union parameter made `older.findings`/`newer.findings` two independently-unioned array types, which fails to type-check when passed into the shared `diffFindingsById<T>` helper (TypeScript can't infer a single `T` for `readonly T[]` from two unrelated array-type unions) — and, more importantly, a union parameter would have silently allowed comparing a `dead-resources` snapshot against a `resource-security` one, which is never a valid comparison. The call site (`history.command.ts`'s `buildComparison`) switches on `domain` and casts to the concrete DTO in each branch, so `T` is always inferred as one concrete type.
+
+**`history --html [filename]`**: writes a self-contained HTML report (`apps/cli/src/formatters/history-report.html-formatter.ts`) — one domain's metric (`totalWasteMonthlyUsd` for `cloud-cost`, total finding count for the hygiene domains) charted as a line over every stored run, plus its table-view twin. Additive, same convention as `--pdf`/`--csv` elsewhere (never replaces stdout).
+
+**Chart implementation: hand-rolled inline SVG, zero chart-library dependency** — not a vendored/bundled charting library, not a CDN script. Same reasoning ADR-0099 used for choosing `node:sqlite` over `better-sqlite3`, and the original reasoning for choosing `pdfkit` over a headless browser: this project avoids heavy dependencies and keeps every report fully offline, consistent with "your data never leaves your machine." A CDN-hosted library was explicitly rejected: opening the report would require internet access and load remote script, in tension with that same positioning. The mark specs (2px line, ~10% opacity area wash, 8px+ end-dot with a 2px surface ring, hairline gridlines, single-hue blue, no legend for the single series) and the hover crosshair+tooltip (vanilla JS, `textContent` only — never `innerHTML` — for inserting date/value strings) follow this project's dataviz conventions. Dark mode is `prefers-color-scheme` only (no `data-theme` toggle scope): this is a static file a user opens directly in their own browser, not a hosted page with a theme switcher.
+
+## Alternatives Considered
+
+- **A union parameter type for `compareHygieneSnapshots`** (`older: DeadResourcesReportDto | ResourceSecurityReportDto`) — the first draft, rejected once it failed to type-check (see above) and once it became clear it would also silently permit an invalid cross-domain comparison.
+- **A vendored/bundled charting library inline in the HTML.** More interactivity (zoom, richer tooltips) out of the box, still fully offline — but a new dependency to track/update, and unjustified for a single-series line chart. Left as a fallback option if richer interaction is ever needed.
+- **CDN-hosted charting library.** Rejected outright: breaks offline use and the "data never leaves your machine" positioning.
+- **Always computing "presumed resolved" regardless of region match.** Rejected in favor of surfacing `regionsChanged` as an explicit caveat — a silent number would overstate confidence in an inference that already can't distinguish "fixed" from "out of scope this run."
+
+## Consequences
+
+`shared-trend-store` is unchanged — both features are pure `apps/cli` additions consuming the DTOs it already stores. `history.command.ts`'s `HistoryDeps` gained `writeHtmlReport` as an injectable seam specifically so its own tests never touch the real filesystem, mirroring why the three scan commands' specs `jest.mock('shared-trend-store')` (ADR-0099) rather than exercise the real SQLite file.
+
+Verified via `pnpm nx run-many --target=lint,typecheck,test,build --projects=cli,shared-trend-store`: 278 tests green. Also verified end-to-end against a seeded SQLite file through the actual packaged CLI (not just `nx build`): `history --compare` renders the expected delta/presumed-resolved figures, and `--html` produces a report with one `<circle>` per snapshot and one table row per snapshot.
+
+Not yet built: a way to compare by a date range instead of "N runs back," and no CSV export for the comparison view (table/JSON only, matching the plain list view's own format set).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -32,6 +32,7 @@ Each entry follows: Context → Decision → Alternatives Considered → Consequ
 | ADR | Title | Status |
 |---|---|---|
 | [0099](0099-local-trend-store.md) | Local historical trend store (SQLite, per-account, full snapshot forever) | Accepted |
+| [0100](0100-history-comparison-and-html-report.md) | `history --compare` and `history --html` — scan-to-scan comparison and an inline-SVG trend report | Accepted |
 
 ## Cost analytics (`cost` / `trend`)
 

--- a/docs/en/usage.md
+++ b/docs/en/usage.md
@@ -344,6 +344,8 @@ node apps/cli/dist/main.js history [options]
 | `--external-id <id>`     | External ID to pass when assuming `--assume-role-arn` (only needed if the role trust policy requires one) | —               |
 | `--domain <domain>`      | Only show snapshots from this domain: `cloud-cost`, `dead-resources`, or `resource-security` | all domains     |
 | `--limit <n>`             | Max snapshots to show, most recent first                                          | `100`           |
+| `--compare <n>`           | Compare the latest run against the one `n` runs back instead of listing (requires `--domain`) | —               |
+| `--html [filename]`       | Also write a self-contained HTML report with a trend chart (requires `--domain`; defaults to `reports/cloudrift-history-<domain>-YYYY_MM_DD.html`) | —               |
 | `--format <format>`      | stdout output format: `table` or `json`                                            | `table`         |
 | `-h, --help`              | Show help                                                                          | —               |
 
@@ -358,11 +360,19 @@ node apps/cli/dist/main.js history --domain cloud-cost --limit 10
 
 # Machine-readable output, full report payload per snapshot expanded back to JSON
 node apps/cli/dist/main.js history --format json | jq '.[0].payload'
+
+# What was I spending 5 runs ago vs. now, including a "presumed resolved" $/month figure
+node apps/cli/dist/main.js history --domain cloud-cost --compare 5
+
+# Self-contained HTML report with a line chart of waste over time
+node apps/cli/dist/main.js history --domain cloud-cost --html
 ```
 
 **No new AWS permission needed:** `history` makes the same `sts:GetCallerIdentity` call every other command already makes to resolve the account ID (skipped entirely if `--account-id` is passed explicitly) — everything else is a local file read, no AWS API call.
 
 **Retention:** every run is kept forever, by design — there is no pruning yet. This is a deliberate simplicity choice, revisited once real-world database growth data exists (see ADR-0099's Consequences).
+
+**`--compare`'s "presumed resolved" figure is an inference, not a confirmed saving:** cloudrift is read-only and never remediates anything, so it cannot know *why* a finding disappeared between the two compared runs (fixed by you, deleted for an unrelated reason, or simply out of this run's `--regions`/`--scanners` scope) — see [ADR-0100](../adr/0100-history-comparison-and-html-report.md).
 
 ## `iam-policy` — print the required IAM policy
 

--- a/docs/it/utilizzo.md
+++ b/docs/it/utilizzo.md
@@ -359,6 +359,8 @@ node apps/cli/dist/main.js history [options]
 | `--external-id <id>`     | External ID da passare quando si usa `--assume-role-arn` (serve solo se la trust policy del ruolo lo richiede) | —               |
 | `--domain <domain>`      | Mostra solo gli snapshot di questo dominio: `cloud-cost`, `dead-resources`, o `resource-security` | tutti i domini  |
 | `--limit <n>`             | Numero massimo di snapshot da mostrare, dal più recente                            | `100`           |
+| `--compare <n>`           | Confronta l'ultima esecuzione con quella di `n` esecuzioni fa invece di elencare (richiede `--domain`) | —               |
+| `--html [filename]`       | Scrive anche un report HTML autocontenuto con un grafico del trend (richiede `--domain`; default `reports/cloudrift-history-<domain>-YYYY_MM_DD.html`) | —               |
 | `--format <format>`      | Formato di output su stdout: `table` o `json`                                       | `table`         |
 | `-h, --help`              | Mostra l'help                                                                       | —               |
 
@@ -373,11 +375,19 @@ node apps/cli/dist/main.js history --domain cloud-cost --limit 10
 
 # Output machine-readable, payload completo del report per ogni snapshot espanso in JSON
 node apps/cli/dist/main.js history --format json | jq '.[0].payload'
+
+# Quanto spendevo 5 esecuzioni fa rispetto ad ora, incluso uno spreco "presumibilmente risolto" in $/mese
+node apps/cli/dist/main.js history --domain cloud-cost --compare 5
+
+# Report HTML autocontenuto con un grafico a linee dello spreco nel tempo
+node apps/cli/dist/main.js history --domain cloud-cost --html
 ```
 
 **Nessun nuovo permesso AWS necessario:** `history` fa la stessa chiamata `sts:GetCallerIdentity` di ogni altro comando per risolvere l'ID account (saltata del tutto se passi `--account-id` esplicitamente) — il resto è solo lettura di un file locale, nessuna chiamata API AWS.
 
 **Retention:** ogni esecuzione viene conservata per sempre, di proposito — non esiste ancora una pulizia automatica. È una scelta deliberata di semplicità, da rivedere quando esisteranno dati reali sulla crescita del database (vedi le Conseguenze dell'ADR-0099).
+
+**Lo "spreco presumibilmente risolto" di `--compare` è un'inferenza, non un risparmio confermato:** cloudrift è read-only e non rimedia mai nulla, quindi non può sapere *perché* un finding è sparito tra le due esecuzioni confrontate (l'hai sistemato tu, la risorsa è stata eliminata per un motivo non collegato, o era semplicemente fuori dallo scope di `--regions`/`--scanners` di questa run) — vedi [ADR-0100](../adr/0100-history-comparison-and-html-report.md) (in inglese).
 
 ## `iam-policy` — stampa la policy IAM richiesta
 


### PR DESCRIPTION
## Summary
- history --compare <n>: diffs the latest snapshot against the one n runs back for one domain. For cloud-cost, includes a "presumed resolved" $/month figure (findings gone between runs) - explicitly labeled as an inference, never a confirmed saving, since cloudrift never remediates anything itself. For dead-resources/resource-security, severity-count deltas.
- history --html [filename]: self-contained HTML report - inline-SVG line chart of the metric over every stored run + its table-view twin. Zero chart-library dependency (same reasoning as choosing pdfkit over a headless browser - fully offline, nothing leaves the machine).
- See ADR-0100 for the full decision, including why compareHygieneSnapshots uses a shared generic type parameter instead of a union type (fixes a real TS inference bug and also prevents comparing across mismatched domains).

## Test plan
- nx run-many lint/typecheck/test/build for cli,shared-trend-store: 278 tests green
- Verified end-to-end against a seeded SQLite file through the packaged CLI
- Manual test against a real AWS account with accumulated history: pending