### PR TITLE
feat(cli): combined history --html report, Terraform PRO wizard badge, CSV docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,8 @@ cloudrift history --domain cloud-cost --limit 10
 cloudrift history --html                       # self-contained HTML trend report, all 3 domains stacked on one page
 ```
 
+The `--html` chart differs by domain: `cloud-cost` is a single dollar-waste line (plus a linear projection and a "top resource types by waste" list); `dead-resources`/`resource-security` chart critical/warning/info as three separate lines with a legend, matching the PDF/table severity breakdown (`resource-security` also gets a plain-language risk narrative, deliberately no dollar figure). The combined report leads with a 3-tile executive summary for a CTO/CEO audience.
+
 See [ADR-0099](https://github.com/elleVas/cloudrift/blob/main/docs/adr/0099-local-trend-store.md)/[ADR-0100](https://github.com/elleVas/cloudrift/blob/main/docs/adr/0100-history-comparison-and-html-report.md) and [docs/en/usage.md](https://github.com/elleVas/cloudrift/blob/main/docs/en/usage.md#history--local-scan-history) for the full flag reference (including `--compare` and single-domain `--html`).
 
 ---

--- a/README.md
+++ b/README.md
@@ -280,9 +280,10 @@ cloudrift resource-security --scanners iam-root-mfa-disabled    # only one check
 ```sh
 cloudrift history                              # every snapshot on record, most recent first
 cloudrift history --domain cloud-cost --limit 10
+cloudrift history --html                       # self-contained HTML trend report, all 3 domains stacked on one page
 ```
 
-See [ADR-0099](https://github.com/elleVas/cloudrift/blob/main/docs/adr/0099-local-trend-store.md) and [docs/en/usage.md](https://github.com/elleVas/cloudrift/blob/main/docs/en/usage.md#history--local-scan-history) for the full flag reference.
+See [ADR-0099](https://github.com/elleVas/cloudrift/blob/main/docs/adr/0099-local-trend-store.md)/[ADR-0100](https://github.com/elleVas/cloudrift/blob/main/docs/adr/0100-history-comparison-and-html-report.md) and [docs/en/usage.md](https://github.com/elleVas/cloudrift/blob/main/docs/en/usage.md#history--local-scan-history) for the full flag reference (including `--compare` and single-domain `--html`).
 
 ---
 

--- a/apps/cli/src/commands/history.command.spec.ts
+++ b/apps/cli/src/commands/history.command.spec.ts
@@ -25,9 +25,12 @@ function makeDeps(opts: { resolvedAccountId?: string; records?: TrendSnapshotRec
   const htmlCalls: Array<[string, string]> = [];
   return {
     resolveAccountId: async () => opts.resolvedAccountId,
-    readSnapshots: (async (accountId: string, options?: unknown) => {
+    readSnapshots: (async (accountId: string, options?: { domain?: string; limit?: number }) => {
       calls.push([accountId, options]);
-      return opts.records ?? SAMPLE_RECORDS;
+      const records = opts.records ?? SAMPLE_RECORDS;
+      // Mirrors `readTrendSnapshots`' own `WHERE domain = ?` filtering — needed once a
+      // caller (e.g. the combined HTML report) queries more than one domain per test.
+      return options?.domain ? records.filter((r) => r.domain === options.domain) : records;
     }) as HistoryDeps['readSnapshots'],
     // Never touch the real filesystem in a unit test — same reasoning as
     // mocking `shared-trend-store` in the scan commands' specs.
@@ -166,11 +169,18 @@ describe('historyCommand', () => {
   });
 
   describe('--html', () => {
-    it('rejects --html without --domain', async () => {
+    it('generates a combined report across all domains when --domain is omitted', async () => {
       const deps = makeDeps({ resolvedAccountId: '123456789012' });
       await historyCommand({ html: true }, deps);
-      expect(stderr).toContain('--html requires --domain');
-      expect(deps.writeHtmlReportArgs).toHaveLength(0);
+
+      expect(deps.writeHtmlReportArgs).toHaveLength(1);
+      const [path, html] = deps.writeHtmlReportArgs[0];
+      expect(path).toContain('cloudrift-history-');
+      expect(path).not.toContain('cloudrift-history-cloud-cost-');
+      expect(html).toContain('<!doctype html>');
+      expect(html).toContain('cloud-cost');
+      expect(html).toContain('dead-resources');
+      expect(html).toContain('resource-security');
     });
 
     it('writes an HTML report to the default path when no filename is given', async () => {

--- a/apps/cli/src/commands/history.command.ts
+++ b/apps/cli/src/commands/history.command.ts
@@ -12,7 +12,7 @@ import { formatTrendHistoryAsTable } from '../formatters/trend-history.table-for
 import { formatTrendHistoryAsJson } from '../formatters/trend-history.json-formatter';
 import { formatHistoryComparisonAsTable } from '../formatters/history-comparison.table-formatter';
 import { formatHistoryComparisonAsJson } from '../formatters/history-comparison.json-formatter';
-import { generateHistoryReportHtml } from '../formatters/history-report.html-formatter';
+import { generateHistoryReportHtml, generateCombinedHistoryReportHtml } from '../formatters/history-report.html-formatter';
 import { compareCloudCostSnapshots, compareHygieneSnapshots, type HistoryComparison } from './history-comparison';
 import { isOutputFormat } from '../output-format';
 import { resolveCredentials } from './resolve-options';
@@ -23,6 +23,31 @@ const HISTORY_DOMAINS = ['cloud-cost', 'dead-resources', 'resource-security'] as
 
 function isTrendDomain(value: string): value is TrendDomain {
   return (HISTORY_DOMAINS as readonly string[]).includes(value);
+}
+
+type ParsedOption = { ok: true; value: number | undefined } | { ok: false; message: string };
+
+/** Flattened out of `historyCommand` — a nested `if` per option adds more to cognitive complexity than a sibling early-return per option. */
+function parseLimitOption(options: HistoryCommandOptions): ParsedOption {
+  if (options.limit === undefined) return { ok: true, value: undefined };
+  const parsed = Number(options.limit);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    return { ok: false, message: `--limit must be a positive integer, got "${options.limit}".` };
+  }
+  return { ok: true, value: parsed };
+}
+
+/** See `parseLimitOption` — same flattening reason. */
+function parseCompareOption(options: HistoryCommandOptions): ParsedOption {
+  if (options.compare === undefined) return { ok: true, value: undefined };
+  if (options.domain === undefined || !isTrendDomain(options.domain)) {
+    return { ok: false, message: '--compare requires --domain (cloud-cost, dead-resources, or resource-security) to know which report shape to compare.' };
+  }
+  const parsed = Number(options.compare);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    return { ok: false, message: `--compare must be a positive integer (how many runs back to compare against), got "${options.compare}".` };
+  }
+  return { ok: true, value: parsed };
 }
 
 /**
@@ -77,6 +102,40 @@ export const defaultHistoryDeps: HistoryDeps = {
 };
 
 /**
+ * Split out of `historyCommand` to keep that function's cognitive complexity
+ * down — this owns the single-domain-vs-combined branch and the resulting
+ * default filename, `historyCommand` just decides whether to call it.
+ */
+async function writeHistoryHtmlReport(
+  htmlOption: string | boolean,
+  domainOption: string | undefined,
+  accountId: string,
+  limit: number | undefined,
+  deps: HistoryDeps,
+): Promise<void> {
+  const day = new Date().toISOString().split('T')[0].replaceAll('-', '_');
+  let html: string;
+  let defaultFilename: string;
+
+  if (domainOption !== undefined) {
+    const domain = domainOption as TrendDomain;
+    const records = await deps.readSnapshots(accountId, { domain, limit: limit ?? 100 });
+    html = generateHistoryReportHtml(records, domain, accountId);
+    defaultFilename = `cloudrift-history-${domain}-${day}.html`;
+  } else {
+    const recordsByDomain = Object.fromEntries(
+      await Promise.all(HISTORY_DOMAINS.map(async (domain) => [domain, await deps.readSnapshots(accountId, { domain, limit: limit ?? 100 })] as const)),
+    ) as Record<TrendDomain, TrendSnapshotRecord[]>;
+    html = generateCombinedHistoryReportHtml(recordsByDomain, accountId);
+    defaultFilename = `cloudrift-history-${day}.html`;
+  }
+
+  const outputPath = typeof htmlOption === 'string' ? resolve(process.cwd(), htmlOption) : resolve(process.cwd(), 'reports', defaultFilename);
+  await deps.writeHtmlReport(outputPath, html);
+  console.error(chalk.green(`  HTML report saved to ${outputPath}`));
+}
+
+/**
  * `history`: reads back the local trend store
  * (`~/.cloudrift/trends/<account-id>.db`) that `analyze` / `dead-resources` /
  * `resource-security` each append a full snapshot to on every run — a local
@@ -90,9 +149,11 @@ export const defaultHistoryDeps: HistoryDeps = {
  * since cloudrift never remediates anything itself (see `history-comparison.ts`).
  *
  * `--html [filename]` additionally writes a self-contained HTML report (inline
- * SVG line chart + table view, no chart-library dependency) of one domain's
- * metric over every stored run — independent of `--compare`/stdout `--format`,
- * same "additional file artifact" convention as `--pdf`/`--csv` elsewhere.
+ * SVG line chart + table view, no chart-library dependency) over every stored
+ * run — independent of `--compare`/stdout `--format`, same "additional file
+ * artifact" convention as `--pdf`/`--csv` elsewhere. With `--domain`, charts
+ * just that one metric; without it, stacks all three tracked domains as
+ * separate cards on one page (see `generateCombinedHistoryReportHtml`).
  */
 export async function historyCommand(
   options: HistoryCommandOptions,
@@ -107,26 +168,13 @@ export async function historyCommand(
     return fail(`--domain must be one of: ${HISTORY_DOMAINS.join(', ')}. Got "${options.domain}".`);
   }
 
-  let limit: number | undefined;
-  if (options.limit !== undefined) {
-    const parsed = Number(options.limit);
-    if (!Number.isInteger(parsed) || parsed <= 0) {
-      return fail(`--limit must be a positive integer, got "${options.limit}".`);
-    }
-    limit = parsed;
-  }
+  const limitResult = parseLimitOption(options);
+  if (!limitResult.ok) return fail(limitResult.message);
+  const limit = limitResult.value;
 
-  let compareN: number | undefined;
-  if (options.compare !== undefined) {
-    if (options.domain === undefined || !isTrendDomain(options.domain)) {
-      return fail('--compare requires --domain (cloud-cost, dead-resources, or resource-security) to know which report shape to compare.');
-    }
-    const parsed = Number(options.compare);
-    if (!Number.isInteger(parsed) || parsed <= 0) {
-      return fail(`--compare must be a positive integer (how many runs back to compare against), got "${options.compare}".`);
-    }
-    compareN = parsed;
-  }
+  const compareResult = parseCompareOption(options);
+  if (!compareResult.ok) return fail(compareResult.message);
+  const compareN = compareResult.value;
 
   const credentialsResult = await resolveCredentials(options);
   if (!credentialsResult.ok) return fail(credentialsResult.error.message);
@@ -135,10 +183,6 @@ export async function historyCommand(
   const accountId = options.accountId ?? (await deps.resolveAccountId(credentials)) ?? 'unknown';
   if (accountId === 'unknown') {
     console.error(chalk.dim('  Could not resolve the AWS account ID via STS — pass --account-id to set it explicitly.'));
-  }
-
-  if (options.html !== undefined && options.html !== false && (options.domain === undefined || !isTrendDomain(options.domain))) {
-    return fail('--html requires --domain (cloud-cost, dead-resources, or resource-security) to know which metric to chart.');
   }
 
   if (compareN !== undefined) {
@@ -158,13 +202,6 @@ export async function historyCommand(
   }
 
   if (options.html !== undefined && options.html !== false) {
-    const domain = options.domain as TrendDomain;
-    const htmlRecords = await deps.readSnapshots(accountId, { domain, limit: limit ?? 100 });
-    const html = generateHistoryReportHtml(htmlRecords, domain, accountId);
-    const day = new Date().toISOString().split('T')[0].replaceAll('-', '_');
-    const outputPath =
-      typeof options.html === 'string' ? resolve(process.cwd(), options.html) : resolve(process.cwd(), 'reports', `cloudrift-history-${domain}-${day}.html`);
-    await deps.writeHtmlReport(outputPath, html);
-    console.error(chalk.green(`  HTML report saved to ${outputPath}`));
+    await writeHistoryHtmlReport(options.html, options.domain, accountId, limit, deps);
   }
 }

--- a/apps/cli/src/formatters/history-report.html-formatter.spec.ts
+++ b/apps/cli/src/formatters/history-report.html-formatter.spec.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { TrendSnapshotRecord } from 'shared-trend-store';
-import { generateHistoryReportHtml } from './history-report.html-formatter';
+import { generateHistoryReportHtml, generateCombinedHistoryReportHtml } from './history-report.html-formatter';
 
 function wasteRecord(id: number, generatedAt: string, totalWasteMonthlyUsd: number, findingIds: string[]): TrendSnapshotRecord {
   return {
@@ -81,5 +81,30 @@ describe('generateHistoryReportHtml', () => {
     const html = generateHistoryReportHtml([], 'cloud-cost', '<script>alert(1)</script>');
     expect(html).not.toContain('<script>alert(1)</script>');
     expect(html).toContain('&lt;script&gt;');
+  });
+});
+
+describe('generateCombinedHistoryReportHtml', () => {
+  it('stacks one card per domain on a single page', () => {
+    const recordsByDomain = {
+      'cloud-cost': [wasteRecord(1, '2026-07-30T00:00:00.000Z', 10, ['vol-1'])],
+      'dead-resources': [hygieneRecord(2, '2026-07-30T00:00:00.000Z', { info: 1 })],
+      'resource-security': [{ ...hygieneRecord(3, '2026-07-30T00:00:00.000Z', { critical: 2 }), domain: 'resource-security' as const }],
+    };
+
+    const html = generateCombinedHistoryReportHtml(recordsByDomain, '123456789012');
+
+    expect(html).toContain('<!doctype html>');
+    expect(html).toContain('cloud-cost — local scan history');
+    expect(html).toContain('dead-resources — local scan history');
+    expect(html).toContain('resource-security — local scan history');
+    expect(html.match(/class="viz-chart-wrap"/g) ?? []).toHaveLength(3);
+  });
+
+  it('renders gracefully when a domain has no snapshots on record', () => {
+    const html = generateCombinedHistoryReportHtml({ 'cloud-cost': [], 'dead-resources': [], 'resource-security': [] }, '123456789012');
+
+    expect(html).toContain('<!doctype html>');
+    expect(html.match(/<tbody><\/tbody>/g) ?? []).toHaveLength(3);
   });
 });

--- a/apps/cli/src/formatters/history-report.html-formatter.spec.ts
+++ b/apps/cli/src/formatters/history-report.html-formatter.spec.ts
@@ -15,6 +15,25 @@ function wasteRecord(id: number, generatedAt: string, totalWasteMonthlyUsd: numb
   };
 }
 
+function wasteRecordWithBreakdown(
+  id: number,
+  generatedAt: string,
+  totalWasteMonthlyUsd: number,
+  breakdown: Array<{ label: string; monthlyCostUsd: number; category?: string }>,
+): TrendSnapshotRecord {
+  return {
+    id,
+    domain: 'cloud-cost',
+    generatedAt,
+    payload: JSON.stringify({
+      meta: { accountId: '123456789012', regions: ['us-east-1'], generatedAt },
+      totalWasteMonthlyUsd,
+      findings: [],
+      breakdown: breakdown.map((b) => ({ kind: 'x', label: b.label, category: b.category ?? 'waste', estimated: false, count: 1, monthlyCostUsd: b.monthlyCostUsd })),
+    }),
+  };
+}
+
 function hygieneRecord(id: number, generatedAt: string, countBySeverity: Record<string, number>): TrendSnapshotRecord {
   return {
     id,
@@ -63,6 +82,93 @@ describe('generateHistoryReportHtml', () => {
     expect(html).not.toContain('presumed resolved');
   });
 
+  it('charts critical/warning/info as three separate lines with a legend and per-severity table columns', () => {
+    const records = [
+      hygieneRecord(2, '2026-07-30T00:00:00.000Z', { critical: 2, warning: 5, info: 1 }),
+      hygieneRecord(1, '2026-07-25T00:00:00.000Z', { critical: 1, warning: 3, info: 4 }),
+    ];
+
+    const html = generateHistoryReportHtml(records, 'resource-security', '123456789012');
+
+    expect(html).toContain('viz-line-critical');
+    expect(html).toContain('viz-line-warning');
+    expect(html).toContain('viz-line-info');
+    expect(html).toContain('viz-legend');
+    expect(html).toContain('>Critical<');
+    expect(html).toContain('>Warning<');
+    expect(html).toContain('>Info<');
+    expect(html).toContain('<th>Critical</th><th>Warning</th><th>Info</th>');
+    expect(html).not.toContain('<th>Findings</th>');
+    // Latest run's counts (table renders most-recent-first, matching readTrendSnapshots' ordering).
+    expect(html).toContain('<td>2</td><td>5</td><td>1</td>');
+    expect(html).toContain('<td>1</td><td>3</td><td>4</td>');
+  });
+
+  it('lists the top 3 waste-category resource kinds by $ from the latest run, excluding optimization entries', () => {
+    const records = [
+      wasteRecordWithBreakdown(1, '2026-07-30T00:00:00.000Z', 100, [
+        { label: 'NAT Gateways', monthlyCostUsd: 32.4 },
+        { label: 'EBS Volumes', monthlyCostUsd: 40 },
+        { label: 'Elastic IPs', monthlyCostUsd: 3.6 },
+        { label: 'Load Balancers', monthlyCostUsd: 16.2 },
+        { label: 'gp2 upgrades', monthlyCostUsd: 999, category: 'optimization' },
+      ]),
+    ];
+
+    const html = generateHistoryReportHtml(records, 'cloud-cost', '123456789012');
+
+    expect(html).toContain('Top resource types by waste');
+    expect(html).toContain('EBS Volumes');
+    expect(html).toContain('$40.00/mo');
+    expect(html).toContain('NAT Gateways');
+    expect(html).toContain('Load Balancers');
+    expect(html).not.toContain('Elastic IPs');
+    expect(html).not.toContain('gp2 upgrades');
+  });
+
+  it('omits the top-wasters list when the payload has no breakdown data', () => {
+    const records = [wasteRecord(1, '2026-07-30T00:00:00.000Z', 10, ['vol-1'])];
+    const html = generateHistoryReportHtml(records, 'cloud-cost', '123456789012');
+    expect(html).not.toContain('Top resource types by waste');
+  });
+
+  // The page's <style> block unconditionally defines all three
+  // `.viz-health-*` rules, so a bare `toContain('viz-health-warning')` would
+  // always pass regardless of which dot is actually rendered — assert on the
+  // dot's own class attribute instead, which only appears once per section.
+  function healthDotClass(html: string): string {
+    const match = /<span class="viz-health-dot viz-health-(\w+)"/.exec(html);
+    if (!match) throw new Error('no health dot found in rendered HTML');
+    return match[1];
+  }
+
+  it('shows a warning health dot on cloud-cost when waste is trending up, good when it is flat or down', () => {
+    const up = generateHistoryReportHtml(
+      [wasteRecord(2, '2026-07-30T00:00:00.000Z', 25, ['vol-1']), wasteRecord(1, '2026-07-25T00:00:00.000Z', 10, ['vol-1'])],
+      'cloud-cost',
+      '123456789012',
+    );
+    expect(healthDotClass(up)).toBe('warning');
+
+    const down = generateHistoryReportHtml(
+      [wasteRecord(2, '2026-07-30T00:00:00.000Z', 10, ['vol-1']), wasteRecord(1, '2026-07-25T00:00:00.000Z', 25, ['vol-1'])],
+      'cloud-cost',
+      '123456789012',
+    );
+    expect(healthDotClass(down)).toBe('good');
+  });
+
+  it("shows a critical/warning/good health dot on resource-security matching the latest run's severity", () => {
+    const critical = generateHistoryReportHtml([hygieneRecord(1, '2026-07-30T00:00:00.000Z', { critical: 1, warning: 0, info: 0 })], 'resource-security', '123456789012');
+    expect(healthDotClass(critical)).toBe('critical');
+
+    const warning = generateHistoryReportHtml([hygieneRecord(1, '2026-07-30T00:00:00.000Z', { critical: 0, warning: 2, info: 0 })], 'resource-security', '123456789012');
+    expect(healthDotClass(warning)).toBe('warning');
+
+    const clear = generateHistoryReportHtml([hygieneRecord(1, '2026-07-30T00:00:00.000Z', { critical: 0, warning: 0, info: 3 })], 'resource-security', '123456789012');
+    expect(healthDotClass(clear)).toBe('good');
+  });
+
   it('renders without a chart when there is only one snapshot, but still shows the table', () => {
     const records = [wasteRecord(1, '2026-07-30T00:00:00.000Z', 10, ['vol-1'])];
     const html = generateHistoryReportHtml(records, 'cloud-cost', '123456789012');
@@ -106,5 +212,24 @@ describe('generateCombinedHistoryReportHtml', () => {
 
     expect(html).toContain('<!doctype html>');
     expect(html.match(/<tbody><\/tbody>/g) ?? []).toHaveLength(3);
+  });
+
+  it('gives every stat tile and every section its own health dot, independent of the other domains', () => {
+    const html = generateCombinedHistoryReportHtml(
+      {
+        'cloud-cost': [wasteRecord(1, '2026-07-30T00:00:00.000Z', 10, ['vol-1'])],
+        'dead-resources': [hygieneRecord(1, '2026-07-30T00:00:00.000Z', { info: 1, warning: 0, critical: 0 })],
+        'resource-security': [{ ...hygieneRecord(2, '2026-07-30T00:00:00.000Z', { critical: 2, warning: 1, info: 0 }), domain: 'resource-security' as const }],
+      },
+      '123456789012',
+    );
+
+    const dots = [...html.matchAll(/class="viz-health-dot viz-health-(\w+)"/g)].map((m) => m[1]);
+    // 3 exec-summary stat tiles + 3 section headings = 6 dots total.
+    expect(dots).toHaveLength(6);
+    // Security is critical while dead-resources/cost are not — no single
+    // combined status could represent both without hiding one of them.
+    expect(dots.filter((d) => d === 'critical')).toHaveLength(2); // security stat tile + security section heading
+    expect(dots.filter((d) => d === 'good')).toHaveLength(4); // cost + dead-resources, tile + heading each
   });
 });

--- a/apps/cli/src/formatters/history-report.html-formatter.ts
+++ b/apps/cli/src/formatters/history-report.html-formatter.ts
@@ -10,6 +10,20 @@ interface DataPoint {
   readonly value: number;
 }
 
+interface SeverityPoint {
+  readonly date: string;
+  readonly critical: number;
+  readonly warning: number;
+  readonly info: number;
+}
+
+/** Fixed, never themed — same hex in light and dark, per the dataviz skill's status palette. */
+const SEVERITY_SERIES = [
+  { key: 'critical', color: 'var(--severity-critical)', label: 'Critical' },
+  { key: 'warning', color: 'var(--severity-warning)', label: 'Warning' },
+  { key: 'info', color: 'var(--text-muted)', label: 'Info' },
+] as const;
+
 const CHART_WIDTH = 720;
 const CHART_HEIGHT = 320;
 const PADDING = { top: 24, right: 24, bottom: 40, left: 56 };
@@ -19,17 +33,27 @@ function escapeHtml(value: string): string {
   return value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
 }
 
-function extractPoints(records: readonly TrendSnapshotRecord[], domain: TrendDomain): DataPoint[] {
+function extractPoints(records: readonly TrendSnapshotRecord[]): DataPoint[] {
   // `records` arrives most-recent-first (readTrendSnapshots' own ordering); a
   // chart reads left-to-right as oldest-to-newest, so reverse it here once.
   const chronological = [...records].reverse();
   return chronological.map((record) => {
-    const payload = JSON.parse(record.payload) as { totalWasteMonthlyUsd?: number; countBySeverity?: Record<string, number> };
-    const value =
-      domain === 'cloud-cost'
-        ? (payload.totalWasteMonthlyUsd ?? 0)
-        : Object.values(payload.countBySeverity ?? {}).reduce((sum, n) => sum + n, 0);
-    return { date: record.generatedAt.split('T')[0], value };
+    const payload = JSON.parse(record.payload) as { totalWasteMonthlyUsd?: number };
+    return { date: record.generatedAt.split('T')[0], value: payload.totalWasteMonthlyUsd ?? 0 };
+  });
+}
+
+function extractSeverityPoints(records: readonly TrendSnapshotRecord[]): SeverityPoint[] {
+  const chronological = [...records].reverse();
+  return chronological.map((record) => {
+    const payload = JSON.parse(record.payload) as { countBySeverity?: Record<string, number> };
+    const bySeverity = payload.countBySeverity ?? {};
+    return {
+      date: record.generatedAt.split('T')[0],
+      critical: bySeverity.critical ?? 0,
+      warning: bySeverity.warning ?? 0,
+      info: bySeverity.info ?? 0,
+    };
   });
 }
 
@@ -39,12 +63,33 @@ function niceMax(value: number): number {
   return Math.ceil(value / magnitude) * magnitude;
 }
 
-function buildChartSvg(points: DataPoint[], valueLabel: string, valuePrefix: string): string {
+/**
+ * Simple least-squares linear regression over (index, value), extrapolated
+ * one slot past the last real point — an honest "if this trend continues"
+ * projection, not a forecast model. `undefined` below 2 points (no trend to
+ * extrapolate) — never fabricated from a single data point.
+ */
+function computeForecast(points: readonly DataPoint[]): number | undefined {
+  const n = points.length;
+  if (n < 2) return undefined;
+  const meanX = (n - 1) / 2;
+  const meanY = points.reduce((sum, p) => sum + p.value, 0) / n;
+  let num = 0;
+  let den = 0;
+  points.forEach((p, i) => {
+    num += (i - meanX) * (p.value - meanY);
+    den += (i - meanX) ** 2;
+  });
+  if (den === 0) return undefined;
+  const slope = num / den;
+  const intercept = meanY - slope * meanX;
+  return Math.max(0, intercept + slope * n);
+}
+
+function buildAxes(maxValue: number, dates: readonly string[], valuePrefix: string): { gridlines: string; yTicks: string; xTicks: string; xAt: (i: number) => number; yAt: (v: number) => number } {
   const plotWidth = CHART_WIDTH - PADDING.left - PADDING.right;
   const plotHeight = CHART_HEIGHT - PADDING.top - PADDING.bottom;
-  const maxValue = niceMax(Math.max(...points.map((p) => p.value), 0));
-  const stepX = points.length > 1 ? plotWidth / (points.length - 1) : 0;
-
+  const stepX = dates.length > 1 ? plotWidth / (dates.length - 1) : 0;
   const xAt = (i: number) => PADDING.left + i * stepX;
   const yAt = (value: number) => PADDING.top + plotHeight - (value / maxValue) * plotHeight;
 
@@ -58,47 +103,108 @@ function buildChartSvg(points: DataPoint[], valueLabel: string, valuePrefix: str
     yTicks.push(`<text class="viz-tick" x="${PADDING.left - 8}" y="${y}" text-anchor="end" dominant-baseline="middle">${valuePrefix}${Math.round(value).toLocaleString()}</text>`);
   }
 
-  const labelEvery = Math.max(1, Math.ceil(points.length / MAX_X_LABELS));
-  const xTicks = points
-    .map((p, i) => (i % labelEvery === 0 || i === points.length - 1 ? `<text class="viz-tick" x="${xAt(i)}" y="${CHART_HEIGHT - PADDING.bottom + 20}" text-anchor="middle">${escapeHtml(p.date)}</text>` : ''))
+  const labelEvery = Math.max(1, Math.ceil(dates.length / MAX_X_LABELS));
+  const xTicks = dates
+    .map((date, i) => (i % labelEvery === 0 || i === dates.length - 1 ? `<text class="viz-tick" x="${xAt(i)}" y="${CHART_HEIGHT - PADDING.bottom + 20}" text-anchor="middle">${escapeHtml(date)}</text>` : ''))
     .join('');
+
+  return { gridlines: gridlines.join('\n  '), yTicks: yTicks.join('\n  '), xTicks, xAt, yAt };
+}
+
+/**
+ * `forecastValue`, when given, extends the chart with one dashed slot past
+ * the last real point (see `computeForecast`) — direct-labeled, never part
+ * of the hoverable points array, since it isn't a real snapshot.
+ */
+function buildChartSvg(points: DataPoint[], valueLabel: string, valuePrefix: string, forecastValue?: number): string {
+  const hasForecast = forecastValue !== undefined;
+  const maxValue = niceMax(Math.max(...points.map((p) => p.value), forecastValue ?? 0, 0));
+  const dates = hasForecast ? [...points.map((p) => p.date), 'Next'] : points.map((p) => p.date);
+  const { gridlines, yTicks, xTicks, xAt, yAt } = buildAxes(maxValue, dates, valuePrefix);
 
   const linePath = points.map((p, i) => `${i === 0 ? 'M' : 'L'} ${xAt(i)} ${yAt(p.value)}`).join(' ');
   const areaPath = `${linePath} L ${xAt(points.length - 1)} ${yAt(0)} L ${xAt(0)} ${yAt(0)} Z`;
-
-  const dots = points
-    .map(
-      (p, i) =>
-        `<circle class="viz-dot" data-index="${i}" cx="${xAt(i)}" cy="${yAt(p.value)}" r="5" />`,
-    )
-    .join('');
+  const dots = points.map((p, i) => `<circle class="viz-dot" data-index="${i}" cx="${xAt(i)}" cy="${yAt(p.value)}" r="5" />`).join('');
 
   const last = points[points.length - 1];
-  const endLabel =
-    points.length > 0
-      ? `<text class="viz-end-label" x="${xAt(points.length - 1)}" y="${yAt(last.value) - 12}" text-anchor="end">${valuePrefix}${last.value.toLocaleString()}</text>`
-      : '';
+  const endLabel = `<text class="viz-end-label" x="${xAt(points.length - 1)}" y="${yAt(last.value) - 12}" text-anchor="end">${valuePrefix}${last.value.toLocaleString()}</text>`;
+
+  const forecastSvg = hasForecast
+    ? `<path class="viz-forecast-line" d="M ${xAt(points.length - 1)} ${yAt(last.value)} L ${xAt(points.length)} ${yAt(forecastValue)}" />
+  <circle class="viz-forecast-dot" cx="${xAt(points.length)}" cy="${yAt(forecastValue)}" r="5" />
+  <text class="viz-forecast-label" x="${xAt(points.length)}" y="${yAt(forecastValue) - 12}" text-anchor="end">${valuePrefix}${forecastValue.toLocaleString(undefined, { maximumFractionDigits: 0 })} (projected)</text>`
+    : '';
 
   return `
 <svg class="viz-svg" viewBox="0 0 ${CHART_WIDTH} ${CHART_HEIGHT}" role="img" aria-label="${escapeHtml(valueLabel)} over time">
