### PR TITLE
fix(ci): actually bottle the release being published, not the previous one

### DIFF
--- a/.github/actions/build-homebrew-bottle/action.yml
+++ b/.github/actions/build-homebrew-bottle/action.yml
@@ -24,6 +24,19 @@ runs:
       shell: bash
       run: mv bare-formula.rb Formula/cloudrift.rb
 
+    # `brew tap NAME "$PWD"` below does a real `git clone` of this checkout —
+    # it only ever sees committed history, so without this commit it would
+    # silently clone the *previous* release's formula (the one still on
+    # `main`) and build/bottle that instead of the version we're releasing.
+    # Local-only: never pushed, just makes the upcoming clone see the bump.
+    - name: Commit the formula locally so the tap clone sees it
+      shell: bash
+      run: |
+        git config user.name "cloudrift-release-bot"
+        git config user.email "actions@users.noreply.github.com"
+        git add Formula/cloudrift.rb
+        git commit -m "cloudrift ${GITHUB_REF_NAME}"
+
     # GitHub's macOS runners ship Homebrew preinstalled; ubuntu-latest doesn't,
     # so install it here to get identical brew commands on every platform.
     - name: Install Homebrew (Linux only)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,6 +183,18 @@ jobs:
       - name: Install formula into tap checkout
         run: mv bare-formula.rb Formula/cloudrift.rb
 
+      # `brew tap NAME "$PWD"` below does a real `git clone` of this checkout
+      # — it only ever sees committed history, so without this commit it
+      # would clone the *previous* release's formula (still on `main`) and
+      # merge the bottle specs onto that instead of the version we're
+      # releasing. Local-only: never pushed, just makes the clone see the bump.
+      - name: Commit the formula locally so the tap clone sees it
+        run: |
+          git config user.name "cloudrift-release-bot"
+          git config user.email "actions@users.noreply.github.com"
+          git add Formula/cloudrift.rb
+          git commit -m "cloudrift ${GITHUB_REF_NAME}"
+
       - name: Download bottle artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -203,6 +215,15 @@ jobs:
       - name: Merge bottle specs into the formula
         run: brew bottle --merge --write --no-commit *.bottle.json
 
+      # `--write` edits the formula inside brew's own tap clone
+      # ($(brew --repository elleVas/cloudrift)/Formula/cloudrift.rb), a
+      # separate directory from this checkout — copy the bottled file back
+      # here so it's what actually gets committed/pushed below. Without this,
+      # the PR ships the plain bare formula and the bottle block silently
+      # never leaves the runner.
+      - name: Copy the bottled formula back into this checkout
+        run: cp "$(brew --repository elleVas/cloudrift)/Formula/cloudrift.rb" Formula/cloudrift.rb
+
       # Upload the tarballs before opening the PR so the tap's `brew audit
       # --online` check (required by branch protection) sees a formula whose
       # bottle root_url already resolves.
@@ -222,10 +243,8 @@ jobs:
         run: |
           BRANCH="bump-${GITHUB_REF_NAME}"
           git checkout -b "$BRANCH"
-          git config user.name "cloudrift-release-bot"
-          git config user.email "actions@users.noreply.github.com"
           git add Formula/cloudrift.rb
-          git commit -m "cloudrift ${GITHUB_REF_NAME}"
+          git commit -m "cloudrift ${GITHUB_REF_NAME}: add bottles"
           git push "https://x-access-token:${GH_TOKEN}@github.com/elleVas/homebrew-cloudrift.git" "$BRANCH"
 
           gh pr create --repo elleVas/homebrew-cloudrift \


### PR DESCRIPTION
## Summary
- `brew tap NAME "$PWD"` does a real `git clone` of the checkout — only committed history is visible. Both `build-bottles` and `publish-bottles` overwrite `Formula/cloudrift.rb` with the new version's bare formula but never committed that change, so **every bottle ever built was silently built against the tap's previous release**. Confirmed empirically on the in-flight v0.9.0 run: the built bottle's own `pkg_version` metadata read `"0.8.0"`, and its `tap_git_revision` matched `main`'s prior HEAD commit exactly.
- `brew bottle --merge --write` compounds this: it edits the formula inside brew's own tap clone (`$(brew --repository elleVas/cloudrift)`, a directory under `Library/Taps`), not the job's own working-tree checkout that later gets committed/pushed. Confirmed on the live tap: the merged v0.8.0 formula has **no bottle block at all** despite the pipeline reporting success — the bottle block never left the runner.
- Net effect so far: `brew install`/`upgrade cloudrift` has always silently used Homebrew's source-build fallback (`npm install`), never a real bottle, for every release. No user-facing breakage (cloudrift has no native/compiled deps), but the bottle infrastructure has been doing nothing.

## Fix
- Commit the overwritten formula locally (never pushed) immediately before `brew tap`, so the clone actually sees the version being released.
- After `brew bottle --merge --write`, copy the bottled formula back from brew's real tap clone path into the job's own checkout before opening the PR.

Validated the clone-visibility mechanism locally with a throwaway synthetic tap (real `brew tap`/`brew untap`, not just reasoning) before writing this fix — confirmed uncommitted changes are invisible to the clone, and a local-only commit fixes it.

## Test plan
- [x] YAML validated
- [x] Underlying `git clone`-visibility mechanism verified locally against a synthetic tap
- [ ] Confirm on the next tagged release that the tap PR actually carries a `bottle do` block, and that its `pkg_version` matches the tagged release