### PR TITLE
feat(cloud-cost-pricing): extract AwsPricingApiAdapter.warmUp into the shared package

### DIFF
--- a/libs/cloud-cost/domain/jest.config.cjs
+++ b/libs/cloud-cost/domain/jest.config.cjs
@@ -18,6 +18,8 @@ module.exports = {
   moduleNameMapper: {
     '^shared-kernel$': '<rootDir>/../../shared/kernel/src/index.ts',
     '^shared-kernel/(.*)$': '<rootDir>/../../shared/kernel/src/$1',
+    '^shared-aws-infra-utils$': '<rootDir>/../../shared/aws-infra-utils/src/index.ts',
+    '^shared-aws-infra-utils/(.*)$': '<rootDir>/../../shared/aws-infra-utils/src/$1',
     '^cloud-cost-pricing$': '<rootDir>/../../shared/cloud-cost-pricing/src/index.ts',
     '^cloud-cost-pricing/(.*)$': '<rootDir>/../../shared/cloud-cost-pricing/src/$1',
     '^(\\.{1,2}/.*)\\.js$': '$1',

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/index.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/index.ts
@@ -67,8 +67,5 @@ export {
   mergePriceTables,
 } from './pricing/table-pricing.adapter';
 export type { PriceTable, RegionPrices } from './pricing/table-pricing.adapter';
-export {
-  AwsPricingApiAdapter,
-  extractOnDemandUsd,
-} from './pricing/aws-pricing-api.adapter';
+export { AwsPricingApiAdapter } from './pricing/aws-pricing-api.adapter';
 export { resolveAwsAccountId } from './account/aws-account-id.resolver';

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/pricing/aws-pricing-api.adapter.spec.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/pricing/aws-pricing-api.adapter.spec.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { PricingClient, GetProductsCommand } from '@aws-sdk/client-pricing';
 import { AwsRegion } from 'cloud-cost-domain';
-import { AwsPricingApiAdapter, extractOnDemandUsd } from './aws-pricing-api.adapter';
+import { AwsPricingApiAdapter } from './aws-pricing-api.adapter';
 
 // Mock only the client; keep GetProductsCommand real so `cmd.input` is populated.
 jest.mock('@aws-sdk/client-pricing', () => {
@@ -54,85 +54,19 @@ function priceListItemWithAttrs(usd: string, attributes: Record<string, string>)
   });
 }
 
-describe('extractOnDemandUsd', () => {
-  it('extracts a positive USD price from a JSON string', () => {
-    expect(extractOnDemandUsd(priceListItem('0.0880000000'))).toEqual([0.088]);
-  });
-
-  it('extracts from an already-parsed object', () => {
-    expect(extractOnDemandUsd(JSON.parse(priceListItem('0.045')))).toEqual([0.045]);
-  });
-
-  it('extracts from a boxed String (the real GetProducts SDK response shape, not a primitive)', () => {
-    // eslint-disable-next-line no-new-wrappers -- reproducing the SDK's own boxed-string PriceList entries
-    expect(extractOnDemandUsd(new String(priceListItem('0.052')))).toEqual([0.052]);
-  });
-
-  it('ignores zero-priced dimensions (free tiers)', () => {
-    expect(extractOnDemandUsd(priceListItem('0.0000000000'))).toEqual([]);
-  });
-
-  it('returns [] for malformed input', () => {
-    expect(extractOnDemandUsd('{ not json')).toEqual([]);
-    expect(extractOnDemandUsd({})).toEqual([]);
-  });
-});
-
-describe('AwsPricingApiAdapter.warmUp', () => {
-  it('builds a PriceTable from unambiguous prices and converts hourly to monthly', async () => {
-    // Every GetProducts call returns one product; NAT (hourly) → ×730.
-    mockSend.mockImplementation((cmd: GetProductsCommand) => {
-      const filters = cmd.input.Filters ?? [];
-      const isNat = filters.some((f) => f.Value === 'NAT Gateway');
-      const usd = isNat ? '0.0450000000' : '0.0880000000';
-      return Promise.resolve({ PriceList: [priceListItem(usd)] });
-    });
+describe('AwsPricingApiAdapter.warmUp/dispose (delegation)', () => {
+  it('delegates warmUp to the shared cloud-cost-pricing adapter and shares its PricingClient for dispose', async () => {
+    mockSend.mockResolvedValue({ PriceList: [priceListItem('0.0880000000')] });
 
     const adapter = new AwsPricingApiAdapter();
     const result = await adapter.warmUp([euWest1]);
 
     expect(result.ok).toBe(true);
-    if (!result.ok) return;
-    const prices = result.value['eu-west-1'];
-    expect(prices['ebs-gp3']).toBe(0.088);
-    expect(prices['nat-gateway']).toBe(+(0.045 * 730).toFixed(4)); // 32.85
+    if (result.ok) expect(result.value['eu-west-1']?.['ebs-gp3']).toBe(0.088);
     expect(mockDestroy).not.toHaveBeenCalled();
     adapter.dispose();
-    expect(mockDestroy).toHaveBeenCalledTimes(1);
-  });
-
-  it('omits a key when the filter is ambiguous (multiple distinct prices)', async () => {
-    mockSend.mockResolvedValue({
-      PriceList: [priceListItem('0.10'), priceListItem('0.20')],
-    });
-
-    const adapter = new AwsPricingApiAdapter();
-    const result = await adapter.warmUp([euWest1]);
-
-    expect(result.ok).toBe(true);
-    // Every spec is ambiguous → no prices resolved → region omitted entirely.
-    if (result.ok) expect(result.value['eu-west-1']).toBeUndefined();
-  });
-
-  it('skips regions with no known location mapping', async () => {
-    mockSend.mockResolvedValue({ PriceList: [priceListItem('0.08')] });
-
-    const adapter = new AwsPricingApiAdapter();
-    const result = await adapter.warmUp([unknownRegion]);
-
-    expect(result.ok).toBe(true);
-    if (result.ok) expect(result.value).toEqual({});
-    expect(mockSend).not.toHaveBeenCalled();
-  });
-
-  it('returns Result.fail (so the caller falls back to static) on SDK error', async () => {
-    mockSend.mockRejectedValue(new Error('AccessDenied: pricing:GetProducts'));
-
-    const adapter = new AwsPricingApiAdapter();
-    const result = await adapter.warmUp([euWest1]);
-
-    expect(result.ok).toBe(false);
-    adapter.dispose();
+    // Exactly one PricingClient is constructed and shared with the composed
+    // shared adapter — dispose() must destroy it exactly once, not twice.
     expect(mockDestroy).toHaveBeenCalledTimes(1);
   });
 });

--- a/libs/cloud-cost/infrastructure/aws-adapter/src/pricing/aws-pricing-api.adapter.ts
+++ b/libs/cloud-cost/infrastructure/aws-adapter/src/pricing/aws-pricing-api.adapter.ts
@@ -1,49 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
-import {
-  PricingClient,
-  GetProductsCommand,
-  type Filter,
-} from '@aws-sdk/client-pricing';
+import { PricingClient } from '@aws-sdk/client-pricing';
 import type { AwsCredentialIdentityProvider } from '@smithy/types';
-import { Result } from 'shared-kernel';
+import type { Result } from 'shared-kernel';
 import type { AwsRegion } from 'cloud-cost-domain';
-import { AwsAdapterError, createAwsClientConfig, mapWithConcurrency } from 'shared-aws-infra-utils';
-import type { PriceTable, RegionPrices } from './table-pricing.adapter';
+import { createAwsClientConfig } from 'shared-aws-infra-utils';
+import { AwsPricingApiAdapter as SharedAwsPricingApiAdapter, REGION_TO_LOCATION } from 'cloud-cost-pricing';
+import type { PriceTable } from './table-pricing.adapter';
 
 /** The Pricing API only lives in some regions; us-east-1 is always valid. */
 const PRICING_API_REGION = 'us-east-1';
-/** AWS convention for converting hourly prices into monthly ones. */
-const HOURS_PER_MONTH = 730;
-/** Concurrent Pricing calls per region (the API has low rate limits). */
-const PRICING_CONCURRENCY = 5;
-
-/**
- * Maps region code → human-readable "location" used by the Pricing API.
- * Regions not present are left to the static price list.
- */
-const REGION_TO_LOCATION: Record<string, string> = {
-  'us-east-1': 'US East (N. Virginia)',
-  'us-east-2': 'US East (Ohio)',
-  'us-west-1': 'US West (N. California)',
-  'us-west-2': 'US West (Oregon)',
-  'ca-central-1': 'Canada (Central)',
-  'eu-west-1': 'EU (Ireland)',
-  'eu-west-2': 'EU (London)',
-  'eu-west-3': 'EU (Paris)',
-  'eu-central-1': 'EU (Frankfurt)',
-  'eu-north-1': 'EU (Stockholm)',
-  'eu-south-1': 'EU (Milan)',
-  'ap-east-1': 'Asia Pacific (Hong Kong)',
-  'ap-south-1': 'Asia Pacific (Mumbai)',
-  'ap-southeast-1': 'Asia Pacific (Singapore)',
-  'ap-southeast-2': 'Asia Pacific (Sydney)',
-  'ap-northeast-1': 'Asia Pacific (Tokyo)',
-  'ap-northeast-2': 'Asia Pacific (Seoul)',
-  'ap-northeast-3': 'Asia Pacific (Osaka)',
-  'sa-east-1': 'South America (Sao Paulo)',
-  'me-south-1': 'Middle East (Bahrain)',
-  'af-south-1': 'Africa (Cape Town)',
-};
 
 /**
  * Maps RDS engine (value from `DescribeDBInstances`) → Pricing API
@@ -65,114 +30,30 @@ const RDS_ENGINE_TO_PRICING_ENGINE: Record<string, string> = {
   'sqlserver-ee': 'SQL Server',
 };
 
-type PriceUnit = 'gb-month' | 'hourly';
-
-interface PriceSpec {
-  /** Key in the PriceTable (must match the ones in prices.json). */
-  key: string;
-  serviceCode: string;
-  /** TERM_MATCH filters in addition to `location` (added automatically). */
-  filters: Array<{ Field: string; Value: string }>;
-  unit: PriceUnit;
-  /**
-   * Extra client-side filter over each item's raw product attributes, for
-   * products where the disambiguating value isn't its own filterable
-   * `TERM_MATCH` attribute at all (e.g. MSK broker instance type is only
-   * embedded in `usagetype`, like `EUC1-Kafka.t3.small` — the region-code
-   * prefix rules out a `TERM_MATCH` on the full string). Applied in addition
-   * to `filters`, before the distinct-price check.
-   */
-  matchAttributes?: (attributes: Record<string, string>) => boolean;
-}
-
 /**
- * Price specs fetched from the Pricing API. Each entry maps a PriceTable key
- * to an AWS product via ServiceCode + filters. The fetch routine is generic
- * and only accepts a price if the filters identify a single value (see
- * `fetchPrice`): ambiguous filters ⇒ fallback to the static list.
- */
-const PRICE_SPECS: readonly PriceSpec[] = [
-  ...(['gp3', 'gp2', 'io1', 'io2', 'st1', 'sc1', 'standard'] as const).map(
-    (vol): PriceSpec => ({
-      key: `ebs-${vol}`,
-      serviceCode: 'AmazonEC2',
-      filters: [
-        { Field: 'productFamily', Value: 'Storage' },
-        { Field: 'volumeApiName', Value: vol },
-      ],
-      unit: 'gb-month',
-    }),
-  ),
-  {
-    key: 'ebs-snapshot',
-    serviceCode: 'AmazonEC2',
-    filters: [{ Field: 'productFamily', Value: 'Storage Snapshot' }],
-    unit: 'gb-month',
-  },
-  {
-    key: 'nat-gateway',
-    serviceCode: 'AmazonEC2',
-    filters: [{ Field: 'productFamily', Value: 'NAT Gateway' }],
-    unit: 'hourly',
-  },
-  {
-    key: 'elastic-ip',
-    serviceCode: 'AmazonEC2',
-    filters: [
-      { Field: 'productFamily', Value: 'IP Address' },
-      { Field: 'group', Value: 'ElasticIP:IdleAddress' },
-    ],
-    unit: 'hourly',
-  },
-  // Phase 5.5 (ADR-0038): low-cardinality fixed-SKU prices, prefetched like
-  // the specs above. Best-effort filters per ADR-0010: an ambiguous/wrong
-  // match yields `undefined` and the static `prices.json` entry is used
-  // instead — never a wrong price.
-  ...(['WINDOWS', 'LUSTRE', 'ONTAP', 'OPENZFS'] as const).map(
-    (fsType): PriceSpec => ({
-      key: `fsx-${fsType.toLowerCase()}`,
-      serviceCode: 'AmazonFSx',
-      filters: [
-        { Field: 'productFamily', Value: 'Storage' },
-        { Field: 'fileSystemType', Value: fsType },
-      ],
-      unit: 'gb-month',
-    }),
-  ),
-  {
-    key: 'vpn-connection',
-    serviceCode: 'AmazonVPC',
-    filters: [{ Field: 'productFamily', Value: 'VPN Connection' }],
-    unit: 'hourly',
-  },
-  {
-    key: 'transit-gateway-attachment',
-    serviceCode: 'AmazonVPC',
-    filters: [{ Field: 'productFamily', Value: 'Transit Gateway' }],
-    unit: 'hourly',
-  },
-  {
-    key: 'kinesis-shard',
-    serviceCode: 'AmazonKinesis',
-    filters: [{ Field: 'productFamily', Value: 'Kinesis Streams' }, { Field: 'group', Value: 'Kinesis-ShardHour' }],
-    unit: 'hourly',
-  },
-];
-
-/**
- * Adapter that fetches prices from the AWS Pricing API. It does not
- * implement `PricingPort` directly: it produces a `PriceTable` via `warmUp`
- * that the composition root merges with the static price list and the
- * user's overrides.
+ * Adapter for the ~13 per-instance-type/class Pricing API lookups only
+ * core's own underutilized-resource scanners need (too high a cardinality
+ * to prefetch in `warmUp`/`prices.json`). `warmUp` itself and the generic
+ * `fetchPrice`/`REGION_TO_LOCATION` primitives it's built on now live in the
+ * shared `cloud-cost-pricing` package (see ADR-0037 in
+ * cloudrift-iac-detector) — this class composes an instance of that shared
+ * adapter rather than duplicating them, sharing the same underlying
+ * `PricingClient`/connection pool.
  */
 export class AwsPricingApiAdapter {
+  private readonly client: PricingClient;
+  private readonly warmUpAdapter: SharedAwsPricingApiAdapter;
+
   constructor(
     credentials?: AwsCredentialIdentityProvider,
-    private readonly client = new PricingClient({
+    client: PricingClient = new PricingClient({
       ...createAwsClientConfig(credentials),
       region: PRICING_API_REGION,
     }),
-  ) {}
+  ) {
+    this.client = client;
+    this.warmUpAdapter = new SharedAwsPricingApiAdapter(credentials, client);
+  }
 
   /**
    * Fetches prices for the requested regions and builds a PriceTable from
@@ -180,28 +61,7 @@ export class AwsPricingApiAdapter {
    * found) is simply omitted: the merge leaves it to the static list.
    */
   async warmUp(regions: readonly AwsRegion[]): Promise<Result<PriceTable>> {
-    try {
-      const table: PriceTable = {};
-      for (const region of regions) {
-        const location = REGION_TO_LOCATION[region.code];
-        if (!location) continue;
-
-        const prices = await mapWithConcurrency(
-          PRICE_SPECS,
-          PRICING_CONCURRENCY,
-          async (spec) => ({ key: spec.key, value: await this.fetchPrice(spec, location) }),
-        );
-
-        const regionPrices: RegionPrices = {};
-        for (const { key, value } of prices) {
-          if (value !== undefined) regionPrices[key] = value;
-        }
-        if (Object.keys(regionPrices).length > 0) table[region.code] = regionPrices;
-      }
-      return Result.ok(table);
-    } catch (err) {
-      return Result.fail(new AwsAdapterError('Pricing', err));
-    }
+    return this.warmUpAdapter.warmUp(regions);
   }
 
   /** Release the underlying HTTP connection pool. Call once after all scans complete. */
@@ -221,7 +81,7 @@ export class AwsPricingApiAdapter {
   ): Promise<number | undefined> {
     const location = REGION_TO_LOCATION[region.code];
     if (!location) return undefined;
-    return this.fetchPrice(
+    return this.warmUpAdapter.fetchPrice(
       {
         key: `ec2-${instanceType}`,
         serviceCode: 'AmazonEC2',
@@ -256,7 +116,7 @@ export class AwsPricingApiAdapter {
     if (!location) return undefined;
     const databaseEngine = RDS_ENGINE_TO_PRICING_ENGINE[engine];
     if (!databaseEngine) return undefined;
-    return this.fetchPrice(
+    return this.warmUpAdapter.fetchPrice(
       {
         key: `rds-${dbInstanceClass}-${engine}-${multiAZ ? 'multi' : 'single'}`,
         serviceCode: 'AmazonRDS',
@@ -283,7 +143,7 @@ export class AwsPricingApiAdapter {
   ): Promise<number | undefined> {
     const location = REGION_TO_LOCATION[region.code];
     if (!location) return undefined;
-    return this.fetchPrice(
+    return this.warmUpAdapter.fetchPrice(
       {
         key: `elasticache-${cacheNodeType}`,
         serviceCode: 'AmazonElastiCache',
@@ -304,7 +164,7 @@ export class AwsPricingApiAdapter {
   async getRedshiftNodePricePerMonth(region: AwsRegion, nodeType: string): Promise<number | undefined> {
     const location = REGION_TO_LOCATION[region.code];
     if (!location) return undefined;
-    return this.fetchPrice(
+    return this.warmUpAdapter.fetchPrice(
       {
         key: `redshift-${nodeType}`,
         serviceCode: 'AmazonRedshift',
@@ -328,7 +188,7 @@ export class AwsPricingApiAdapter {
   async getOpenSearchInstancePricePerMonth(region: AwsRegion, instanceType: string): Promise<number | undefined> {
     const location = REGION_TO_LOCATION[region.code];
     if (!location) return undefined;
-    return this.fetchPrice(
+    return this.warmUpAdapter.fetchPrice(
       {
         key: `opensearch-${instanceType}`,
         serviceCode: 'AmazonES',
@@ -352,7 +212,7 @@ export class AwsPricingApiAdapter {
     // region-code prefix ("EUC1") rules out an exact TERM_MATCH on the full
     // string. Disambiguated client-side instead — verified against a live
     // `GetProducts` call, 2026-07-20.
-    return this.fetchPrice(
+    return this.warmUpAdapter.fetchPrice(
       {
         key: `msk-${brokerInstanceType}`,
         serviceCode: 'AmazonMSK',
@@ -376,7 +236,7 @@ export class AwsPricingApiAdapter {
   async getDocDbInstancePricePerMonth(region: AwsRegion, dbInstanceClass: string): Promise<number | undefined> {
     const location = REGION_TO_LOCATION[region.code];
     if (!location) return undefined;
-    return this.fetchPrice(
+    return this.warmUpAdapter.fetchPrice(
       {
         key: `docdb-${dbInstanceClass}`,
         serviceCode: 'AmazonDocDB',
@@ -401,7 +261,7 @@ export class AwsPricingApiAdapter {
   async getNeptuneInstancePricePerMonth(region: AwsRegion, dbInstanceClass: string): Promise<number | undefined> {
     const location = REGION_TO_LOCATION[region.code];
     if (!location) return undefined;
-    return this.fetchPrice(
+    return this.warmUpAdapter.fetchPrice(
       {
         key: `neptune-${dbInstanceClass}`,
         serviceCode: 'AmazonNeptune',
@@ -440,7 +300,7 @@ export class AwsPricingApiAdapter {
     const location = REGION_TO_LOCATION[region.code];
     if (!location) return undefined;
     const instanceType = hostInstanceType.replace(/^mq\./, '');
-    return this.fetchPrice(
+    return this.warmUpAdapter.fetchPrice(
       {
         key: `mq-${instanceType}-${deploymentOption}-${brokerEngine}`,
         serviceCode: 'AmazonMQ',
@@ -460,7 +320,7 @@ export class AwsPricingApiAdapter {
   async getWorkSpacesBundlePricePerMonth(region: AwsRegion, computeTypeName: string): Promise<number | undefined> {
     const location = REGION_TO_LOCATION[region.code];
     if (!location) return undefined;
-    return this.fetchPrice(
+    return this.warmUpAdapter.fetchPrice(
       {
         key: `workspaces-${computeTypeName}`,
         serviceCode: 'AmazonWorkSpaces',
@@ -485,7 +345,7 @@ export class AwsPricingApiAdapter {
   async getSageMakerNotebookInstancePricePerMonth(region: AwsRegion, instanceType: string): Promise<number | undefined> {
     const location = REGION_TO_LOCATION[region.code];
     if (!location) return undefined;
-    return this.fetchPrice(
+    return this.warmUpAdapter.fetchPrice(
       {
         key: `sagemaker-notebook-${instanceType}`,
         serviceCode: 'AmazonSageMaker',
@@ -503,7 +363,7 @@ export class AwsPricingApiAdapter {
   async getSageMakerEndpointInstancePricePerMonth(region: AwsRegion, instanceType: string): Promise<number | undefined> {
     const location = REGION_TO_LOCATION[region.code];
     if (!location) return undefined;
-    return this.fetchPrice(
+    return this.warmUpAdapter.fetchPrice(
       {
         key: `sagemaker-endpoint-${instanceType}`,
         serviceCode: 'AmazonSageMaker',
@@ -517,83 +377,4 @@ export class AwsPricingApiAdapter {
     );
   }
 
-  /**
-   * Returns the price for a spec **only if the returned products agree on a
-   * single value**. Ambiguous filters (more than one distinct value) ⇒
-   * `undefined`, to avoid risking a wrong price (worse than the price list).
-   */
-  private async fetchPrice(spec: PriceSpec, location: string): Promise<number | undefined> {
-    const filters: Filter[] = [
-      { Type: 'TERM_MATCH', Field: 'location', Value: location },
-      ...spec.filters.map((f) => ({ Type: 'TERM_MATCH' as const, Field: f.Field, Value: f.Value })),
-    ];
-
-    const response = await this.client.send(
-      new GetProductsCommand({ ServiceCode: spec.serviceCode, Filters: filters, MaxResults: 100 }),
-    );
-
-    const distinct = new Set<number>();
-    for (const item of response.PriceList ?? []) {
-      if (spec.matchAttributes && !spec.matchAttributes(extractProductAttributes(item))) continue;
-      for (const usd of extractOnDemandUsd(item)) distinct.add(usd);
-    }
-    if (distinct.size !== 1) return undefined;
-
-    const [usd] = [...distinct];
-    const monthly = spec.unit === 'hourly' ? usd * HOURS_PER_MONTH : usd;
-    return +monthly.toFixed(4);
-  }
-}
-
-/**
- * Parses a PriceList entry into the product object. Entries are usually a
- * JSON string, but the SDK returns them as a boxed `String` (its own
- * lazily-parsed JSON wrapper) rather than a primitive — `typeof` on those is
- * `'object'`, not `'string'`, so a plain `typeof item === 'string'` check
- * misses them and silently drops every price. `instanceof String` catches
- * that case too; already-parsed plain objects fall through unchanged.
- */
-function parseProductItem(item: unknown): unknown {
-  if (typeof item === 'string' || item instanceof String) {
-    try {
-      return JSON.parse(item as string);
-    } catch {
-      return undefined;
-    }
-  }
-  return item;
-}
-
-/**
- * Extracts `product.attributes` (e.g. `usagetype`, `instanceType`,
- * `storageType`) from a PriceList entry, for specs whose `matchAttributes`
- * needs to filter on a field the Pricing API doesn't expose as a
- * `TERM_MATCH`-able attribute of its own.
- */
-function extractProductAttributes(item: unknown): Record<string, string> {
-  const product = parseProductItem(item);
-  const attributes = (product as { product?: { attributes?: Record<string, string> } })?.product?.attributes;
-  return attributes ?? {};
-}
-
-/**
- * Extracts the OnDemand prices (USD, > 0) from a PriceList entry. The entry
- * is a JSON string (or already an object, depending on the SDK version).
- */
-export function extractOnDemandUsd(item: unknown): number[] {
-  const product = parseProductItem(item);
-  const onDemand = (product as { terms?: { OnDemand?: Record<string, unknown> } })?.terms?.OnDemand;
-  if (!onDemand || typeof onDemand !== 'object') return [];
-
-  const prices: number[] = [];
-  for (const offer of Object.values(onDemand)) {
-    const dimensions = (offer as { priceDimensions?: Record<string, unknown> })?.priceDimensions;
-    if (!dimensions) continue;
-    for (const dimension of Object.values(dimensions)) {
-      const usd = (dimension as { pricePerUnit?: { USD?: string } })?.pricePerUnit?.USD;
-      const value = usd !== undefined ? Number(usd) : NaN;
-      if (Number.isFinite(value) && value > 0) prices.push(value);
-    }
-  }
-  return prices;
 }

--- a/libs/dead-resources/domain/jest.config.cjs
+++ b/libs/dead-resources/domain/jest.config.cjs
@@ -18,6 +18,8 @@ module.exports = {
   moduleNameMapper: {
     '^shared-kernel$': '<rootDir>/../../shared/kernel/src/index.ts',
     '^shared-kernel/(.*)$': '<rootDir>/../../shared/kernel/src/$1',
+    '^shared-aws-infra-utils$': '<rootDir>/../../shared/aws-infra-utils/src/index.ts',
+    '^shared-aws-infra-utils/(.*)$': '<rootDir>/../../shared/aws-infra-utils/src/$1',
     '^cloud-cost-domain$': '<rootDir>/../../cloud-cost/domain/src/index.ts',
     '^cloud-cost-domain/(.*)$': '<rootDir>/../../cloud-cost/domain/src/$1',
     '^cloud-cost-pricing$': '<rootDir>/../../shared/cloud-cost-pricing/src/index.ts',

--- a/libs/mcp-server/application/jest.config.cjs
+++ b/libs/mcp-server/application/jest.config.cjs
@@ -18,6 +18,8 @@ module.exports = {
   moduleNameMapper: {
     '^shared-kernel$': '<rootDir>/../../shared/kernel/src/index.ts',
     '^shared-kernel/(.*)$': '<rootDir>/../../shared/kernel/src/$1',
+    '^shared-aws-infra-utils$': '<rootDir>/../../shared/aws-infra-utils/src/index.ts',
+    '^shared-aws-infra-utils/(.*)$': '<rootDir>/../../shared/aws-infra-utils/src/$1',
     '^cloud-cost-domain$': '<rootDir>/../../cloud-cost/domain/src/index.ts',
     '^cloud-cost-domain/(.*)$': '<rootDir>/../../cloud-cost/domain/src/$1',
     '^cloud-cost-pricing$': '<rootDir>/../../shared/cloud-cost-pricing/src/index.ts',

--- a/libs/resource-security/domain/jest.config.cjs
+++ b/libs/resource-security/domain/jest.config.cjs
@@ -18,6 +18,8 @@ module.exports = {
   moduleNameMapper: {
     '^shared-kernel$': '<rootDir>/../../shared/kernel/src/index.ts',
     '^shared-kernel/(.*)$': '<rootDir>/../../shared/kernel/src/$1',
+    '^shared-aws-infra-utils$': '<rootDir>/../../shared/aws-infra-utils/src/index.ts',
+    '^shared-aws-infra-utils/(.*)$': '<rootDir>/../../shared/aws-infra-utils/src/$1',
     '^cloud-cost-domain$': '<rootDir>/../../cloud-cost/domain/src/index.ts',
     '^cloud-cost-domain/(.*)$': '<rootDir>/../../cloud-cost/domain/src/$1',
     '^cloud-cost-pricing$': '<rootDir>/../../shared/cloud-cost-pricing/src/index.ts',

--- a/libs/shared/cloud-cost-pricing/jest.config.cjs
+++ b/libs/shared/cloud-cost-pricing/jest.config.cjs
@@ -18,6 +18,8 @@ module.exports = {
   moduleNameMapper: {
     '^shared-kernel$': '<rootDir>/../kernel/src/index.ts',
     '^shared-kernel/(.*)$': '<rootDir>/../kernel/src/$1',
+    '^shared-aws-infra-utils$': '<rootDir>/../aws-infra-utils/src/index.ts',
+    '^shared-aws-infra-utils/(.*)$': '<rootDir>/../aws-infra-utils/src/$1',
     '^(\\.{1,2}/.*)\\.js$': '$1',
   },
 };

--- a/libs/shared/cloud-cost-pricing/package.json
+++ b/libs/shared/cloud-cost-pricing/package.json
@@ -72,6 +72,11 @@
   },
   "dependencies": {
     "shared-kernel": "workspace:*",
+    "shared-aws-infra-utils": "workspace:*",
+    "@aws-sdk/client-pricing": "^3.1095.0",
     "tslib": "^2.8.1"
+  },
+  "devDependencies": {
+    "@smithy/types": "^4.9.0"
   }
 }

--- a/libs/shared/cloud-cost-pricing/src/aws-pricing-api.adapter.spec.ts
+++ b/libs/shared/cloud-cost-pricing/src/aws-pricing-api.adapter.spec.ts
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: Apache-2.0
+import { PricingClient, GetProductsCommand } from '@aws-sdk/client-pricing';
+import { AwsRegion } from './aws-region.value-object';
+import { AwsPricingApiAdapter, extractOnDemandUsd } from './aws-pricing-api.adapter';
+
+// Mock only the client; keep GetProductsCommand real so `cmd.input` is populated.
+jest.mock('@aws-sdk/client-pricing', () => {
+  const actual = jest.requireActual('@aws-sdk/client-pricing');
+  return { ...actual, PricingClient: jest.fn() };
+});
+
+const mockSend = jest.fn();
+const mockDestroy = jest.fn();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (PricingClient as jest.Mock).mockImplementation(() => ({
+    send: mockSend,
+    destroy: mockDestroy,
+  }));
+});
+
+const euWest1 = AwsRegion.create('eu-west-1');
+const unknownRegion = AwsRegion.create('mx-central-1'); // not in REGION_TO_LOCATION
+
+/** Builds a PriceList JSON string with a single OnDemand USD price. */
+function priceListItem(usd: string): string {
+  return JSON.stringify({
+    terms: {
+      OnDemand: {
+        offer1: {
+          priceDimensions: {
+            dim1: { pricePerUnit: { USD: usd } },
+          },
+        },
+      },
+    },
+  });
+}
+
+describe('extractOnDemandUsd', () => {
+  it('extracts a positive USD price from a JSON string', () => {
+    expect(extractOnDemandUsd(priceListItem('0.0880000000'))).toEqual([0.088]);
+  });
+
+  it('extracts from an already-parsed object', () => {
+    expect(extractOnDemandUsd(JSON.parse(priceListItem('0.045')))).toEqual([0.045]);
+  });
+
+  it('extracts from a boxed String (the real GetProducts SDK response shape, not a primitive)', () => {
+    expect(extractOnDemandUsd(new String(priceListItem('0.052')))).toEqual([0.052]);
+  });
+
+  it('ignores zero-priced dimensions (free tiers)', () => {
+    expect(extractOnDemandUsd(priceListItem('0.0000000000'))).toEqual([]);
+  });
+
+  it('returns [] for malformed input', () => {
+    expect(extractOnDemandUsd('{ not json')).toEqual([]);
+    expect(extractOnDemandUsd({})).toEqual([]);
+  });
+});
+
+describe('AwsPricingApiAdapter.warmUp', () => {
+  it('builds a PriceTable from unambiguous prices and converts hourly to monthly', async () => {
+    // Every GetProducts call returns one product; NAT (hourly) → ×730.
+    mockSend.mockImplementation((cmd: GetProductsCommand) => {
+      const filters = cmd.input.Filters ?? [];
+      const isNat = filters.some((f) => f.Value === 'NAT Gateway');
+      const usd = isNat ? '0.0450000000' : '0.0880000000';
+      return Promise.resolve({ PriceList: [priceListItem(usd)] });
+    });
+
+    const adapter = new AwsPricingApiAdapter();
+    const result = await adapter.warmUp([euWest1]);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const prices = result.value['eu-west-1'];
+    expect(prices['ebs-gp3']).toBe(0.088);
+    expect(prices['nat-gateway']).toBe(+(0.045 * 730).toFixed(4)); // 32.85
+    expect(mockDestroy).not.toHaveBeenCalled();
+    adapter.dispose();
+    expect(mockDestroy).toHaveBeenCalledTimes(1);
+  });
+
+  it('omits a key when the filter is ambiguous (multiple distinct prices)', async () => {
+    mockSend.mockResolvedValue({
+      PriceList: [priceListItem('0.10'), priceListItem('0.20')],
+    });
+
+    const adapter = new AwsPricingApiAdapter();
+    const result = await adapter.warmUp([euWest1]);
+
+    expect(result.ok).toBe(true);
+    // Every spec is ambiguous → no prices resolved → region omitted entirely.
+    if (result.ok) expect(result.value['eu-west-1']).toBeUndefined();
+  });
+
+  it('skips regions with no known location mapping', async () => {
+    mockSend.mockResolvedValue({ PriceList: [priceListItem('0.08')] });
+
+    const adapter = new AwsPricingApiAdapter();
+    const result = await adapter.warmUp([unknownRegion]);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toEqual({});
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  it('returns Result.fail (so the caller falls back to static) on SDK error', async () => {
+    mockSend.mockRejectedValue(new Error('AccessDenied: pricing:GetProducts'));
+
+    const adapter = new AwsPricingApiAdapter();
+    const result = await adapter.warmUp([euWest1]);
+
+    expect(result.ok).toBe(false);
+    adapter.dispose();
+    expect(mockDestroy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/libs/shared/cloud-cost-pricing/src/aws-pricing-api.adapter.ts
+++ b/libs/shared/cloud-cost-pricing/src/aws-pricing-api.adapter.ts
@@ -1,0 +1,277 @@
+// SPDX-License-Identifier: Apache-2.0
+import { PricingClient, GetProductsCommand, type Filter } from '@aws-sdk/client-pricing';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
+import { Result } from 'shared-kernel';
+import { AwsAdapterError, createAwsClientConfig, mapWithConcurrency } from 'shared-aws-infra-utils';
+import type { AwsRegion } from './aws-region.value-object';
+import type { PriceTable, RegionPrices } from './table-pricing.adapter';
+
+/** The Pricing API only lives in some regions; us-east-1 is always valid. */
+const PRICING_API_REGION = 'us-east-1';
+/** AWS convention for converting hourly prices into monthly ones. */
+const HOURS_PER_MONTH = 730;
+/** Concurrent Pricing calls per region (the API has low rate limits). */
+const PRICING_CONCURRENCY = 5;
+
+/**
+ * Maps region code → human-readable "location" used by the Pricing API.
+ * Regions not present are left to the static price list. Exported so a
+ * consumer building its own on-demand (non-`warmUp`) Pricing API queries —
+ * e.g. cloudrift core's per-instance-type lookups — can reuse the same
+ * mapping via `fetchPrice` instead of duplicating it.
+ */
+export const REGION_TO_LOCATION: Record<string, string> = {
+  'us-east-1': 'US East (N. Virginia)',
+  'us-east-2': 'US East (Ohio)',
+  'us-west-1': 'US West (N. California)',
+  'us-west-2': 'US West (Oregon)',
+  'ca-central-1': 'Canada (Central)',
+  'eu-west-1': 'EU (Ireland)',
+  'eu-west-2': 'EU (London)',
+  'eu-west-3': 'EU (Paris)',
+  'eu-central-1': 'EU (Frankfurt)',
+  'eu-north-1': 'EU (Stockholm)',
+  'eu-south-1': 'EU (Milan)',
+  'ap-east-1': 'Asia Pacific (Hong Kong)',
+  'ap-south-1': 'Asia Pacific (Mumbai)',
+  'ap-southeast-1': 'Asia Pacific (Singapore)',
+  'ap-southeast-2': 'Asia Pacific (Sydney)',
+  'ap-northeast-1': 'Asia Pacific (Tokyo)',
+  'ap-northeast-2': 'Asia Pacific (Seoul)',
+  'ap-northeast-3': 'Asia Pacific (Osaka)',
+  'sa-east-1': 'South America (Sao Paulo)',
+  'me-south-1': 'Middle East (Bahrain)',
+  'af-south-1': 'Africa (Cape Town)',
+};
+
+export type PriceUnit = 'gb-month' | 'hourly';
+
+export interface PriceSpec {
+  /** Key in the PriceTable (must match the ones in prices.json). */
+  key: string;
+  serviceCode: string;
+  /** TERM_MATCH filters in addition to `location` (added automatically). */
+  filters: Array<{ Field: string; Value: string }>;
+  unit: PriceUnit;
+  /**
+   * Extra client-side filter over each item's raw product attributes, for
+   * products where the disambiguating value isn't its own filterable
+   * `TERM_MATCH` attribute at all (e.g. MSK broker instance type is only
+   * embedded in `usagetype`, like `EUC1-Kafka.t3.small` — the region-code
+   * prefix rules out a `TERM_MATCH` on the full string). Applied in addition
+   * to `filters`, before the distinct-price check.
+   */
+  matchAttributes?: (attributes: Record<string, string>) => boolean;
+}
+
+/**
+ * Price specs prefetched by `warmUp`. Each entry maps a PriceTable key to an
+ * AWS product via ServiceCode + filters. Only low-cardinality, fixed-SKU
+ * kinds belong here — anything keyed by instance type/class (EC2, RDS,
+ * ElastiCache, ...) has too high a cardinality to prefetch and is resolved
+ * on demand instead, outside this adapter (see `fetchPrice`).
+ */
+const PRICE_SPECS: readonly PriceSpec[] = [
+  ...(['gp3', 'gp2', 'io1', 'io2', 'st1', 'sc1', 'standard'] as const).map(
+    (vol): PriceSpec => ({
+      key: `ebs-${vol}`,
+      serviceCode: 'AmazonEC2',
+      filters: [
+        { Field: 'productFamily', Value: 'Storage' },
+        { Field: 'volumeApiName', Value: vol },
+      ],
+      unit: 'gb-month',
+    }),
+  ),
+  {
+    key: 'ebs-snapshot',
+    serviceCode: 'AmazonEC2',
+    filters: [{ Field: 'productFamily', Value: 'Storage Snapshot' }],
+    unit: 'gb-month',
+  },
+  {
+    key: 'nat-gateway',
+    serviceCode: 'AmazonEC2',
+    filters: [{ Field: 'productFamily', Value: 'NAT Gateway' }],
+    unit: 'hourly',
+  },
+  {
+    key: 'elastic-ip',
+    serviceCode: 'AmazonEC2',
+    filters: [
+      { Field: 'productFamily', Value: 'IP Address' },
+      { Field: 'group', Value: 'ElasticIP:IdleAddress' },
+    ],
+    unit: 'hourly',
+  },
+  ...(['WINDOWS', 'LUSTRE', 'ONTAP', 'OPENZFS'] as const).map(
+    (fsType): PriceSpec => ({
+      key: `fsx-${fsType.toLowerCase()}`,
+      serviceCode: 'AmazonFSx',
+      filters: [
+        { Field: 'productFamily', Value: 'Storage' },
+        { Field: 'fileSystemType', Value: fsType },
+      ],
+      unit: 'gb-month',
+    }),
+  ),
+  {
+    key: 'vpn-connection',
+    serviceCode: 'AmazonVPC',
+    filters: [{ Field: 'productFamily', Value: 'VPN Connection' }],
+    unit: 'hourly',
+  },
+  {
+    key: 'transit-gateway-attachment',
+    serviceCode: 'AmazonVPC',
+    filters: [{ Field: 'productFamily', Value: 'Transit Gateway' }],
+    unit: 'hourly',
+  },
+  {
+    key: 'kinesis-shard',
+    serviceCode: 'AmazonKinesis',
+    filters: [{ Field: 'productFamily', Value: 'Kinesis Streams' }, { Field: 'group', Value: 'Kinesis-ShardHour' }],
+    unit: 'hourly',
+  },
+];
+
+/**
+ * Adapter that fetches prices from the AWS Pricing API. It does not
+ * implement `PricingPort` directly: it produces a `PriceTable` via `warmUp`
+ * that the composition root merges with the static price list and the
+ * user's overrides (see ADR-0009 in cloudrift core).
+ *
+ * Deliberately minimal: this class only carries `warmUp` (the low-cardinality
+ * prefetch) and the generic `fetchPrice` primitive it's built on — not the
+ * ~13 per-instance-type on-demand lookups (EC2/RDS/ElastiCache/...) that
+ * cloudrift core's own scanners need. Those stay in core's own adapter,
+ * composing an instance of this class for `warmUp`/`fetchPrice` rather than
+ * duplicating this logic — see ADR-0037 in cloudrift-iac-detector for why
+ * only this slice is shared.
+ */
+export class AwsPricingApiAdapter {
+  constructor(
+    credentials?: AwsCredentialIdentityProvider,
+    private readonly client = new PricingClient({
+      ...createAwsClientConfig(credentials),
+      region: PRICING_API_REGION,
+    }),
+  ) {}
+
+  /**
+   * Fetches prices for the requested regions and builds a PriceTable from
+   * them. A missing key (unknown region, ambiguous filter, product not
+   * found) is simply omitted: the merge leaves it to the static list.
+   */
+  async warmUp(regions: readonly AwsRegion[]): Promise<Result<PriceTable>> {
+    try {
+      const table: PriceTable = {};
+      for (const region of regions) {
+        const location = REGION_TO_LOCATION[region.code];
+        if (!location) continue;
+
+        const prices = await mapWithConcurrency(
+          PRICE_SPECS,
+          PRICING_CONCURRENCY,
+          async (spec) => ({ key: spec.key, value: await this.fetchPrice(spec, location) }),
+        );
+
+        const regionPrices: RegionPrices = {};
+        for (const { key, value } of prices) {
+          if (value !== undefined) regionPrices[key] = value;
+        }
+        if (Object.keys(regionPrices).length > 0) table[region.code] = regionPrices;
+      }
+      return Result.ok(table);
+    } catch (err) {
+      return Result.fail(new AwsAdapterError('Pricing', err));
+    }
+  }
+
+  /** Release the underlying HTTP connection pool. Call once after all scans complete. */
+  dispose(): void {
+    this.client.destroy();
+  }
+
+  /**
+   * Returns the price for a spec **only if the returned products agree on a
+   * single value**. Ambiguous filters (more than one distinct value) ⇒
+   * `undefined`, to avoid risking a wrong price (worse than the price list).
+   * Public so a consumer's own on-demand (per-instance-type) queries can
+   * reuse this primitive instead of reimplementing it.
+   */
+  async fetchPrice(spec: PriceSpec, location: string): Promise<number | undefined> {
+    const filters: Filter[] = [
+      { Type: 'TERM_MATCH', Field: 'location', Value: location },
+      ...spec.filters.map((f) => ({ Type: 'TERM_MATCH' as const, Field: f.Field, Value: f.Value })),
+    ];
+
+    const response = await this.client.send(
+      new GetProductsCommand({ ServiceCode: spec.serviceCode, Filters: filters, MaxResults: 100 }),
+    );
+
+    const distinct = new Set<number>();
+    for (const item of response.PriceList ?? []) {
+      if (spec.matchAttributes && !spec.matchAttributes(extractProductAttributes(item))) continue;
+      for (const usd of extractOnDemandUsd(item)) distinct.add(usd);
+    }
+    if (distinct.size !== 1) return undefined;
+
+    const [usd] = [...distinct];
+    const monthly = spec.unit === 'hourly' ? usd * HOURS_PER_MONTH : usd;
+    return +monthly.toFixed(4);
+  }
+}
+
+/**
+ * Parses a PriceList entry into the product object. Entries are usually a
+ * JSON string, but the SDK returns them as a boxed `String` (its own
+ * lazily-parsed JSON wrapper) rather than a primitive — `typeof` on those is
+ * `'object'`, not `'string'`, so a plain `typeof item === 'string'` check
+ * misses them and silently drops every price. `instanceof String` catches
+ * that case too; already-parsed plain objects fall through unchanged.
+ */
+function parseProductItem(item: unknown): unknown {
+  if (typeof item === 'string' || item instanceof String) {
+    try {
+      return JSON.parse(item as string);
+    } catch {
+      return undefined;
+    }
+  }
+  return item;
+}
+
+/**
+ * Extracts `product.attributes` (e.g. `usagetype`, `instanceType`,
+ * `storageType`) from a PriceList entry, for specs whose `matchAttributes`
+ * needs to filter on a field the Pricing API doesn't expose as a
+ * `TERM_MATCH`-able attribute of its own.
+ */
+function extractProductAttributes(item: unknown): Record<string, string> {
+  const product = parseProductItem(item);
+  const attributes = (product as { product?: { attributes?: Record<string, string> } })?.product?.attributes;
+  return attributes ?? {};
+}
+
+/**
+ * Extracts the OnDemand prices (USD, > 0) from a PriceList entry. The entry
+ * is a JSON string (or already an object, depending on the SDK version).
+ */
+export function extractOnDemandUsd(item: unknown): number[] {
+  const product = parseProductItem(item);
+  const onDemand = (product as { terms?: { OnDemand?: Record<string, unknown> } })?.terms?.OnDemand;
+  if (!onDemand || typeof onDemand !== 'object') return [];
+
+  const prices: number[] = [];
+  for (const offer of Object.values(onDemand)) {
+    const dimensions = (offer as { priceDimensions?: Record<string, unknown> })?.priceDimensions;
+    if (!dimensions) continue;
+    for (const dimension of Object.values(dimensions)) {
+      const usd = (dimension as { pricePerUnit?: { USD?: string } })?.pricePerUnit?.USD;
+      const value = usd !== undefined ? Number(usd) : NaN;
+      if (Number.isFinite(value) && value > 0) prices.push(value);
+    }
+  }
+  return prices;
+}

--- a/libs/shared/cloud-cost-pricing/src/index.ts
+++ b/libs/shared/cloud-cost-pricing/src/index.ts
@@ -13,3 +13,5 @@ export type { TaggedResource, WasteVerdict, WastePolicyOptions } from './waste-p
 export { TablePricingAdapter, mergePriceTables } from './table-pricing.adapter';
 export type { PriceTable, RegionPrices } from './table-pricing.adapter';
 export { StaticPriceTableAdapter, BUILTIN_PRICE_TABLE, BUILTIN_PRICES_AS_OF } from './static-price-table.adapter';
+export { AwsPricingApiAdapter, REGION_TO_LOCATION, extractOnDemandUsd } from './aws-pricing-api.adapter';
+export type { PriceSpec, PriceUnit } from './aws-pricing-api.adapter';

--- a/libs/shared/cloud-cost-pricing/tsconfig.lib.json
+++ b/libs/shared/cloud-cost-pricing/tsconfig.lib.json
@@ -15,6 +15,9 @@
   "references": [
     {
       "path": "../kernel/tsconfig.lib.json"
+    },
+    {
+      "path": "../aws-infra-utils/tsconfig.lib.json"
     }
   ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -668,12 +668,22 @@ importers:
 
   libs/shared/cloud-cost-pricing:
     dependencies:
+      '@aws-sdk/client-pricing':
+        specifier: ^3.1095.0
+        version: 3.1095.0
+      shared-aws-infra-utils:
+        specifier: workspace:*
+        version: link:../aws-infra-utils
       shared-kernel:
         specifier: workspace:*
         version: link:../kernel
       tslib:
         specifier: ^2.8.1
         version: 2.8.1
+    devDependencies:
+      '@smithy/types':
+        specifier: ^4.9.0
+        version: 4.16.1
 
   libs/shared/cloud-cost-pricing/dist-pkg: {}
 


### PR DESCRIPTION
## Summary
- New minimal `AwsPricingApiAdapter` (`warmUp`/`fetchPrice`/`dispose` only) in `libs/shared/cloud-cost-pricing`, exported from `@ellevas/cloud-cost-pricing` — `cloudrift-iac-detector` needs live regional pricing for its zombie-cost estimate, but only this generic prefetch slice, not the ~13 per-instance-type on-demand methods (EC2/RDS/ElastiCache/...) only our own underutilized scanners use.
- Core's own `AwsPricingApiAdapter` now composes an instance of the shared class for `warmUp`, sharing one `PricingClient`/connection pool, instead of duplicating the prefetch/fetch logic. Its 13 on-demand methods are unchanged.
- Also fixes a latent `shared-aws-infra-utils` jest `moduleNameMapper` gap in 4 packages (`cloud-cost-domain`, `dead-resources-domain`, `resource-security-domain`, `mcp-server-application`) — surfaced now that `cloud-cost-pricing` depends on it transitively, but a real pre-existing gap (those packages would have hit the same failure the moment anything else pulled `shared-aws-infra-utils` in through `cloud-cost-pricing`).

## Test plan
- [x] `pnpm nx run-many --target=lint,typecheck,test,build --all` green across all 19 projects
- [x] `cloud-cost-pricing` and `cloud-cost-infrastructure-aws-adapter` coverage thresholds pass
- [x] No behavior change to any of the 13 on-demand pricing methods or their existing test coverage