-  ${gridlines.join('\n  ')}
+  ${gridlines}
   <path class="viz-area" d="${areaPath}" />
   <path class="viz-line" d="${linePath}" />
   ${dots}
   ${endLabel}
-  ${yTicks.join('\n  ')}
+  ${forecastSvg}
+  ${yTicks}
+  ${xTicks}
+  <line class="viz-crosshair" x1="0" y1="${PADDING.top}" x2="0" y2="${CHART_HEIGHT - PADDING.bottom}" style="display:none" />
+</svg>`;
+}
+
+/**
+ * Findings-by-severity chart for `dead-resources`/`resource-security`: three
+ * lines (critical/warning/info) instead of one aggregate total, using the
+ * dataviz skill's fixed status palette (never themed — same hex in light and
+ * dark) so severity reads the same way it does in the PDF/table reports.
+ * Per the skill's rules for ≥2 series: a legend (never color-alone), direct
+ * end-labels, and a table view underneath (already part of the section).
+ */
+function buildSeverityChartSvg(points: SeverityPoint[]): string {
+  const maxValue = niceMax(Math.max(...points.flatMap((p) => [p.critical, p.warning, p.info]), 0));
+  const { gridlines, yTicks, xTicks, xAt, yAt } = buildAxes(
+    maxValue,
+    points.map((p) => p.date),
+    '',
+  );
+
+  const legend = SEVERITY_SERIES.map(
+    ({ key, label }) => `<span class="viz-legend-item"><span class="viz-legend-swatch viz-legend-swatch-${key}"></span>${label}</span>`,
+  ).join('');
+
+  const last = points[points.length - 1];
+  const series = SEVERITY_SERIES.map(({ key }) => {
+    const linePath = points.map((p, i) => `${i === 0 ? 'M' : 'L'} ${xAt(i)} ${yAt(p[key])}`).join(' ');
+    const dots = points.map((p, i) => `<circle class="viz-dot-${key}" data-index="${i}" cx="${xAt(i)}" cy="${yAt(p[key])}" r="4" />`).join('');
+    const endLabel = `<text class="viz-end-label-${key}" x="${xAt(points.length - 1)}" y="${yAt(last[key]) - 8}" text-anchor="end">${last[key].toLocaleString()}</text>`;
+    return `<path class="viz-line-${key}" d="${linePath}" />\n  ${dots}\n  ${endLabel}`;
+  }).join('\n  ');
+
+  return `
+<div class="viz-legend">${legend}</div>
+<svg class="viz-svg" viewBox="0 0 ${CHART_WIDTH} ${CHART_HEIGHT}" role="img" aria-label="Findings by severity over time">
+  ${gridlines}
+  ${series}
+  ${yTicks}
   ${xTicks}
   <line class="viz-crosshair" x1="0" y1="${PADDING.top}" x2="0" y2="${CHART_HEIGHT - PADDING.bottom}" style="display:none" />
 </svg>`;
 }
 
 function buildTableRows(records: readonly TrendSnapshotRecord[], domain: TrendDomain): string {
+  if (domain === 'cloud-cost') {
+    return records
+      .map((record) => {
+        const payload = JSON.parse(record.payload) as { totalWasteMonthlyUsd?: number; findings?: unknown[] };
+        const findingsCount = payload.findings?.length ?? 0;
+        const cost = `$${(payload.totalWasteMonthlyUsd ?? 0).toFixed(2)}`;
+        return `<tr><td>${escapeHtml(record.generatedAt.split('T')[0])}</td><td>${escapeHtml(domain)}</td><td>${findingsCount}</td><td>${cost}</td></tr>`;
+      })
+      .join('\n');
+  }
+
   return records
     .map((record) => {
-      const payload = JSON.parse(record.payload) as { totalWasteMonthlyUsd?: number; countBySeverity?: Record<string, number>; findings?: unknown[] };
-      const findingsCount = domain === 'cloud-cost' ? (payload.findings?.length ?? 0) : Object.values(payload.countBySeverity ?? {}).reduce((sum, n) => sum + n, 0);
-      const cost = domain === 'cloud-cost' ? `$${(payload.totalWasteMonthlyUsd ?? 0).toFixed(2)}` : '—';
-      return `<tr><td>${escapeHtml(record.generatedAt.split('T')[0])}</td><td>${escapeHtml(domain)}</td><td>${findingsCount}</td><td>${cost}</td></tr>`;
+      const payload = JSON.parse(record.payload) as { countBySeverity?: Record<string, number> };
+      const bySeverity = payload.countBySeverity ?? {};
+      return `<tr><td>${escapeHtml(record.generatedAt.split('T')[0])}</td><td>${escapeHtml(domain)}</td><td>${bySeverity.critical ?? 0}</td><td>${bySeverity.warning ?? 0}</td><td>${bySeverity.info ?? 0}</td></tr>`;
     })
     .join('\n');
 }
@@ -125,6 +231,87 @@ function buildSummary(records: readonly TrendSnapshotRecord[], domain: TrendDoma
   return `<p class="viz-summary">Resolved <strong>${comparison.resolvedFindings.length}</strong> finding(s), <strong>${comparison.newFindings.length}</strong> new, across the period shown.</p>`;
 }
 
+type HealthStatus = 'good' | 'warning' | 'critical';
+
+function latestSeverity(records: readonly TrendSnapshotRecord[]): { critical: number; warning: number; info: number } {
+  if (records.length === 0) return { critical: 0, warning: 0, info: 0 };
+  const payload = JSON.parse(records[0].payload) as { countBySeverity?: Record<string, number> };
+  const { critical = 0, warning = 0, info = 0 } = payload.countBySeverity ?? {};
+  return { critical, warning, info };
+}
+
+/** Shared by `dead-resources`/`resource-security` — both carry the same severity shape. */
+function severityHealth(sev: { critical: number; warning: number }): HealthStatus {
+  if (sev.critical > 0) return 'critical';
+  if (sev.warning > 0) return 'warning';
+  return 'good';
+}
+
+/**
+ * No "critical" tier for cost — there's no honest threshold for what counts
+ * as a catastrophic dollar figure, unlike security findings which already
+ * carry their own severity. Direction of the trend is the only thing this
+ * can say without inventing a cutoff.
+ */
+function costTrendHealth(records: readonly TrendSnapshotRecord[]): HealthStatus {
+  if (records.length < 2) return 'good';
+  const comparison = compareCloudCostSnapshots(JSON.parse(records[records.length - 1].payload) as WasteReportDto, JSON.parse(records[0].payload) as WasteReportDto);
+  return comparison.deltaUsd > 0 ? 'warning' : 'good';
+}
+
+/**
+ * A small color dot, never the sole carrier of the status — every call site
+ * pairs it with a `title` tooltip and, in the surrounding card/tile, actual
+ * text (severity counts, trend direction) that says the same thing in words.
+ */
+function healthDot(status: HealthStatus, label: string): string {
+  return `<span class="viz-health-dot viz-health-${status}" title="${escapeHtml(label)}"></span>`;
+}
+
+/**
+ * A business-language read of the latest severity breakdown — deliberately
+ * no dollar figure. Unlike `cloud-cost`, there is no honest way to price a
+ * security finding (no real market cost the way AWS list prices exist for
+ * waste), so this stays qualitative rather than inventing a "risk exposure
+ * in $" number, consistent with every other "honest caveat" in this project.
+ */
+function buildSecurityRiskNarrative(records: readonly TrendSnapshotRecord[]): string {
+  if (records.length === 0) return '';
+  const { critical, warning, info } = latestSeverity(records);
+  const total = critical + warning + info;
+  if (total === 0) return '<p class="viz-summary viz-risk-narrative">No open security-posture findings on the latest run.</p>';
+
+  const parts = [critical > 0 ? `${critical} critical` : '', warning > 0 ? `${warning} warning` : '', info > 0 ? `${info} info` : ''].filter(Boolean).join(', ');
+  const risk =
+    critical > 0
+      ? 'exposing the account to unauthorized access, data exposure, or compliance violations — address these first'
+      : warning > 0
+        ? 'worth reviewing before they compound into higher-severity risk'
+        : 'low-severity items, no immediate action required';
+  return `<p class="viz-summary viz-risk-narrative"><strong>${total}</strong> open finding(s) (${parts}) — ${risk}.</p>`;
+}
+
+/**
+ * "Where is the money going" for the latest run — turns the headline $ figure
+ * into something actionable. Reuses `WasteReportDto.breakdown`, already
+ * aggregated and labeled per resource kind (see `toWasteReportDto`), instead
+ * of re-deriving totals from `findings` here.
+ */
+function buildTopWastersList(records: readonly TrendSnapshotRecord[]): string {
+  if (records.length === 0) return '';
+  const payload = JSON.parse(records[0].payload) as { breakdown?: Array<{ label: string; monthlyCostUsd: number; category: string }> };
+  const wasters = (payload.breakdown ?? [])
+    .filter((b) => b.category === 'waste' && b.monthlyCostUsd > 0)
+    .sort((a, b) => b.monthlyCostUsd - a.monthlyCostUsd)
+    .slice(0, 3);
+  if (wasters.length === 0) return '';
+
+  const items = wasters
+    .map((b) => `<li><span class="viz-top-waster-label">${escapeHtml(b.label)}</span><span class="viz-top-waster-value">$${b.monthlyCostUsd.toFixed(2)}/mo</span></li>`)
+    .join('');
+  return `<div class="viz-top-wasters"><p class="viz-top-wasters-title">Top resource types by waste (latest run)</p><ul class="viz-top-wasters-list">${items}</ul></div>`;
+}
+
 /**
  * One domain's chart + summary + table, as a standalone `<div class="viz-card">`.
  * Points are embedded as a sibling `application/json` script tag (not a JS
@@ -132,29 +319,116 @@ function buildSummary(records: readonly TrendSnapshotRecord[], domain: TrendDoma
  * cards on one page via `querySelectorAll` instead of a single global chart.
  */
 function buildDomainSection(records: readonly TrendSnapshotRecord[], domain: TrendDomain): string {
-  const points = extractPoints(records, domain);
-  const valueLabel = domain === 'cloud-cost' ? 'Monthly waste (USD)' : 'Findings';
-  const valuePrefix = domain === 'cloud-cost' ? '$' : '';
-  const chartSvg = points.length > 0 ? buildChartSvg(points, valueLabel, valuePrefix) : '';
+  const isCost = domain === 'cloud-cost';
+  const points = isCost ? extractPoints(records) : extractSeverityPoints(records);
+  const forecastValue = isCost ? computeForecast(points as DataPoint[]) : undefined;
+  const chartSvg = points.length === 0 ? '' : isCost ? buildChartSvg(points as DataPoint[], 'Monthly waste (USD)', '$', forecastValue) : buildSeverityChartSvg(points as SeverityPoint[]);
   const tableRows = buildTableRows(records, domain);
+  const riskNarrative = domain === 'resource-security' ? buildSecurityRiskNarrative(records) : '';
   const summary = buildSummary(records, domain);
+  const forecastCaveat =
+    forecastValue !== undefined
+      ? `<p class="viz-summary viz-forecast-caveat">Projected next run: <strong>$${forecastValue.toFixed(2)}</strong> — a straight-line trend estimate from the runs shown, not a guarantee.</p>`
+      : '';
+  const topWasters = isCost ? buildTopWastersList(records) : '';
   const pointsJson = JSON.stringify(points).replace(/</g, '\\u003c');
+  const tableHeader = isCost
+    ? '<tr><th>Date</th><th>Domain</th><th>Findings</th><th>Monthly waste</th></tr>'
+    : '<tr><th>Date</th><th>Domain</th><th>Critical</th><th>Warning</th><th>Info</th></tr>';
+
+  let health: HealthStatus;
+  let healthTitle: string;
+  if (isCost) {
+    health = costTrendHealth(records);
+    healthTitle = health === 'warning' ? 'Waste trending up' : 'Waste stable or trending down';
+  } else {
+    const sev = latestSeverity(records);
+    health = severityHealth(sev);
+    healthTitle = health === 'critical' ? `${sev.critical} critical finding(s)` : health === 'warning' ? `${sev.warning} warning finding(s)` : 'No critical/warning findings';
+  }
 
   return `
   <div class="viz-card">
