### PR TITLE
chore(cloud-cost-pricing): bump to 0.0.2, declare bundled AWS SDK deps

### DIFF
--- a/libs/shared/cloud-cost-pricing/package.json
+++ b/libs/shared/cloud-cost-pricing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cloud-cost-pricing",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",
@@ -74,9 +74,9 @@
     "shared-kernel": "workspace:*",
     "shared-aws-infra-utils": "workspace:*",
     "@aws-sdk/client-pricing": "^3.1095.0",
+    "@aws-sdk/credential-providers": "^3.1095.0",
+    "@smithy/node-http-handler": "^4.9.11",
+    "@smithy/types": "^4.9.0",
     "tslib": "^2.8.1"
-  },
-  "devDependencies": {
-    "@smithy/types": "^4.9.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -671,6 +671,15 @@ importers:
       '@aws-sdk/client-pricing':
         specifier: ^3.1095.0
         version: 3.1095.0
+      '@aws-sdk/credential-providers':
+        specifier: ^3.1095.0
+        version: 3.1097.0
+      '@smithy/node-http-handler':
+        specifier: ^4.9.11
+        version: 4.9.11
+      '@smithy/types':
+        specifier: ^4.9.0
+        version: 4.16.1
       shared-aws-infra-utils:
         specifier: workspace:*
         version: link:../aws-infra-utils
@@ -680,12 +689,6 @@ importers:
       tslib:
         specifier: ^2.8.1
         version: 2.8.1
-    devDependencies:
-      '@smithy/types':
-        specifier: ^4.9.0
-        version: 4.16.1
-
-  libs/shared/cloud-cost-pricing/dist-pkg: {}
 
   libs/shared/kernel:
     dependencies:


### PR DESCRIPTION
## Summary
- `publish-pkg` failed on PR #95's output: `@aws-sdk/credential-providers` and `@smithy/node-http-handler`, both pulled in transitively by bundling `shared-aws-infra-utils` (its `createAwsClientConfig` assume-role/HTTP-handler support), weren't declared as `cloud-cost-pricing`'s own dependencies, so the publish script couldn't resolve their versions.
- Declared them to match `shared-aws-infra-utils`'s own `package.json` exactly, since bundling it means inheriting its runtime deps.
- **`@ellevas/cloud-cost-pricing@0.0.2` already published to GitHub Packages** (done ahead of this PR, verified the generated `dist-pkg/package.json` lists exactly the 3 needed runtime deps before publishing).

## Test plan
- [x] `pnpm nx run-many --target=lint,typecheck,test,build --all` green across all 19 projects
- [x] `pnpm nx run cloud-cost-pricing:publish-pkg` succeeds, generates a correct `dist-pkg/package.json`
- [x] `npm publish` from `dist-pkg/` succeeded, package live on GitHub Packages