-    <h2>${escapeHtml(domain)} — local scan history</h2>
+    <h2>${healthDot(health, healthTitle)}${escapeHtml(domain)} — local scan history</h2>
     <p class="viz-subtitle">${records.length} run(s) on record</p>
+    ${riskNarrative}
     ${summary}
-    <div class="viz-chart-wrap" data-value-prefix="${escapeHtml(valuePrefix)}">
+    <div class="viz-chart-wrap" data-value-prefix="${isCost ? '$' : ''}" ${isCost ? '' : 'data-series="critical,warning,info"'}>
       ${chartSvg}
       <script type="application/json" class="viz-points">${pointsJson}</script>
       <div class="viz-tooltip"><div class="viz-tooltip-date"></div><div class="viz-tooltip-value"></div></div>
     </div>
+    ${forecastCaveat}
+    ${topWasters}
     <table class="viz-table">
-      <thead><tr><th>Date</th><th>Domain</th><th>Findings</th><th>Monthly waste</th></tr></thead>
+      <thead>${tableHeader}</thead>
       <tbody>${tableRows}</tbody>
     </table>
   </div>`;
+}
+
+function statTile(label: string, value: string, sub: string, health: HealthStatus, healthTitle: string): string {
+  return `<div class="viz-stat-tile"><div class="viz-stat-label">${healthDot(health, healthTitle)}${escapeHtml(label)}</div><div class="viz-stat-value">${value}</div><div class="viz-stat-sub">${sub}</div></div>`;
+}
+
+function buildCostStatTile(records: readonly TrendSnapshotRecord[]): string {
+  const health = costTrendHealth(records);
+  const healthTitle = health === 'warning' ? 'Waste trending up' : 'Waste stable or trending down';
+  if (records.length === 0) return statTile('Monthly Waste', '—', 'No scans yet', health, healthTitle);
+  const latest = JSON.parse(records[0].payload) as { totalWasteMonthlyUsd?: number };
+  const value = `$${(latest.totalWasteMonthlyUsd ?? 0).toFixed(2)}`;
+  if (records.length < 2) return statTile('Monthly Waste', value, 'No earlier run to compare', health, healthTitle);
+
+  const comparison = compareCloudCostSnapshots(JSON.parse(records[records.length - 1].payload) as WasteReportDto, JSON.parse(records[0].payload) as WasteReportDto);
+  const deltaClass = comparison.deltaUsd > 0 ? 'viz-delta-bad' : comparison.deltaUsd < 0 ? 'viz-delta-good' : '';
+  const arrow = comparison.deltaUsd > 0 ? '▲' : comparison.deltaUsd < 0 ? '▼' : '—';
+  return statTile('Monthly Waste', value, `<span class="${deltaClass}">${arrow} $${Math.abs(comparison.deltaUsd).toFixed(2)} vs earliest run shown</span>`, health, healthTitle);
+}
+
+/** No dollar figure here either — see `buildSecurityRiskNarrative` for why. */
+function buildSecurityStatTile(records: readonly TrendSnapshotRecord[]): string {
+  const sev = latestSeverity(records);
+  const health = severityHealth(sev);
+  const healthTitle = health === 'critical' ? `${sev.critical} critical finding(s)` : health === 'warning' ? `${sev.warning} warning finding(s)` : 'No critical/warning findings';
+  if (records.length === 0) return statTile('Security Risk', '—', 'No scans yet', health, healthTitle);
+  const value = sev.critical > 0 ? `${sev.critical} critical` : sev.warning > 0 ? `${sev.warning} warning` : 'Clear';
+  const sub =
+    sev.critical > 0
+      ? '<span class="viz-delta-bad">Unauthorized-access / compliance exposure</span>'
+      : sev.warning > 0
+        ? 'Review before it compounds'
+        : 'No open findings';
+  return statTile('Security Risk', value, sub, health, healthTitle);
+}
+
+function buildDeadResourcesStatTile(records: readonly TrendSnapshotRecord[]): string {
+  const sev = latestSeverity(records);
+  const health = severityHealth(sev);
+  const healthTitle = health === 'critical' ? `${sev.critical} critical finding(s)` : health === 'warning' ? `${sev.warning} warning finding(s)` : 'No critical/warning findings';
+  if (records.length === 0) return statTile('Dead Resources', '—', 'No scans yet', health, healthTitle);
+  const total = sev.critical + sev.warning + sev.info;
+  if (records.length < 2) return statTile('Dead Resources', `${total}`, 'No earlier run to compare', health, healthTitle);
+
+  const comparison = compareHygieneSnapshots(
+    'dead-resources',
+    JSON.parse(records[records.length - 1].payload) as DeadResourcesReportDto,
+    JSON.parse(records[0].payload) as DeadResourcesReportDto,
+  );
+  return statTile('Dead Resources', `${total}`, `${comparison.resolvedFindings.length} resolved, ${comparison.newFindings.length} new since earliest run shown`, health, healthTitle);
+}
+
+/**
+ * Cross-domain headline row for the combined report only (see
+ * `generateCombinedHistoryReportHtml`) — a single-domain report already has
+ * its one chart as the whole story, so this would just repeat it.
+ */
+function buildExecutiveSummary(recordsByDomain: Readonly<Record<TrendDomain, readonly TrendSnapshotRecord[]>>): string {
+  const tiles = [
+    buildCostStatTile(recordsByDomain['cloud-cost']),
+    buildSecurityStatTile(recordsByDomain['resource-security']),
+    buildDeadResourcesStatTile(recordsByDomain['dead-resources']),
+  ].join('');
+  return `<div class="viz-exec-summary">${tiles}</div>`;
 }
 
 const PAGE_STYLE = `
@@ -170,6 +444,9 @@ const PAGE_STYLE = `
     --series-1: #2a78d6;
     --good: #006300;
     --bad: #d03b3b;
+    /* Status palette — fixed, never themed: same hex in light and dark. */
+    --severity-critical: #d03b3b;
+    --severity-warning: #fab219;
     font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
     background: var(--page);
     color: var(--text-primary);
@@ -200,12 +477,48 @@ const PAGE_STYLE = `
   .viz-summary strong { color: var(--text-primary); }
   .viz-delta-good { color: var(--good); }
   .viz-delta-bad { color: var(--bad); }
+  .viz-forecast-caveat, .viz-risk-narrative { font-size: 12px; font-style: italic; }
+  .viz-top-wasters { margin: 12px 0 0; }
+  .viz-top-wasters-title { font-size: 11px; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.04em; margin: 0 0 6px; }
+  .viz-top-wasters-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 2px; }
+  .viz-top-wasters-list li { display: flex; justify-content: space-between; gap: 12px; font-size: 13px; padding: 5px 0; border-bottom: 1px solid var(--gridline); }
+  .viz-top-waster-value { font-weight: 600; font-variant-numeric: tabular-nums; white-space: nowrap; }
+  .viz-health-dot { display: inline-block; width: 8px; height: 8px; border-radius: 50%; margin-right: 6px; vertical-align: middle; }
+  .viz-health-good { background: var(--good); }
+  .viz-health-warning { background: var(--severity-warning); }
+  .viz-health-critical { background: var(--severity-critical); }
+  .viz-exec-summary { display: flex; gap: 16px; margin: 0 0 24px; }
+  .viz-stat-tile { flex: 1; background: var(--surface-1); border-radius: 8px; padding: 16px 20px; }
+  .viz-stat-label { font-size: 11px; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.04em; margin-bottom: 6px; }
+  .viz-stat-value { font-size: 24px; font-weight: 700; color: var(--text-primary); margin-bottom: 4px; }
+  .viz-stat-sub { font-size: 12px; color: var(--text-secondary); }
   .viz-svg { width: 100%; height: auto; overflow: visible; }
   .viz-gridline { stroke: var(--gridline); stroke-width: 1; }
   .viz-line { fill: none; stroke: var(--series-1); stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; }
   .viz-area { fill: var(--series-1); opacity: 0.1; stroke: none; }
   .viz-dot { fill: var(--series-1); stroke: var(--surface-1); stroke-width: 2; }
   .viz-end-label { fill: var(--text-primary); font-size: 13px; font-weight: 600; }
+  .viz-forecast-line { fill: none; stroke: var(--series-1); stroke-width: 2; stroke-dasharray: 5 4; opacity: 0.55; }
+  .viz-forecast-dot { fill: var(--surface-1); stroke: var(--series-1); stroke-width: 2; opacity: 0.8; }
+  .viz-forecast-label { fill: var(--text-secondary); font-size: 11px; font-style: italic; }
+  .viz-line-critical, .viz-line-warning, .viz-line-info { fill: none; stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; }
+  .viz-line-critical { stroke: var(--severity-critical); }
+  .viz-line-warning { stroke: var(--severity-warning); }
+  .viz-line-info { stroke: var(--text-muted); }
+  .viz-dot-critical, .viz-dot-warning, .viz-dot-info { stroke: var(--surface-1); stroke-width: 2; }
+  .viz-dot-critical { fill: var(--severity-critical); }
+  .viz-dot-warning { fill: var(--severity-warning); }
+  .viz-dot-info { fill: var(--text-muted); }
+  .viz-end-label-critical, .viz-end-label-warning, .viz-end-label-info { font-size: 12px; font-weight: 600; }
+  .viz-end-label-critical { fill: var(--severity-critical); }
+  .viz-end-label-warning { fill: var(--severity-warning); }
+  .viz-end-label-info { fill: var(--text-muted); }
+  .viz-legend { display: flex; gap: 16px; margin-bottom: 8px; font-size: 12px; color: var(--text-secondary); }
+  .viz-legend-item { display: inline-flex; align-items: center; gap: 6px; }
+  .viz-legend-swatch { width: 10px; height: 10px; border-radius: 2px; display: inline-block; }
+  .viz-legend-swatch-critical { background: var(--severity-critical); }
+  .viz-legend-swatch-warning { background: var(--severity-warning); }
+  .viz-legend-swatch-info { background: var(--text-muted); }
   .viz-tick { fill: var(--text-muted); font-size: 11px; font-variant-numeric: tabular-nums; }
   .viz-crosshair { stroke: var(--baseline); stroke-width: 1; }
   .viz-tooltip {
@@ -216,17 +529,26 @@ const PAGE_STYLE = `
   }
   .viz-tooltip .viz-tooltip-value { font-weight: 600; }
   .viz-tooltip .viz-tooltip-date { color: var(--text-secondary); }
+  .viz-tooltip-row { display: block; }
+  .viz-tooltip-row-critical { color: var(--severity-critical); }
+  .viz-tooltip-row-warning { color: var(--severity-warning); }
+  .viz-tooltip-row-info { color: var(--text-muted); }
   table.viz-table { width: 100%; border-collapse: collapse; margin-top: 24px; font-size: 13px; }
   table.viz-table th, table.viz-table td { text-align: left; padding: 6px 8px; border-bottom: 1px solid var(--gridline); }
   table.viz-table th { color: var(--text-muted); font-weight: 600; }
-  table.viz-table td:nth-child(3), table.viz-table td:nth-child(4) { font-variant-numeric: tabular-nums; }
+  table.viz-table td:nth-child(3), table.viz-table td:nth-child(4), table.viz-table td:nth-child(5) { font-variant-numeric: tabular-nums; }
   .viz-chart-wrap { position: relative; }`;
 
 /**
  * Wires up every `.viz-chart-wrap` on the page independently (one page can
  * hold one card or several stacked ones — see `generateCombinedHistoryReportHtml`),
  * reading each chart's own points from its sibling `application/json` script
- * instead of a single page-wide variable.
+ * instead of a single page-wide variable. `data-series` (present only on the
+ * severity charts) switches the tooltip from a single value to one row per
+ * series — dots for each series share the same x position per index, so the
+ * first series' dots alone drive nearest-point lookup. The forecast slot (if
+ * any) is a static direct-labeled point, not part of `points` — never
+ * hoverable, since it isn't a real snapshot.
  */
 const PAGE_SCRIPT = `
     (function () {
@@ -235,11 +557,14 @@ const PAGE_SCRIPT = `
         var pointsTag = wrap.querySelector('.viz-points');
         var points = pointsTag ? JSON.parse(pointsTag.textContent) : [];
         if (!svg || points.length === 0) return;
+        var seriesAttr = wrap.getAttribute('data-series');
+        var seriesKeys = seriesAttr ? seriesAttr.split(',') : ['value'];
         var crosshair = svg.querySelector('.viz-crosshair');
         var tooltip = wrap.querySelector('.viz-tooltip');
         var dateEl = tooltip.querySelector('.viz-tooltip-date');
         var valueEl = tooltip.querySelector('.viz-tooltip-value');
-        var dots = Array.prototype.slice.call(svg.querySelectorAll('.viz-dot'));
+        var firstSeriesDotClass = seriesAttr ? '.viz-dot-' + seriesKeys[0] : '.viz-dot';
+        var dots = Array.prototype.slice.call(svg.querySelectorAll(firstSeriesDotClass));
         var valuePrefix = wrap.getAttribute('data-value-prefix') || '';
 
         function showAt(index) {
@@ -252,7 +577,14 @@ const PAGE_SCRIPT = `
           crosshair.style.display = 'block';
           var point = points[index];
           dateEl.textContent = point.date;
-          valueEl.textContent = valuePrefix + point.value.toLocaleString();
+          if (seriesAttr) {
+            valueEl.innerHTML = seriesKeys.map(function (key) {
+              var label = key.charAt(0).toUpperCase() + key.slice(1);
+              return '<span class="viz-tooltip-row viz-tooltip-row-' + key + '">' + label + ': ' + point[key].toLocaleString() + '</span>';
+            }).join('');
+          } else {
+            valueEl.textContent = valuePrefix + point.value.toLocaleString();
+          }
           var rect = svg.getBoundingClientRect();
           var scale = rect.width / ${CHART_WIDTH};
           tooltip.style.left = (cx * scale + 12) + 'px';
@@ -303,12 +635,14 @@ function buildPage(title: string, subtitle: string, sectionsHtml: string): strin
 }
 
 /**
- * Self-contained HTML report for one domain's trend history: a single-series
- * line chart (inline SVG, zero chart-library dependency) plus its
- * table-view twin, per the project's dataviz conventions — hand-rolled SVG
- * over a bundled charting library or a CDN script, consistent with why
- * `pdfkit` was chosen over a headless browser (no heavy dependency, fully
- * offline, nothing ever leaves the machine).
+ * Self-contained HTML report for one domain's trend history: a line chart
+ * (inline SVG, zero chart-library dependency) — a single series for
+ * `cloud-cost` (monthly waste, with a linear projection past the last real
+ * run), three for `dead-resources`/`resource-security` (critical/warning/
+ * info) — plus its table-view twin, per the project's dataviz conventions:
+ * hand-rolled SVG over a bundled charting library or a CDN script,
+ * consistent with why `pdfkit` was chosen over a headless browser (no heavy
+ * dependency, fully offline, nothing ever leaves the machine).
  */
 export function generateHistoryReportHtml(records: readonly TrendSnapshotRecord[], domain: TrendDomain, accountId: string): string {
   const title = `cloudrift — ${domain} history`;
@@ -320,11 +654,15 @@ export function generateHistoryReportHtml(records: readonly TrendSnapshotRecord[
  * Same report, but stacking all three tracked domains (cloud-cost,
  * dead-resources, resource-security) as separate cards on one page instead
  * of writing three files — `history --html` without `--domain` picks this.
+ * Leads with a 3-tile executive summary (monthly waste + delta, security
+ * risk, dead-resources trend) aimed at a CTO/CEO audience who wants the
+ * headline before scrolling into any one domain's detail.
  */
 export function generateCombinedHistoryReportHtml(recordsByDomain: Readonly<Record<TrendDomain, readonly TrendSnapshotRecord[]>>, accountId: string): string {
   const domains: TrendDomain[] = ['cloud-cost', 'dead-resources', 'resource-security'];
   const title = 'cloudrift — scan history';
   const subtitle = `Account ${escapeHtml(accountId)} · generated locally, never uploaded anywhere`;
+  const execSummary = buildExecutiveSummary(recordsByDomain);
   const sections = domains.map((domain) => buildDomainSection(recordsByDomain[domain], domain)).join('\n');
-  return buildPage(title, subtitle, sections);
+  return buildPage(title, subtitle, execSummary + sections);
 }

--- a/apps/cli/src/formatters/history-report.html-formatter.ts
+++ b/apps/cli/src/formatters/history-report.html-formatter.ts
@@ -126,27 +126,38 @@ function buildSummary(records: readonly TrendSnapshotRecord[], domain: TrendDoma
 }
 
 /**
- * Self-contained HTML report for one domain's trend history: a single-series
- * line chart (inline SVG, zero chart-library dependency) plus its
- * table-view twin, per the project's dataviz conventions — hand-rolled SVG
- * over a bundled charting library or a CDN script, consistent with why
- * `pdfkit` was chosen over a headless browser (no heavy dependency, fully
- * offline, nothing ever leaves the machine).
+ * One domain's chart + summary + table, as a standalone `<div class="viz-card">`.
+ * Points are embedded as a sibling `application/json` script tag (not a JS
+ * variable) so the page-level script below can support any number of these
+ * cards on one page via `querySelectorAll` instead of a single global chart.
  */
-export function generateHistoryReportHtml(records: readonly TrendSnapshotRecord[], domain: TrendDomain, accountId: string): string {
+function buildDomainSection(records: readonly TrendSnapshotRecord[], domain: TrendDomain): string {
   const points = extractPoints(records, domain);
   const valueLabel = domain === 'cloud-cost' ? 'Monthly waste (USD)' : 'Findings';
   const valuePrefix = domain === 'cloud-cost' ? '$' : '';
   const chartSvg = points.length > 0 ? buildChartSvg(points, valueLabel, valuePrefix) : '';
   const tableRows = buildTableRows(records, domain);
   const summary = buildSummary(records, domain);
+  const pointsJson = JSON.stringify(points).replace(/</g, '\\u003c');
 
-  return `<!doctype html>
-<html lang="en">
-<head>
-<meta charset="utf-8" />
-<title>cloudrift — ${escapeHtml(domain)} history</title>
-<style>
+  return `
+  <div class="viz-card">
+    <h2>${escapeHtml(domain)} — local scan history</h2>
+    <p class="viz-subtitle">${records.length} run(s) on record</p>
+    ${summary}
+    <div class="viz-chart-wrap" data-value-prefix="${escapeHtml(valuePrefix)}">
+      ${chartSvg}
+      <script type="application/json" class="viz-points">${pointsJson}</script>
+      <div class="viz-tooltip"><div class="viz-tooltip-date"></div><div class="viz-tooltip-value"></div></div>
+    </div>
+    <table class="viz-table">
+      <thead><tr><th>Date</th><th>Domain</th><th>Findings</th><th>Monthly waste</th></tr></thead>
+      <tbody>${tableRows}</tbody>
+    </table>
+  </div>`;
+}
+
+const PAGE_STYLE = `
   .viz-root {
     color-scheme: light;
     --surface-1: #fcfcfb;
@@ -180,8 +191,10 @@ export function generateHistoryReportHtml(records: readonly TrendSnapshotRecord[
       --bad: #e66767;
     }
   }
-  .viz-card { background: var(--surface-1); border-radius: 8px; padding: 24px; max-width: 800px; margin: 0 auto 24px; }
-  h1 { font-size: 20px; margin: 0 0 4px; }
+  .viz-page { max-width: 800px; margin: 0 auto; }
+  .viz-card { background: var(--surface-1); border-radius: 8px; padding: 24px; margin: 0 0 24px; }
+  h1 { font-size: 22px; margin: 0 0 4px; }
+  h2 { font-size: 18px; margin: 0 0 4px; }
   .viz-subtitle { color: var(--text-secondary); font-size: 13px; margin: 0 0 20px; }
   .viz-summary { color: var(--text-secondary); font-size: 14px; line-height: 1.5; }
   .viz-summary strong { color: var(--text-primary); }
@@ -207,73 +220,111 @@ export function generateHistoryReportHtml(records: readonly TrendSnapshotRecord[
   table.viz-table th, table.viz-table td { text-align: left; padding: 6px 8px; border-bottom: 1px solid var(--gridline); }
   table.viz-table th { color: var(--text-muted); font-weight: 600; }
   table.viz-table td:nth-child(3), table.viz-table td:nth-child(4) { font-variant-numeric: tabular-nums; }
-  .viz-chart-wrap { position: relative; }
+  .viz-chart-wrap { position: relative; }`;
+
+/**
+ * Wires up every `.viz-chart-wrap` on the page independently (one page can
+ * hold one card or several stacked ones — see `generateCombinedHistoryReportHtml`),
+ * reading each chart's own points from its sibling `application/json` script
+ * instead of a single page-wide variable.
+ */
+const PAGE_SCRIPT = `
+    (function () {
+      document.querySelectorAll('.viz-chart-wrap').forEach(function (wrap) {
+        var svg = wrap.querySelector('.viz-svg');
+        var pointsTag = wrap.querySelector('.viz-points');
+        var points = pointsTag ? JSON.parse(pointsTag.textContent) : [];
+        if (!svg || points.length === 0) return;
+        var crosshair = svg.querySelector('.viz-crosshair');
+        var tooltip = wrap.querySelector('.viz-tooltip');
+        var dateEl = tooltip.querySelector('.viz-tooltip-date');
+        var valueEl = tooltip.querySelector('.viz-tooltip-value');
+        var dots = Array.prototype.slice.call(svg.querySelectorAll('.viz-dot'));
+        var valuePrefix = wrap.getAttribute('data-value-prefix') || '';
+
+        function showAt(index) {
+          var dot = dots[index];
+          if (!dot) return;
+          var cx = parseFloat(dot.getAttribute('cx'));
+          var cy = parseFloat(dot.getAttribute('cy'));
+          crosshair.setAttribute('x1', cx);
+          crosshair.setAttribute('x2', cx);
+          crosshair.style.display = 'block';
+          var point = points[index];
+          dateEl.textContent = point.date;
+          valueEl.textContent = valuePrefix + point.value.toLocaleString();
+          var rect = svg.getBoundingClientRect();
+          var scale = rect.width / ${CHART_WIDTH};
+          tooltip.style.left = (cx * scale + 12) + 'px';
+          tooltip.style.top = (cy * scale - 8) + 'px';
+          tooltip.style.display = 'block';
+        }
+
+        function hide() {
+          crosshair.style.display = 'none';
+          tooltip.style.display = 'none';
+        }
+
+        svg.addEventListener('mousemove', function (event) {
+          var rect = svg.getBoundingClientRect();
+          var scale = ${CHART_WIDTH} / rect.width;
+          var localX = (event.clientX - rect.left) * scale;
+          var nearest = 0;
+          var nearestDist = Infinity;
+          dots.forEach(function (dot, i) {
+            var dist = Math.abs(parseFloat(dot.getAttribute('cx')) - localX);
+            if (dist < nearestDist) { nearestDist = dist; nearest = i; }
+          });
+          showAt(nearest);
+        });
+        svg.addEventListener('mouseleave', hide);
+      });
+    })();`;
+
+function buildPage(title: string, subtitle: string, sectionsHtml: string): string {
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>${escapeHtml(title)}</title>
+<style>${PAGE_STYLE}
 </style>
 </head>
 <body class="viz-root">
-  <div class="viz-card">
-    <h1>${escapeHtml(domain)} — local scan history</h1>
-    <p class="viz-subtitle">Account ${escapeHtml(accountId)} · ${records.length} run(s) on record · generated locally, never uploaded anywhere</p>
-    ${summary}
-    <div class="viz-chart-wrap">
-      ${chartSvg}
-      <div class="viz-tooltip"><div class="viz-tooltip-date"></div><div class="viz-tooltip-value"></div></div>
-    </div>
-    <table class="viz-table">
-      <thead><tr><th>Date</th><th>Domain</th><th>Findings</th><th>Monthly waste</th></tr></thead>
-      <tbody>${tableRows}</tbody>
-    </table>
+  <div class="viz-page">
+    <h1>${escapeHtml(title)}</h1>
+    <p class="viz-subtitle">${subtitle}</p>
+    ${sectionsHtml}
   </div>
-  <script>
-    (function () {
-      var points = ${JSON.stringify(points).replace(/</g, '\\u003c')};
-      var svg = document.querySelector('.viz-svg');
-      if (!svg || points.length === 0) return;
-      var crosshair = svg.querySelector('.viz-crosshair');
-      var tooltip = document.querySelector('.viz-tooltip');
-      var dateEl = tooltip.querySelector('.viz-tooltip-date');
-      var valueEl = tooltip.querySelector('.viz-tooltip-value');
-      var dots = Array.prototype.slice.call(svg.querySelectorAll('.viz-dot'));
-      var valuePrefix = ${JSON.stringify(valuePrefix)};
-
-      function showAt(index) {
-        var dot = dots[index];
-        if (!dot) return;
-        var cx = parseFloat(dot.getAttribute('cx'));
-        var cy = parseFloat(dot.getAttribute('cy'));
-        crosshair.setAttribute('x1', cx);
-        crosshair.setAttribute('x2', cx);
-        crosshair.style.display = 'block';
-        var point = points[index];
-        dateEl.textContent = point.date;
-        valueEl.textContent = valuePrefix + point.value.toLocaleString();
-        var rect = svg.getBoundingClientRect();
-        var scale = rect.width / ${CHART_WIDTH};
-        tooltip.style.left = (cx * scale + 12) + 'px';
-        tooltip.style.top = (cy * scale - 8) + 'px';
-        tooltip.style.display = 'block';
-      }
-
-      function hide() {
-        crosshair.style.display = 'none';
-        tooltip.style.display = 'none';
-      }
-
-      svg.addEventListener('mousemove', function (event) {
-        var rect = svg.getBoundingClientRect();
-        var scale = ${CHART_WIDTH} / rect.width;
-        var localX = (event.clientX - rect.left) * scale;
-        var nearest = 0;
-        var nearestDist = Infinity;
-        dots.forEach(function (dot, i) {
-          var dist = Math.abs(parseFloat(dot.getAttribute('cx')) - localX);
-          if (dist < nearestDist) { nearestDist = dist; nearest = i; }
-        });
-        showAt(nearest);
-      });
-      svg.addEventListener('mouseleave', hide);
-    })();
+  <script>${PAGE_SCRIPT}
   </script>
 </body>
 </html>`;
+}
+
+/**
+ * Self-contained HTML report for one domain's trend history: a single-series
+ * line chart (inline SVG, zero chart-library dependency) plus its
+ * table-view twin, per the project's dataviz conventions — hand-rolled SVG
+ * over a bundled charting library or a CDN script, consistent with why
+ * `pdfkit` was chosen over a headless browser (no heavy dependency, fully
+ * offline, nothing ever leaves the machine).
+ */
+export function generateHistoryReportHtml(records: readonly TrendSnapshotRecord[], domain: TrendDomain, accountId: string): string {
+  const title = `cloudrift — ${domain} history`;
+  const subtitle = `Account ${escapeHtml(accountId)} · ${records.length} run(s) on record · generated locally, never uploaded anywhere`;
+  return buildPage(title, subtitle, buildDomainSection(records, domain));
+}
+
+/**
+ * Same report, but stacking all three tracked domains (cloud-cost,
+ * dead-resources, resource-security) as separate cards on one page instead
+ * of writing three files — `history --html` without `--domain` picks this.
+ */
+export function generateCombinedHistoryReportHtml(recordsByDomain: Readonly<Record<TrendDomain, readonly TrendSnapshotRecord[]>>, accountId: string): string {
+  const domains: TrendDomain[] = ['cloud-cost', 'dead-resources', 'resource-security'];
+  const title = 'cloudrift — scan history';
+  const subtitle = `Account ${escapeHtml(accountId)} · generated locally, never uploaded anywhere`;
+  const sections = domains.map((domain) => buildDomainSection(recordsByDomain[domain], domain)).join('\n');
+  return buildPage(title, subtitle, sections);
 }

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -230,7 +230,10 @@ program
   .option('--compare <n>', 'compare the latest run against the one n runs back instead of listing (requires --domain)')
   // See the `analyze` command's --pdf option above for why [filename] needs
   // to be written as --html=./path.html when combined with other flags.
-  .option('--html [filename]', 'Also write a self-contained HTML report with a trend chart (optional filename, defaults to reports/cloudrift-history-<domain>-YYYY_MM_DD.html; requires --domain)')
+  .option(
+    '--html [filename]',
+    'Also write a self-contained HTML report with a trend chart (optional filename, defaults to reports/cloudrift-history-<domain>-YYYY_MM_DD.html). Without --domain, charts all three domains stacked on one page instead of just one',
+  )
   .option('--format <format>', 'stdout output format: table (default) or json', 'table')
   .action((options) => historyCommand(options));
 

--- a/apps/cli/src/wizard/entry.wizard.ts
+++ b/apps/cli/src/wizard/entry.wizard.ts
@@ -132,7 +132,7 @@ async function runHistoryMode(outro: Outro): Promise<void> {
   if (output === undefined) return;
 
   outro('Reading local scan history...');
-  await historyCommand({ domain: output.domain, format: output.format });
+  await historyCommand({ domain: output.domain, format: output.format, html: output.saveHtml });
 }
 
 async function runTerraformMode(outro: Outro): Promise<void> {

--- a/apps/cli/src/wizard/mode-picker.wizard.ts
+++ b/apps/cli/src/wizard/mode-picker.wizard.ts
@@ -1,4 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
+import chalk from 'chalk';
+import { resolveCloudriftIacDetectorBinary } from './terraform-handoff.wizard';
 
 export type WizardMode = 'waste' | 'cost' | 'trend' | 'dead-resources' | 'resource-security' | 'history' | 'terraform';
 
@@ -19,6 +21,8 @@ export type WizardMode = 'waste' | 'cost' | 'trend' | 'dead-resources' | 'resour
  */
 export async function promptMode(): Promise<WizardMode | undefined> {
   const { select, cancel, isCancel } = await import('@clack/prompts');
+
+  const terraformUnlocked = resolveCloudriftIacDetectorBinary() !== undefined;
 
   const mode = await select<WizardMode>({
     message: 'What do you want to do?',
@@ -51,8 +55,10 @@ export async function promptMode(): Promise<WizardMode | undefined> {
       },
       {
         value: 'terraform',
-        label: 'Terraform source analysis',
-        hint: 'Pro — separate cloudrift-iac-detector package: orphans, duplicates, dead code, auto-fix',
+        label: terraformUnlocked ? 'Terraform source analysis (PRO)' : chalk.yellow('🔒 Terraform source analysis (PRO)'),
+        hint: terraformUnlocked
+          ? 'orphans, duplicates, dead code, auto-fix'
+          : 'locked — separate cloudrift-iac-detector Pro package required, not found on PATH',
       },
     ],
   });

--- a/apps/cli/src/wizard/output-format.wizard.ts
+++ b/apps/cli/src/wizard/output-format.wizard.ts
@@ -103,11 +103,17 @@ export async function promptCostTrendOutput(): Promise<CostTrendOutputChoice | u
 export interface HistoryOutputChoice {
   domain?: 'cloud-cost' | 'dead-resources' | 'resource-security';
   format: 'table' | 'json';
+  saveHtml: boolean;
 }
 
-/** Domain filter + output format for the `history` wizard flow — no PDF/CSV, `history` doesn't support file artifacts. */
+/**
+ * Domain filter + output format for the `history` wizard flow — no PDF/CSV,
+ * `history` doesn't support those file artifacts. HTML is always offered:
+ * with a single domain it charts just that metric, with "Every domain" it
+ * charts all three stacked on one page (see `generateCombinedHistoryReportHtml`).
+ */
 export async function promptHistoryOutput(): Promise<HistoryOutputChoice | undefined> {
-  const { select, isCancel, cancel } = await import('@clack/prompts');
+  const { select, confirm, isCancel, cancel } = await import('@clack/prompts');
 
   const domain = await select<HistoryOutputChoice['domain'] | 'all'>({
     message: 'Which scan history do you want to see?',
@@ -131,7 +137,13 @@ export async function promptHistoryOutput(): Promise<HistoryOutputChoice | undef
   });
   if (isCancel(format)) return bail(cancel);
 
-  return { domain: domain === 'all' ? undefined : domain, format };
+  const saveHtml = await confirm({
+    message: domain === 'all' ? 'Also save a combined HTML report (all 3 domains, one chart each) to disk?' : 'Also save an HTML trend report to disk?',
+    initialValue: false,
+  });
+  if (isCancel(saveHtml)) return bail(cancel);
+
+  return { domain: domain === 'all' ? undefined : domain, format, saveHtml };
 }
 
 function bail(cancelFn: (message?: string) => void): undefined {

--- a/docs/en/usage.md
+++ b/docs/en/usage.md
@@ -391,6 +391,8 @@ node apps/cli/dist/main.js history --html
 
 **`--compare`'s "presumed resolved" figure is an inference, not a confirmed saving:** cloudrift is read-only and never remediates anything, so it cannot know *why* a finding disappeared between the two compared runs (fixed by you, deleted for an unrelated reason, or simply out of this run's `--regions`/`--scanners` scope) — see [ADR-0100](../adr/0100-history-comparison-and-html-report.md).
 
+**`--html`'s chart differs by domain:** `cloud-cost` charts a single line (monthly waste in USD), with a dashed linear-projection point one run past the last real one ("if this trend continues," not a guarantee — needs ≥2 runs), and a "top resource types by waste" list from the latest run's breakdown. `dead-resources`/`resource-security` chart three lines instead — critical/warning/info, the same severity breakdown and colors as the PDF/table reports — with a legend and a matching 3-column table, instead of one aggregate "findings" total; `resource-security` also gets a plain-language risk narrative (no dollar figure — there's no honest way to price a security finding the way AWS list prices exist for waste). The combined report (no `--domain`) additionally leads with a 3-tile executive summary (monthly waste + delta, security risk, dead-resources trend) aimed at a CTO/CEO audience who wants the headline before scrolling into any one domain.
+
 ## `iam-policy` — print the required IAM policy
 
 ```sh

--- a/docs/en/usage.md
+++ b/docs/en/usage.md
@@ -39,14 +39,15 @@ node apps/cli/dist/main.js analyze [options]
 | `--external-id <id>`        | External ID to pass when assuming `--assume-role-arn` (only needed if the role trust policy requires one)     | —                  |
 | `--min-age-days <days>`      | Grace period: resources younger than this many days are not reported (overrides config)                       | `7`                |
 | `--ignore-tag <tag>`         | Resources carrying this tag are excluded from the report (overrides config)                                   | `cloudrift:ignore` |
-| `--pdf [filename]`           | Also write a PDF report to disk (defaults to `cloudrift-report-YYYY-MM-DD.pdf`)                                | —                  |
-| `--json [filename]`          | Also write a JSON report to disk (defaults to `cloudrift-report-YYYY-MM-DD.json`)                              | —                  |
-| `--silent`                   | Suppress all stdout output (banner, report, confirmations) — use with `--pdf`/`--json` for file-only output    | off                |
+| `--pdf [filename]`           | Also write a PDF report to disk (defaults to `reports/AWS_report_YYYY_MM_DD.pdf`)                              | —                  |
+| `--json [filename]`          | Also write a JSON report to disk (defaults to `reports/AWS_report_YYYY_MM_DD.json`)                            | —                  |
+| `--csv [filename]`           | Also write a CSV report to disk (defaults to `reports/AWS_report_YYYY_MM_DD.csv`)                              | —                  |
+| `--silent`                   | Suppress all stdout output (banner, report, confirmations) — use with `--pdf`/`--json`/`--csv` for file-only output | off                |
 | `-h, --help`                 | Show help                                                                                                      | —                  |
 
-> **stdout vs. file artifacts:** `--format` controls what goes to **stdout** (the report itself). `--json` / `--pdf` write **additional files** to disk and are independent of `--format` — by default the chosen `--format` still prints to stdout *in addition to* writing those files (so e.g. `--pdf` alone still shows the table by default). Add `--silent` for file-only output with nothing printed to the terminal. In machine-readable formats (`json`, `markdown`, `csv`) all human messages are routed to stderr, so stdout carries only the report — ideal for piping. Errors and the cost-gate alert always surface on stderr, even with `--silent`.
+> **stdout vs. file artifacts:** `--format` controls what goes to **stdout** (the report itself). `--json` / `--pdf` / `--csv` write **additional files** to disk and are independent of `--format` — by default the chosen `--format` still prints to stdout *in addition to* writing those files (so e.g. `--pdf` alone still shows the table by default). Add `--silent` for file-only output with nothing printed to the terminal. In machine-readable formats (`json`, `markdown`, `csv`) all human messages are routed to stderr, so stdout carries only the report — ideal for piping. Errors and the cost-gate alert always surface on stderr, even with `--silent`.
 >
-> **Flag order with `--pdf`/`--json`:** their filename is an *optional* value (`--pdf [filename]`), so it's only picked up if it immediately follows the flag — `--pdf --silent ./report.pdf` fails ("too many arguments") because `--silent` blocks `--pdf` from seeing the filename, leaving `./report.pdf` with nothing to attach to. Either keep the filename right after the flag (`--pdf ./report.pdf --silent`), or use `=` to make order irrelevant: `--pdf=./report.pdf --silent --format json`.
+> **Flag order with `--pdf`/`--json`/`--csv`:** their filename is an *optional* value (`--pdf [filename]`), so it's only picked up if it immediately follows the flag — `--pdf --silent ./report.pdf` fails ("too many arguments") because `--silent` blocks `--pdf` from seeing the filename, leaving `./report.pdf` with nothing to attach to. Either keep the filename right after the flag (`--pdf ./report.pdf --silent`), or use `=` to make order irrelevant: `--pdf=./report.pdf --silent --format json`.
 >
 > **Choosing which services to scan:** running `analyze` in a real terminal (and outside CI) shows an interactive picker — a checkbox list of every scanner, all pre-selected, so pressing Enter immediately scans everything like before. Deselect what you don't need, or skip the picker entirely with `--scanners <kinds...>` (an explicit list) or `--all-services` (scan everything, no prompt). In CI or whenever stdout isn't a terminal, the picker never appears and every scanner runs by default — automation is never blocked waiting on input.
 
@@ -73,6 +74,9 @@ node apps/cli/dist/main.js analyze --pdf
 
 # Same, but with nothing printed to the terminal — just the file
 node apps/cli/dist/main.js analyze --pdf ./report.pdf --silent
+
+# Export a CSV report (e.g. to open in a spreadsheet)
+node apps/cli/dist/main.js analyze --csv ./report.csv --silent
 
 # Machine-readable output (e.g. to feed a dashboard or CI check)
 node apps/cli/dist/main.js analyze --format json | jq '.totalWasteMonthlyUsd'
@@ -143,6 +147,7 @@ node apps/cli/dist/main.js trend [options]
 | `--refresh-cache` | Bypass the local Cost Explorer cache and re-fetch closed periods from AWS | off |
 | `-y, --yes` | Skip the "this costs $0.01" confirmation | — |
 | `--pdf [filename]` | Also write a PDF report (defaults to `reports/cloudrift-cost-YYYY_MM_DD.pdf`) | — |
+| `--csv [filename]` | Also write a CSV report (defaults to `reports/cloudrift-cost-YYYY_MM_DD.csv`) | — |
 | `--silent` | Suppress all stdout output | off |
 
 **`trend`** — monthly spend over the last N calendar months (including the current partial one), rendered as an ANSI bar chart by default.
@@ -159,6 +164,7 @@ node apps/cli/dist/main.js trend [options]
 | `--refresh-cache` | Bypass the local Cost Explorer cache | off |
 | `-y, --yes` | Skip the billing confirmation | — |
 | `--pdf [filename]` | Also write a PDF report (defaults to `reports/cloudrift-trend-YYYY_MM_DD.pdf`) | — |
+| `--csv [filename]` | Also write a CSV report (defaults to `reports/cloudrift-trend-YYYY_MM_DD.csv`) | — |
 | `--silent` | Suppress all stdout output | off |
 
 **Examples:**
@@ -198,6 +204,7 @@ node apps/cli/dist/main.js dead-resources [options]
 | `--scanners <kinds...>`      | Only run these checks (space-separated, e.g. `ec2-keypair-unused iam-user-inactive`)                           | all checks          |
 | `--format <format>`          | stdout output format: `table`, `json`, or `csv`                                                                | `table`            |
 | `--pdf [filename]`           | Also write a PDF report to disk (defaults to `reports/cloudrift-dead-resources-YYYY_MM_DD.pdf`)                | —                  |
+| `--csv [filename]`           | Also write a CSV report to disk (defaults to `reports/cloudrift-dead-resources-YYYY_MM_DD.csv`)                | —                  |
 | `--silent`                   | Suppress all stdout output (banner, report). Errors still surface.                                              | off                |
 | `-h, --help`                 | Show help                                                                                                       | —                  |
 
@@ -238,6 +245,9 @@ node apps/cli/dist/main.js dead-resources --format json | jq '.findings[] | sele
 
 # PDF report, nothing printed to the terminal
 node apps/cli/dist/main.js dead-resources --pdf ./hygiene.pdf --silent
+
+# CSV report, e.g. to open in a spreadsheet
+node apps/cli/dist/main.js dead-resources --csv ./hygiene.csv --silent
 ```
 
 **IAM permissions:** this command needs `ec2:DescribeKeyPairs`, `ec2:DescribeReservedInstances`, `ec2:DescribeSecurityGroups`, `iam:ListUsers`, `iam:ListAccessKeys`, `iam:GetAccessKeyLastUsed`, `iam:ListPolicies`, `iam:ListRoles`, `logs:DescribeLogGroups`, `acm:ListCertificates`, `route53:ListHostedZones`, `cloudformation:DescribeStacks`, `s3:ListAllMyBuckets`, `s3:ListBucket`, `cloudwatch:DescribeAlarms` in addition to `analyze`'s policy — see [docs/en/iam-permissions.md](iam-permissions.md).
@@ -262,6 +272,7 @@ node apps/cli/dist/main.js resource-security [options]
 | `--scanners <kinds...>`      | Only run these checks (space-separated, e.g. `iam-root-mfa-disabled s3-bucket-public`)                         | all checks          |
 | `--format <format>`          | stdout output format: `table`, `json`, or `csv`                                                                | `table`            |
 | `--pdf [filename]`           | Also write a PDF report to disk (defaults to `reports/cloudrift-resource-security-YYYY_MM_DD.pdf`)             | —                  |
+| `--csv [filename]`           | Also write a CSV report to disk (defaults to `reports/cloudrift-resource-security-YYYY_MM_DD.csv`)             | —                  |
 | `--silent`                   | Suppress all stdout output (banner, report). Errors still surface.                                              | off                |
 | `-h, --help`                 | Show help                                                                                                       | —                  |
 
@@ -303,6 +314,9 @@ node apps/cli/dist/main.js resource-security --format json | jq '.findings[] | s
 
 # PDF report, nothing printed to the terminal
 node apps/cli/dist/main.js resource-security --pdf ./security.pdf --silent
+
+# CSV report, e.g. to open in a spreadsheet
+node apps/cli/dist/main.js resource-security --csv ./security.csv --silent
 ```
 
 **IAM permissions:** this command needs `iam:GetAccountSummary`, `iam:ListMFADevices`, `iam:GetAccountPasswordPolicy`, `s3:GetBucketAcl`, `s3:GetBucketPolicyStatus`, `s3:GetPublicAccessBlock`, `s3:GetBucketEncryption`, `ec2:DescribeSnapshotAttribute`, `cloudtrail:DescribeTrails` in addition to `analyze`'s policy (several other checks reuse actions already granted for `analyze`/`dead-resources`) — see [docs/en/iam-permissions.md](iam-permissions.md).
@@ -345,7 +359,7 @@ node apps/cli/dist/main.js history [options]
 | `--domain <domain>`      | Only show snapshots from this domain: `cloud-cost`, `dead-resources`, or `resource-security` | all domains     |
 | `--limit <n>`             | Max snapshots to show, most recent first                                          | `100`           |
 | `--compare <n>`           | Compare the latest run against the one `n` runs back instead of listing (requires `--domain`) | —               |
-| `--html [filename]`       | Also write a self-contained HTML report with a trend chart (requires `--domain`; defaults to `reports/cloudrift-history-<domain>-YYYY_MM_DD.html`) | —               |
+| `--html [filename]`       | Also write a self-contained HTML report with a trend chart. With `--domain`, charts just that domain (defaults to `reports/cloudrift-history-<domain>-YYYY_MM_DD.html`); without it, stacks all three domains on one page (defaults to `reports/cloudrift-history-YYYY_MM_DD.html`) | —               |
 | `--format <format>`      | stdout output format: `table` or `json`                                            | `table`         |
 | `-h, --help`              | Show help                                                                          | —               |
 
@@ -366,6 +380,9 @@ node apps/cli/dist/main.js history --domain cloud-cost --compare 5
 
 # Self-contained HTML report with a line chart of waste over time
 node apps/cli/dist/main.js history --domain cloud-cost --html
+
+# Combined HTML report: all three domains stacked on one page, one chart each
+node apps/cli/dist/main.js history --html
 ```
 
 **No new AWS permission needed:** `history` makes the same `sts:GetCallerIdentity` call every other command already makes to resolve the account ID (skipped entirely if `--account-id` is passed explicitly) — everything else is a local file read, no AWS API call.

--- a/docs/it/leggimi.md
+++ b/docs/it/leggimi.md
@@ -25,7 +25,7 @@ Preferisci i flag al wizard (script, CI)? Stesso tool, stesso output:
 cloudrift analyze -r us-east-1 eu-west-1 --pdf
 ```
 
-Vedi [Utilizzo](#utilizzo) per l'elenco completo dei flag.
+Vedi [utilizzo.md](./utilizzo.md) per l'elenco completo dei flag.
 
 > ⚠️ **Disclaimer:** cloudrift segnala solo spreco stimato e raccomandazioni — non cancella, modifica o ferma alcuna risorsa AWS. Ogni finding deve essere validato dal tuo team infrastrutturale prima di agire. I maintainer non si assumono alcuna responsabilità per le azioni intraprese sulla base di questo report.
 > **Contatti:** [raffaelevasini@gmail.com](mailto:raffaelevasini@gmail.com) · <a href="https://github.com/elleVas" target="_blank" rel="noopener noreferrer">GitHub</a> · <a href="https://www.linkedin.com/in/raffaele-vasini-87937470/" target="_blank" rel="noopener noreferrer">LinkedIn</a>
@@ -35,7 +35,9 @@ Vedi [Utilizzo](#utilizzo) per l'elenco completo dei flag.
 - [Guida rapida](#guida-rapida)
 - [Cosa rileva](#cosa-rileva)
 - [Confronto e trend di spesa](#confronto-e-trend-di-spesa-cost--trend)
-- [Utilizzo](#utilizzo)
+- [Risorse morte/inutilizzate](#risorse-morteinutilizzate-dead-resources)
+- [Postura di sicurezza](#postura-di-sicurezza-resource-security)
+- [Storico locale delle scansioni](#storico-locale-delle-scansioni-history)
 - [File di configurazione](#file-di-configurazione)
 - [Fonti dei prezzi](#fonti-dei-prezzi)
 - [Uso in CI/CD](#uso-in-cicd)
@@ -211,151 +213,100 @@ cloudrift cost                          # questo mese finora vs. gli stessi gior
 cloudrift trend --months 12             # spesa mensile negli ultimi 12 mesi, grafico a barre ANSI
 ```
 
-> ⚠️ A differenza di ogni scanner sopra (chiamate describe/list gratuite), `cost`/`trend` chiamano **AWS Cost Explorer, che fattura $0.01 a richiesta** — gli unici comandi di cloudrift che possono generare un costo AWS. Entrambi chiedono conferma prima della prima chiamata (saltabile con `-y`/`--yes`); i periodi di fatturazione chiusi vengono cachati su disco così rilanciare lo stesso comando per le stesse date non fattura di nuovo. Vedi [Utilizzo](#utilizzo) per il riferimento completo dei flag.
+> ⚠️ A differenza di ogni scanner sopra (chiamate describe/list gratuite), `cost`/`trend` chiamano **AWS Cost Explorer, che fattura $0.01 a richiesta** — gli unici comandi di cloudrift che possono generare un costo AWS. Entrambi chiedono conferma prima della prima chiamata (saltabile con `-y`/`--yes`); i periodi di fatturazione chiusi vengono cachati su disco così rilanciare lo stesso comando per le stesse date non fattura di nuovo. Vedi [utilizzo.md](./utilizzo.md#cost--trend--confronto-e-trend-di-spesa) per il riferimento completo dei flag.
 
 ---
 
-<details>
-<summary><strong>Utilizzo</strong> — flag, esempi, report PDF, gestione errori parziali, prezzi per regione</summary>
+### Risorse morte/inutilizzate (`dead-resources`)
 
-### Utilizzo
-
-```sh
-node apps/cli/dist/main.js analyze [opzioni]
-```
-
-| Opzione                      | Descrizione                                                                                                          | Default            |
-| ---------------------------- | -------------------------------------------------------------------------------------------------------------------- | ------------------ |
-| `-r, --regions <regioni...>` | Regioni AWS da scansionare                                                                                           | `us-east-1`        |
-| `--format <format>`          | Formato di stdout: `table`, `json` o `markdown` (per CI / commenti PR)                                              | `table`            |
-| `--config <path>`            | Percorso del file di config (default: `cloudrift.config.json` / `.cloudriftrc` nella cwd)                          | auto-rilevato      |
-| `--live-pricing`             | Recupera i prezzi di listino correnti dall'AWS Pricing API (fallback alla tabella statica; i prezzi del config vincono) | off (tabella statica) |
-| `--scanners <kinds...>`      | Esegue solo questi servizi (elenco di resource kind separati da spazio, es. `ebs-volume elastic-ip`); salta il picker interattivo | — |
-| `--all-services`             | Esegue tutti gli scanner senza il picker interattivo                                                                  | on in CI / non-TTY |
-| `--account-id <id>`          | Override dell'account ID (rilevato automaticamente via `sts:GetCallerIdentity` se omesso)                            | auto-rilevato      |
-| `--min-age-days <giorni>`    | Periodo di grazia: le risorse più giovani di N giorni non vengono segnalate (ha precedenza sul config)              | `7`                |
-| `--ignore-tag <tag>`         | Le risorse con questo tag vengono escluse dal report (ha precedenza sul config)                                     | `cloudrift:ignore` |
-| `--pdf [filename]`           | Scrive anche un report PDF su disco (default `cloudrift-report-YYYY-MM-DD.pdf`)                                      | —                  |
-| `--json [filename]`          | Scrive anche un report JSON su disco (default `cloudrift-report-YYYY-MM-DD.json`)                                   | —                  |
-| `--silent`                   | Sopprime tutto l'output su stdout (banner, report, conferme) — usalo con `--pdf`/`--json` per ottenere solo il file | off                |
-| `-h, --help`                 | Mostra l'help                                                                                                        | —                  |
-
-> **stdout vs. file:** `--format` controlla cosa va su **stdout** (il report). `--json` / `--pdf` scrivono **file aggiuntivi** su disco, indipendenti da `--format` — di default il `--format` scelto continua comunque a essere stampato su stdout *in aggiunta* alla scrittura di quei file (quindi es. `--pdf` da solo mostra comunque la tabella). Aggiungi `--silent` per ottenere solo il file, senza nulla stampato a terminale. Nei formati machine-readable (`json`, `markdown`) tutti i messaggi umani vanno su stderr, così su stdout resta solo il report — ideale per il piping. Errori e l'alert della soglia di costo vanno sempre su stderr, anche con `--silent`.
->
-> **Ordine dei flag con `--pdf`/`--json`:** il filename è un valore *opzionale* (`--pdf [filename]`), quindi viene raccolto solo se segue immediatamente il flag — `--pdf --silent ./report.pdf` fallisce ("too many arguments") perché `--silent` impedisce a `--pdf` di vedere il filename, lasciando `./report.pdf` senza nulla a cui agganciarsi. Tieni il filename subito dopo il flag (`--pdf ./report.pdf --silent`), oppure usa `=` per rendere l'ordine irrilevante: `--pdf=./report.pdf --silent --format json`.
->
-> **Scegliere quali servizi scansionare:** lanciando `analyze` in un vero terminale (e fuori da CI) appare un picker interattivo — una checklist di tutti gli scanner, tutti pre-selezionati, così premere Invio scansiona tutto come prima. Deseleziona quello che non ti serve, oppure salta del tutto il picker con `--scanners <kinds...>` (elenco esplicito) o `--all-services` (scansiona tutto, nessun prompt). In CI o ogni volta che stdout non è un terminale, il picker non appare mai e viene eseguito ogni scanner di default — l'automazione non resta mai bloccata in attesa di input.
-
-**Esempi:**
+Uno scan di hygiene separato, deliberatamente fuori dal modello cost-waste qui sopra: cose lasciate morte o inutilizzate nell'account con **costo $0** (quindi invisibili ai criteri cost-based di `analyze`) ma comunque da ripulire o rivedere.
 
 ```sh
-# Scansione nella regione di default (us-east-1)
-node apps/cli/dist/main.js analyze
-
-# Più regioni contemporaneamente
-node apps/cli/dist/main.js analyze -r us-east-1 eu-west-1 ap-southeast-1
-
-# Disattiva il periodo di grazia (segnala risorse di qualsiasi età)
-node apps/cli/dist/main.js analyze --min-age-days 0
-
-# Scansiona solo EBS volumes ed Elastic IP, saltando il picker interattivo
-node apps/cli/dist/main.js analyze --scanners ebs-volume elastic-ip
-
-# Scansiona tutto senza il picker interattivo (es. in uno script lanciato da terminale)
-node apps/cli/dist/main.js analyze --all-services
-
-# Esporta un report PDF con nome automatico (reports/AWS_report_YYYY_MM_DD.pdf)
-node apps/cli/dist/main.js analyze --pdf
-
-# Come sopra, ma senza nulla stampato a terminale — solo il file
-node apps/cli/dist/main.js analyze --pdf ./report.pdf --silent
-
-# Output machine-readable (es. per una dashboard o un check CI)
-node apps/cli/dist/main.js analyze --format json | jq '.totalWasteMonthlyUsd'
-
-# Filtra i findings con jq (findings è un array flat, componibile)
-node apps/cli/dist/main.js analyze --format json | jq '.findings[] | select(.category=="waste")'
-
-# Report Markdown (es. commento PR / step summary su GitHub Actions)
-node apps/cli/dist/main.js analyze --format markdown >> "$GITHUB_STEP_SUMMARY"
+cloudrift dead-resources                              # ogni check, us-east-1
+cloudrift dead-resources -r us-east-1 eu-west-1        # più regioni (solo i check regionali — vedi sotto)
+cloudrift dead-resources --scanners iam-user-inactive  # un solo check
 ```
 
-**Report PDF:**
+| Check | Cosa viene segnalato | Severity | Soglia di default |
+| --- | --- | --- | --- |
+| **Key pair EC2 (inutilizzate)** | Non referenziata da nessuna istanza running/stopped | info | Periodo di grazia di 7 giorni (`--min-age-days`) |
+| **Reserved Instance EC2 (in scadenza)** | Attiva, termine entro la soglia | warning | 30 giorni |
+| **Security group EC2 (inutilizzati)** | Non referenziato da nessuna network interface (il gruppo `default` è escluso) | info | nessuna — l'API non espone una data di creazione |
+| **Log group CloudWatch (vuoti)** | Non ha mai memorizzato eventi | info | Periodo di grazia di 7 giorni (`--min-age-days`) |
+| **Certificati ACM (inutilizzati)** | Non attaccati a nessuna risorsa AWS | info | Periodo di grazia di 7 giorni (`--min-age-days`) |
+| **Stack CloudFormation (bloccati)** | `CREATE_FAILED`/`ROLLBACK_FAILED`/`DELETE_FAILED`/`UPDATE_ROLLBACK_FAILED` | critical | Periodo di grazia di 7 giorni (`--min-age-days`) |
+| **Alarm CloudWatch (orfani)** | Bloccato in `INSUFFICIENT_DATA` | warning | Periodo di grazia di 7 giorni (`--min-age-days`) |
+| **Utenti IAM (inattivi)** | Nessun login console o uso di access key | warning | 90 giorni (o mai, oltre il periodo di grazia di 7 giorni dalla creazione) |
+| **Policy IAM (non collegate)** | Customer-managed, zero attachment (le policy AWS-managed sono escluse — non si possono comunque eliminare) | info | Periodo di grazia di 7 giorni (`--min-age-days`) |
+| **Ruoli IAM (inutilizzati)** | Mai assunti, o non entro la soglia (i ruoli service-linked sono esclusi) | warning | 90 giorni (o mai, oltre il periodo di grazia di 7 giorni dalla creazione) |
+| **Access key IAM (obsolete)** | Chiave attiva non ruotata entro la soglia | warning | 90 giorni |
+| **Hosted zone Route53 (vuote)** | Nessun record oltre alla coppia NS/SOA di default | info | nessuna — l'API non espone una data di creazione |
+| **Bucket S3 (vuoti)** | Zero oggetti | info | Periodo di grazia di 7 giorni (`--min-age-days`) |
+| **Instance profile IAM (non collegati)** | Non attaccati a nessuna istanza EC2 in nessuna regione AWS | info | Periodo di grazia di 7 giorni (`--min-age-days`) |
+| **Topic SNS (senza subscription)** | Zero subscription | info | nessuna — l'API non espone una data di creazione |
+| **Regole EventBridge (senza target)** | Nessun target configurato (solo default event bus) | info | nessuna — l'API non espone una data di creazione |
+| **Repository ECR (vuoti)** | Zero immagini | info | Periodo di grazia di 7 giorni (`--min-age-days`) |
+| **State machine Step Functions (mai eseguite)** | Tipo STANDARD, zero esecuzioni (EXPRESS escluso) | info | Periodo di grazia di 7 giorni (`--min-age-days`) |
 
-Il flag `--pdf` genera un PDF in aggiunta all'output console (aggiungi `--silent` per sopprimere l'output console e ottenere solo il file). Il report contiene:
+**IAM, Route53 e (per questo comando) S3 sono servizi AWS globali**: quei sette check girano una sola volta per scansione, indipendentemente da quante `--regions` passi, mai una volta per regione — gli altri undici check sono genuinamente regionali. Vedi [ADR-0078](../adr/0078-dead-resources-parallel-domain.md)/[ADR-0079](../adr/0079-dead-resources-global-scope-scanners.md) (in inglese) per il razionale di questa separazione. `--format json`/`csv`/`--pdf` per output machine-readable/condivisibile. Vedi [utilizzo.md](./utilizzo.md#dead-resources--hygiene-per-risorse-morteinutilizzate) per il riferimento completo dei flag.
 
-- **Executive summary** — totale spreco mensile e annuale, numero di risorse, breakdown per tipo
-- **Top raccomandazioni** — fino a 8 voci ordinate per impatto mensile, con risparmio annuale stimato
-- **Pagine di dettaglio** — una tabella per ogni tipo di risorsa trovata (EBS, Elastic IP, RDS, Load Balancer, EC2, Snapshot, NAT Gateway)
-- **Scan warnings** — elencati se alcuni tipi di risorsa non hanno potuto essere scansionati
+---
+
+### Postura di sicurezza (`resource-security`)
+
+Un terzo dominio, separato: configurazioni rischiose su risorse effettivamente in uso (a differenza di `dead-resources` sopra, che trova risorse abbandonate) — igiene IAM/account, esposizione di rete, storage pubblico, cifratura a riposo, visibilità/audit. Tutti e 14 i check sono di sola lettura (`Describe*`/`Get*`/`List*`). Vedi [ADR-0081](../adr/0081-resource-security-parallel-domain.md) (in inglese).
 
 ```sh
-# Dopo aver eseguito con --pdf vedrai:
-#   Generating PDF report... saved to /path/to/reports/AWS_report_2026_06_09.pdf
+cloudrift resource-security                                    # ogni check, us-east-1
+cloudrift resource-security -r us-east-1 eu-west-1              # più regioni (solo i check regionali — vedi sotto)
+cloudrift resource-security --scanners iam-root-mfa-disabled    # un solo check
 ```
 
-**Output di esempio:**
-
-```
-  Scanning us-east-1 (account 123456789012) for wasted cloud resources...
-
-  EBS Volumes — Unattached
-  ┌────────────────────┬───────────┬────────┬──────┬────────────┬────────────┐
-  │ Volume ID          │ Region    │ Size   │ Type │ Created    │ Est. Cost  │
-  ├────────────────────┼───────────┼────────┼──────┼────────────┼────────────┤
-  │ vol-0abc123def456  │ us-east-1 │ 500 GB │ gp3  │ 2025-01-15 │ $40.00/mo  │
-  └────────────────────┴───────────┴────────┴──────┴────────────┴────────────┘
-
-  Total estimated waste: $40.00/month
-```
-
-**Comportamento in caso di errori parziali:**
-
-Se la scansione di un tipo di risorsa fallisce (es. permessi mancanti su CloudWatch per i NAT Gateway), il tool:
-
-- restituisce comunque tutti gli altri risultati disponibili
-- mostra una sezione "Scan Warnings" con i dettagli dell'errore
-- indica il totale come `(incomplete — see warnings above)`
-
-```
-  ⚠ Scan Warnings
-  • NAT Gateways: Access denied to CloudWatch metrics
-
-  Total estimated waste: $56.20/month (incomplete — see warnings above)
-```
-
-**Prezzi per regione:**
-
-I prezzi sono per-regione (file `prices.json` nell'infrastruttura). Regioni supportate con prezzi specifici: `us-east-1`, `us-west-2`, `eu-west-1`, `eu-central-1`, `ap-southeast-1`, `ap-northeast-1`. Per le altre regioni viene usato il prezzo di default (us-east-1).
-
-#### `cost` / `trend` — confronto e trend di spesa
-
-> ⚠️ Chiamano AWS Cost Explorer, che fattura **$0.01 a richiesta** — gli unici comandi di cloudrift che possono generare un costo AWS. Chiedono conferma prima della prima chiamata a meno di `-y`/`--yes`, `--silent`, o esecuzione fuori da un TTY/in CI. I periodi chiusi vengono cachati su disco (`~/.cloudrift/cache/cost-explorer/`). Nessuno dei due comandi ha un flag `--regions` — Cost Explorer è un endpoint globale unico.
-
-| Opzione (`cost`) | Descrizione | Default |
+| Check | Cosa viene segnalato | Severity |
 | --- | --- | --- |
-| `--account-id <id>` | Override account ID | auto-rilevato |
-| `--format <format>` | `table` o `json` | `table` |
-| `--fail-on-increase <pct>` | Esce con codice 2 se la spesa è aumentata più di questa percentuale | off |
-| `--refresh-cache` | Ignora la cache locale | off |
-| `-y, --yes` | Salta la conferma di fatturazione | — |
-| `--pdf [filename]` | Scrive anche un PDF | — |
+| **Account root (MFA disabilitata)** | `iam:GetAccountSummary` → `AccountMFAEnabled` | critical |
+| **Utenti IAM (MFA disabilitata)** | Nessun dispositivo MFA registrato | warning |
+| **Access key IAM (rotazione in ritardo)** | Chiave attiva più vecchia di 90 giorni (CIS 1.14) | warning |
+| **Account root (access key attiva)** | `AccountAccessKeysPresent` | critical |
+| **Password policy dell'account (debole o assente)** | Sotto la baseline CIS, o assente | warning |
+| **Security group EC2 (ingress aperto su porte sensibili)** | `0.0.0.0/0`/`::/0` su porte SSH/RDP/database | critical |
+| **Security group EC2 di default (permissivi)** | Il security group default della VPC ha ancora regole | warning |
+| **Bucket S3 (pubblici)** | Pubblici via ACL e/o bucket policy | critical |
+| **Snapshot EC2 (pubblici)** | `createVolumePermission` concesso a `all` | critical |
+| **Volumi EBS (non cifrati)** | Non cifrati a riposo | warning |
+| **Istanze RDS (non cifrate)** | Storage non cifrato a riposo | warning |
+| **Bucket S3 (senza cifratura di default)** | Nessuna cifratura lato server di default | warning |
+| **Istanze RDS (pubblicamente accessibili)** | Raggiungibili dall'esterno della VPC | critical |
+| **CloudTrail (nessun trail multi-regione)** | Nessun trail con logging multi-regione | warning |
 
-| Opzione (`trend`) | Descrizione | Default |
-| --- | --- | --- |
-| `--months <n>` | Mesi solari da mostrare (1–36) | `6` |
-| `--services <nomi...>` | Limita a questi servizi (es. `ec2 s3`) | tutti |
-| `--format <format>` | `table` (grafico ANSI) o `json` | `table` |
-| `--refresh-cache` / `-y, --yes` / `--pdf [filename]` | Come `cost` | — |
+**IAM, S3 (elenco bucket) e CloudTrail sono trattati come globali per questo comando**: quegli otto check girano una sola volta per scansione, indipendentemente da quante `--regions` passi, mai una volta per regione — gli altri sei check sono genuinamente regionali. `--format json`/`csv`/`--pdf` per output machine-readable/condivisibile, nessun `--min-age-days` (una configurazione di sicurezza errata è un rischio dal momento in cui esiste). Vedi [utilizzo.md](./utilizzo.md#resource-security--scansione-della-postura-di-sicurezza) per il riferimento completo dei flag.
+
+---
+
+### Storico locale delle scansioni (`history`)
+
+`analyze`, `dead-resources` e `resource-security` aggiungono ciascuno uno snapshot completo del proprio report a un file SQLite locale per-account (`~/.cloudrift/trends/<account-id>.db`) ad ogni esecuzione — in modalità best-effort, senza mai bloccare la scansione, niente viene mai caricato da nessuna parte. `history` lo rilegge:
 
 ```sh
-node apps/cli/dist/main.js cost --fail-on-increase 20 --format json
-node apps/cli/dist/main.js trend --months 12 --services ec2 s3 --yes
+cloudrift history                              # ogni snapshot registrato, dal più recente
+cloudrift history --domain cloud-cost --limit 10
 ```
 
-Riferimento completo, comportamento della cache e dettagli sulla conferma di fatturazione: [docs/en/usage.md](../en/usage.md#cost--trend--spend-comparison-and-monthly-trend) (in inglese) o [utilizzo.md](./utilizzo.md#cost--trend--confronto-e-trend-di-spesa).
+Vedi [ADR-0099](../adr/0099-local-trend-store.md) (in inglese) e [utilizzo.md](./utilizzo.md#history--storico-locale-delle-scansioni) per il riferimento completo dei flag.
 
-</details>
+---
+
+### Usalo come server MCP (`mcp`)
+
+Esegui cloudrift come server [MCP](https://modelcontextprotocol.io) locale via stdio, così un agente AI — Claude Code, Kiro, VS Code Copilot Chat (Agent mode) — può chiamare direttamente `analyze_cloudrift`, `get_resource_types` e `get_required_iam_permissions` invece che tu lanci la CLI a mano. Eredita le stesse credenziali AWS di ogni altro comando; vedi [ADR-0082](../adr/0082-mcp-server-second-input-adapter.md).
+
+```sh
+cloudrift mcp
+```
+
+Vedi [server-mcp.md](server-mcp.md) per la configurazione dei client (Kiro, VS Code, Claude Code) e [utilizzo.md](utilizzo.md#mcp--esegui-cloudrift-come-server-mcp-locale) per l'interruttore `CLOUDRIFT_DISABLE_MCP`.
+
+---
 
 <details>
 <summary><strong>File di configurazione</strong> — campi di <code>cloudrift.config.json</code>, override, tuning falsi positivi</summary>
@@ -579,18 +530,6 @@ Il principal AWS deve avere le seguenti permission in sola lettura:
 <details>
 <summary><strong>Sviluppo</strong> — modalità watch, test per libreria, lint, typecheck</summary>
 
-### Usalo come server MCP (`mcp`)
-
-Esegui cloudrift come server [MCP](https://modelcontextprotocol.io) locale via stdio, così un agente AI — Claude Code, Kiro, VS Code Copilot Chat (Agent mode) — può chiamare direttamente `analyze_cloudrift`, `get_resource_types` e `get_required_iam_permissions` invece che tu lanci la CLI a mano. Eredita le stesse credenziali AWS di ogni altro comando; vedi [ADR-0082](../adr/0082-mcp-server-second-input-adapter.md).
-
-```sh
-cloudrift mcp
-```
-
-Vedi [server-mcp.md](server-mcp.md) per la configurazione dei client (Kiro, VS Code, Claude Code) e [utilizzo.md](utilizzo.md#mcp--esegui-cloudrift-come-server-mcp-locale) per l'interruttore `CLOUDRIFT_DISABLE_MCP`.
-
----
-
 ### Sviluppo
 
 ```sh
@@ -631,6 +570,7 @@ Tutta la documentazione è nella cartella [`docs/`](../) — italiano in [`docs/
 
 | File (IT)                                                | Contenuto                                                         |
 | --------------------------------------------------------- | ----------------------------------------------------------------- |
+| [utilizzo.md](utilizzo.md)                                 | Flag CLI, esempi, report PDF, gestione errori parziali            |
 | [architettura.md](architettura.md)                        | Scelte architetturali, layer del sistema, percorso multi-cloud    |
 | [scelte-tecniche.md](scelte-tecniche.md)                   | Nx, pnpm, TypeScript, AWS SDK v3, Result pattern, jest             |
 | [funzionamento.md](funzionamento.md)                       | Flusso di esecuzione end-to-end, spiegazione del codice           |

--- a/docs/it/leggimi.md
+++ b/docs/it/leggimi.md
@@ -290,9 +290,10 @@ cloudrift resource-security --scanners iam-root-mfa-disabled    # un solo check
 ```sh
 cloudrift history                              # ogni snapshot registrato, dal più recente
 cloudrift history --domain cloud-cost --limit 10
+cloudrift history --html                       # report HTML autocontenuto, tutti e 3 i domini impilati su una pagina
 ```
 
-Vedi [ADR-0099](../adr/0099-local-trend-store.md) (in inglese) e [utilizzo.md](./utilizzo.md#history--storico-locale-delle-scansioni) per il riferimento completo dei flag.
+Vedi [ADR-0099](../adr/0099-local-trend-store.md)/[ADR-0100](../adr/0100-history-comparison-and-html-report.md) (in inglese) e [utilizzo.md](./utilizzo.md#history--storico-locale-delle-scansioni) per il riferimento completo dei flag (incluso `--compare` e `--html` per singolo dominio).
 
 ---
 

--- a/docs/it/leggimi.md
+++ b/docs/it/leggimi.md
@@ -293,6 +293,8 @@ cloudrift history --domain cloud-cost --limit 10
 cloudrift history --html                       # report HTML autocontenuto, tutti e 3 i domini impilati su una pagina
 ```
 
+Il grafico di `--html` cambia in base al dominio: `cloud-cost` è una singola linea di spreco in dollari (più una previsione lineare e una lista "top resource type per spreco"); `dead-resources`/`resource-security` mostrano critical/warning/info come tre linee separate con legenda, la stessa scomposizione per severity di PDF/tabella (`resource-security` include anche una narrativa di rischio in linguaggio semplice, deliberatamente senza cifre in $). Il report combinato apre con 3 stat tile esecutivi pensati per un pubblico CTO/CEO.
+
 Vedi [ADR-0099](../adr/0099-local-trend-store.md)/[ADR-0100](../adr/0100-history-comparison-and-html-report.md) (in inglese) e [utilizzo.md](./utilizzo.md#history--storico-locale-delle-scansioni) per il riferimento completo dei flag (incluso `--compare` e `--html` per singolo dominio).
 
 ---

--- a/docs/it/utilizzo.md
+++ b/docs/it/utilizzo.md
@@ -406,6 +406,8 @@ node apps/cli/dist/main.js history --html
 
 **Lo "spreco presumibilmente risolto" di `--compare` è un'inferenza, non un risparmio confermato:** cloudrift è read-only e non rimedia mai nulla, quindi non può sapere *perché* un finding è sparito tra le due esecuzioni confrontate (l'hai sistemato tu, la risorsa è stata eliminata per un motivo non collegato, o era semplicemente fuori dallo scope di `--regions`/`--scanners` di questa run) — vedi [ADR-0100](../adr/0100-history-comparison-and-html-report.md) (in inglese).
 
+**Il grafico di `--html` cambia in base al dominio:** `cloud-cost` mostra una singola linea (spreco mensile in USD), con un punto di previsione lineare tratteggiato una run oltre l'ultima reale ("se il trend continua", non una garanzia — servono almeno 2 run), e una lista "top resource type per spreco" dall'ultima run. `dead-resources`/`resource-security` mostrano invece tre linee — critical/warning/info, la stessa scomposizione per severity e gli stessi colori dei report PDF/tabella — con legenda e una tabella a 3 colonne corrispondente, invece di un unico totale aggregato di "findings"; `resource-security` include anche una narrativa di rischio in linguaggio semplice (nessuna cifra in $ — non esiste un modo onesto di quantificare un finding di sicurezza come invece esistono i prezzi di listino AWS per lo spreco). Il report combinato (senza `--domain`) apre inoltre con 3 stat tile esecutivi (spreco mensile + delta, rischio security, trend dead-resources) pensati per un pubblico CTO/CEO che vuole il titolo prima di scendere nel dettaglio di un singolo dominio.
+
 ## `iam-policy` — stampa la policy IAM richiesta
 
 ```sh

--- a/docs/it/utilizzo.md
+++ b/docs/it/utilizzo.md
@@ -29,7 +29,7 @@ node apps/cli/dist/main.js analyze [opzioni]
 | Opzione                      | Descrizione                                                                                                          | Default            |
 | ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ |
 | `-r, --regions <regioni...>` | Regioni AWS da scansionare                                                                                           | `us-east-1`        |
-| `--format <format>`          | Formato di stdout: `table`, `json` o `markdown` (per CI / commenti PR)                                              | `table`            |
+| `--format <format>`          | Formato di stdout: `table`, `json`, `markdown` (per CI / commenti PR) o `csv`                                       | `table`            |
 | `--config <path>`            | Percorso del file di config (default: `cloudrift.config.json` / `.cloudriftrc` nella cwd)                          | auto-rilevato      |
 | `--live-pricing`             | Recupera i prezzi di listino correnti dall'AWS Pricing API (fallback alla tabella statica; i prezzi del config vincono) | off (tabella statica) |
 | `--scanners <kinds...>`      | Esegue solo questi servizi (elenco di resource kind separati da spazio, es. `ebs-volume elastic-ip`); salta il picker interattivo | — |
@@ -39,14 +39,15 @@ node apps/cli/dist/main.js analyze [opzioni]
 | `--external-id <id>`        | External ID da passare quando si assume `--assume-role-arn` (serve solo se la trust policy del ruolo lo richiede)   | —                  |
 | `--min-age-days <giorni>`    | Periodo di grazia: le risorse più giovani di N giorni non vengono segnalate (ha precedenza sul config)              | `7`                |
 | `--ignore-tag <tag>`         | Le risorse con questo tag vengono escluse dal report (ha precedenza sul config)                                     | `cloudrift:ignore` |
-| `--pdf [filename]`           | Scrive anche un report PDF su disco (default `cloudrift-report-YYYY-MM-DD.pdf`)                                      | —                  |
-| `--json [filename]`          | Scrive anche un report JSON su disco (default `cloudrift-report-YYYY-MM-DD.json`)                                   | —                  |
-| `--silent`                   | Sopprime tutto l'output su stdout (banner, report, conferme) — usalo con `--pdf`/`--json` per ottenere solo il file | off                |
+| `--pdf [filename]`           | Scrive anche un report PDF su disco (default `reports/AWS_report_YYYY_MM_DD.pdf`)                                    | —                  |
+| `--json [filename]`          | Scrive anche un report JSON su disco (default `reports/AWS_report_YYYY_MM_DD.json`)                                 | —                  |
+| `--csv [filename]`           | Scrive anche un report CSV su disco (default `reports/AWS_report_YYYY_MM_DD.csv`)                                   | —                  |
+| `--silent`                   | Sopprime tutto l'output su stdout (banner, report, conferme) — usalo con `--pdf`/`--json`/`--csv` per ottenere solo il file | off                |
 | `-h, --help`                 | Mostra l'help                                                                                                        | —                  |
 
-> **stdout vs. file:** `--format` controlla cosa va su **stdout** (il report). `--json` / `--pdf` scrivono **file aggiuntivi** su disco, indipendenti da `--format` — di default il `--format` scelto continua comunque a essere stampato su stdout *in aggiunta* alla scrittura di quei file (quindi es. `--pdf` da solo mostra comunque la tabella). Aggiungi `--silent` per ottenere solo il file, senza nulla stampato a terminale. Nei formati machine-readable (`json`, `markdown`) tutti i messaggi umani vanno su stderr, così su stdout resta solo il report — ideale per il piping. Errori e l'alert della soglia di costo vanno sempre su stderr, anche con `--silent`.
+> **stdout vs. file:** `--format` controlla cosa va su **stdout** (il report). `--json` / `--pdf` / `--csv` scrivono **file aggiuntivi** su disco, indipendenti da `--format` — di default il `--format` scelto continua comunque a essere stampato su stdout *in aggiunta* alla scrittura di quei file (quindi es. `--pdf` da solo mostra comunque la tabella). Aggiungi `--silent` per ottenere solo il file, senza nulla stampato a terminale. Nei formati machine-readable (`json`, `markdown`, `csv`) tutti i messaggi umani vanno su stderr, così su stdout resta solo il report — ideale per il piping. Errori e l'alert della soglia di costo vanno sempre su stderr, anche con `--silent`.
 >
-> **Ordine dei flag con `--pdf`/`--json`:** il filename è un valore *opzionale* (`--pdf [filename]`), quindi viene raccolto solo se segue immediatamente il flag — `--pdf --silent ./report.pdf` fallisce ("too many arguments") perché `--silent` impedisce a `--pdf` di vedere il filename, lasciando `./report.pdf` senza nulla a cui agganciarsi. Tieni il filename subito dopo il flag (`--pdf ./report.pdf --silent`), oppure usa `=` per rendere l'ordine irrilevante: `--pdf=./report.pdf --silent --format json`.
+> **Ordine dei flag con `--pdf`/`--json`/`--csv`:** il filename è un valore *opzionale* (`--pdf [filename]`), quindi viene raccolto solo se segue immediatamente il flag — `--pdf --silent ./report.pdf` fallisce ("too many arguments") perché `--silent` impedisce a `--pdf` di vedere il filename, lasciando `./report.pdf` senza nulla a cui agganciarsi. Tieni il filename subito dopo il flag (`--pdf ./report.pdf --silent`), oppure usa `=` per rendere l'ordine irrilevante: `--pdf=./report.pdf --silent --format json`.
 >
 > **Scegliere quali servizi scansionare:** lanciando `analyze` in un vero terminale (e fuori da CI) appare un picker interattivo — una checklist di tutti gli scanner, tutti pre-selezionati, così premere Invio scansiona tutto come prima. Deseleziona quello che non ti serve, oppure salta del tutto il picker con `--scanners <kinds...>` (elenco esplicito) o `--all-services` (scansiona tutto, nessun prompt). In CI o ogni volta che stdout non è un terminale, il picker non appare mai e viene eseguito ogni scanner di default — l'automazione non resta mai bloccata in attesa di input.
 
@@ -73,6 +74,9 @@ node apps/cli/dist/main.js analyze --pdf
 
 # Come sopra, ma senza nulla stampato a terminale — solo il file
 node apps/cli/dist/main.js analyze --pdf ./report.pdf --silent
+
+# Esporta un report CSV (es. da aprire in un foglio di calcolo)
+node apps/cli/dist/main.js analyze --csv ./report.csv --silent
 
 # Output machine-readable (es. per una dashboard o un check CI)
 node apps/cli/dist/main.js analyze --format json | jq '.totalWasteMonthlyUsd'
@@ -153,11 +157,12 @@ node apps/cli/dist/main.js trend [opzioni]
 | `--assume-role-arn <arn>` | Assume questo ruolo IAM via STS prima di scansionare, per l'accesso cross-account | — |
 | `--external-id <id>` | External ID da passare quando si assume `--assume-role-arn` (serve solo se la trust policy del ruolo lo richiede) | — |
 | `--config <path>` | Percorso del file di config | auto-rilevato |
-| `--format <format>` | Formato di stdout: `table` o `json` | `table` |
+| `--format <format>` | Formato di stdout: `table`, `json` o `csv` | `table` |
 | `--fail-on-increase <pct>` | Esce con codice 2 se la spesa è aumentata più di questa percentuale rispetto al periodo precedente (ha precedenza su `config.costIncreaseAlertPercent`) | off |
 | `--refresh-cache` | Ignora la cache locale di Cost Explorer e rifà il fetch dei periodi chiusi da AWS | off |
 | `-y, --yes` | Salta la conferma "questo costa $0.01" | — |
 | `--pdf [filename]` | Scrive anche un report PDF (default `reports/cloudrift-cost-YYYY_MM_DD.pdf`) | — |
+| `--csv [filename]` | Scrive anche un report CSV (default `reports/cloudrift-cost-YYYY_MM_DD.csv`) | — |
 | `--silent` | Sopprime tutto l'output su stdout | off |
 
 **`trend`** — spesa mensile negli ultimi N mesi solari (incluso quello corrente, parziale), mostrata come grafico a barre ANSI di default.
@@ -170,10 +175,11 @@ node apps/cli/dist/main.js trend [opzioni]
 | `--config <path>` | Percorso del file di config | auto-rilevato |
 | `--months <n>` | Numero di mesi solari da mostrare (1–36) | `6` |
 | `--services <nomi...>` | Limita a questi servizi (scorciatoie tipo `ec2 s3 rds`, oppure il nome esatto usato da Cost Explorer) | tutti i servizi |
-| `--format <format>` | Formato di stdout: `table` (grafico a barre ANSI) o `json` | `table` |
+| `--format <format>` | Formato di stdout: `table` (grafico a barre ANSI), `json` o `csv` | `table` |
 | `--refresh-cache` | Ignora la cache locale di Cost Explorer | off |
 | `-y, --yes` | Salta la conferma di fatturazione | — |
 | `--pdf [filename]` | Scrive anche un report PDF (default `reports/cloudrift-trend-YYYY_MM_DD.pdf`) | — |
+| `--csv [filename]` | Scrive anche un report CSV (default `reports/cloudrift-trend-YYYY_MM_DD.csv`) | — |
 | `--silent` | Sopprime tutto l'output su stdout | off |
 
 **Esempi:**
@@ -211,8 +217,9 @@ node apps/cli/dist/main.js dead-resources [opzioni]
 | `--min-age-days <giorni>`    | Periodo di grazia: le risorse più giovani di N giorni non vengono segnalate (`ec2-ri-expiring-soon` non lo usa — vedi sotto) | `7` |
 | `--ignore-tag <tag>`         | Le risorse con questo tag vengono escluse dal report                                                            | `cloudrift:ignore` |
 | `--scanners <kinds...>`      | Esegue solo questi check (separati da spazio, es. `ec2-keypair-unused iam-user-inactive`)                       | tutti i check       |
-| `--format <format>`          | Formato di stdout: `table` o `json`                                                                             | `table`            |
+| `--format <format>`          | Formato di stdout: `table`, `json` o `csv`                                                                       | `table`            |
 | `--pdf [filename]`           | Scrive anche un report PDF su disco (default `reports/cloudrift-dead-resources-YYYY_MM_DD.pdf`)                | —                  |
+| `--csv [filename]`           | Scrive anche un report CSV su disco (default `reports/cloudrift-dead-resources-YYYY_MM_DD.csv`)                | —                  |
 | `--silent`                   | Sopprime tutto l'output su stdout (banner, report). Gli errori restano visibili.                                | off                |
 | `-h, --help`                 | Mostra l'help                                                                                                    | —                  |
 
@@ -253,6 +260,9 @@ node apps/cli/dist/main.js dead-resources --format json | jq '.findings[] | sele
 
 # Report PDF, nulla stampato a terminale
 node apps/cli/dist/main.js dead-resources --pdf ./hygiene.pdf --silent
+
+# Report CSV, es. da aprire in un foglio di calcolo
+node apps/cli/dist/main.js dead-resources --csv ./hygiene.csv --silent
 ```
 
 **Permessi IAM:** questo comando richiede `ec2:DescribeKeyPairs`, `ec2:DescribeReservedInstances`, `ec2:DescribeSecurityGroups`, `iam:ListUsers`, `iam:ListAccessKeys`, `iam:GetAccessKeyLastUsed`, `iam:ListPolicies`, `iam:ListRoles`, `logs:DescribeLogGroups`, `acm:ListCertificates`, `route53:ListHostedZones`, `cloudformation:DescribeStacks`, `s3:ListAllMyBuckets`, `s3:ListBucket`, `cloudwatch:DescribeAlarms` in aggiunta alla policy di `analyze` — vedi [docs/it/permessi-iam.md](permessi-iam.md).
@@ -275,8 +285,9 @@ node apps/cli/dist/main.js resource-security [opzioni]
 | `--external-id <id>`        | External ID da passare quando si assume `--assume-role-arn` (serve solo se la trust policy del ruolo lo richiede) | — |
 | `--ignore-tag <tag>`         | Le risorse con questo tag sono escluse dal report                                                              | `cloudrift:ignore` |
 | `--scanners <kinds...>`      | Esegue solo questi check (separati da spazio, es. `iam-root-mfa-disabled s3-bucket-public`)                    | tutti i check       |
-| `--format <format>`          | Formato di output su stdout: `table` o `json`                                                                  | `table`            |
+| `--format <format>`          | Formato di output su stdout: `table`, `json` o `csv`                                                             | `table`            |
 | `--pdf [filename]`           | Scrive anche un report PDF su disco (default `reports/cloudrift-resource-security-YYYY_MM_DD.pdf`)             | —                  |
+| `--csv [filename]`           | Scrive anche un report CSV su disco (default `reports/cloudrift-resource-security-YYYY_MM_DD.csv`)             | —                  |
 | `--silent`                   | Sopprime tutto l'output stdout (banner, report). Gli errori restano visibili.                                   | off                |
 | `-h, --help`                 | Mostra l'help                                                                                                   | —                  |
 
@@ -318,6 +329,9 @@ node apps/cli/dist/main.js resource-security --format json | jq '.findings[] | s
 
 # Report PDF, niente stampato a terminale
 node apps/cli/dist/main.js resource-security --pdf ./sicurezza.pdf --silent
+
+# Report CSV, es. da aprire in un foglio di calcolo
+node apps/cli/dist/main.js resource-security --csv ./sicurezza.csv --silent
 ```
 
 **Permessi IAM:** questo comando richiede `iam:GetAccountSummary`, `iam:ListMFADevices`, `iam:GetAccountPasswordPolicy`, `s3:GetBucketAcl`, `s3:GetBucketPolicyStatus`, `s3:GetPublicAccessBlock`, `s3:GetBucketEncryption`, `ec2:DescribeSnapshotAttribute`, `cloudtrail:DescribeTrails` in aggiunta alla policy di `analyze` (altri check riusano action già concesse per `analyze`/`dead-resources`) — vedi [docs/it/permessi-iam.md](permessi-iam.md).
@@ -360,7 +374,7 @@ node apps/cli/dist/main.js history [options]
 | `--domain <domain>`      | Mostra solo gli snapshot di questo dominio: `cloud-cost`, `dead-resources`, o `resource-security` | tutti i domini  |
 | `--limit <n>`             | Numero massimo di snapshot da mostrare, dal più recente                            | `100`           |
 | `--compare <n>`           | Confronta l'ultima esecuzione con quella di `n` esecuzioni fa invece di elencare (richiede `--domain`) | —               |
-| `--html [filename]`       | Scrive anche un report HTML autocontenuto con un grafico del trend (richiede `--domain`; default `reports/cloudrift-history-<domain>-YYYY_MM_DD.html`) | —               |
+| `--html [filename]`       | Scrive anche un report HTML autocontenuto con un grafico del trend. Con `--domain` grafica solo quel dominio (default `reports/cloudrift-history-<domain>-YYYY_MM_DD.html`); senza, impila tutti e tre i domini su un'unica pagina (default `reports/cloudrift-history-YYYY_MM_DD.html`) | —               |
 | `--format <format>`      | Formato di output su stdout: `table` o `json`                                       | `table`         |
 | `-h, --help`              | Mostra l'help                                                                       | —               |
 
@@ -381,6 +395,9 @@ node apps/cli/dist/main.js history --domain cloud-cost --compare 5
 
 # Report HTML autocontenuto con un grafico a linee dello spreco nel tempo
 node apps/cli/dist/main.js history --domain cloud-cost --html
+
+# Report HTML combinato: tutti e tre i domini impilati su una pagina, un grafico ciascuno
+node apps/cli/dist/main.js history --html
 ```
 
 **Nessun nuovo permesso AWS necessario:** `history` fa la stessa chiamata `sts:GetCallerIdentity` di ogni altro comando per risolvere l'ID account (saltata del tutto se passi `--account-id` esplicitamente) — il resto è solo lettura di un file locale, nessuna chiamata API AWS.


### PR DESCRIPTION
## Summary
- `history --html` without `--domain` now stacks all three tracked domains (cloud-cost/dead-resources/resource-security) as separate chart cards on one self-contained HTML page, instead of requiring a single domain.
- Wizard's mode picker shows a locked yellow `🔒 Terraform source analysis (PRO)` badge when the separate `cloudrift-iac-detector` binary isn't found on PATH.
- Fixes a real doc gap: the `--csv` file-artifact flag was undocumented in `docs/en/usage.md`, `docs/it/utilizzo.md`, and `docs/it/leggimi.md`; Italian docs were also missing `csv` as a stdout `--format` value entirely.
- Removes a ~145-line duplicated flag reference in `docs/it/leggimi.md` in favor of linking to `docs/it/utilizzo.md` (mirrors the English README's pattern), and adds the `dead-resources`/`resource-security`/`history` sections that were missing there.

## Test plan
- [x] `nx test cli` — 37 suites / 280 tests passing
- [x] `nx run cli:typecheck` clean
- [x] `nx build cli` clean
- [x] Verified manually against a real AWS account: combined HTML report renders all 3 domain sections correctly
- [ ] Reviewer: note the diff includes PR #93's content again due to that PR being squash-merged (`10feca8`) while this branch's own copy of those commits (`02b0573`) predates the squash — the actual new work is only the last commit (`48f9372`); happy to rebase for a cleaner diff if preferred

🤖 Generated with [Claude Code](https://claude.com/claude-code)