### PR TITLE
feat(cli): add Slack/webhook/email notifications for scan alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,19 @@ See [ADR-0099](https://github.com/elleVas/cloudrift/blob/main/docs/adr/0099-loca
 
 ---
 
+### Notifications (Slack / webhook / email)
+
+`analyze`, `dead-resources`, `resource-security`, and `history --compare` can send a summary to Slack, a generic webhook, or email — `--notify-slack`, `--notify-webhook`, `--notify-email <address>`. Best-effort and never blocking: a broken webhook logs a warning, the scan itself is unaffected. Fires only when there's something worth reporting (critical/warning findings, waste over `costAlertThresholdUsd`, or a worsening trend on `history --compare`) — a clean run stays quiet. **Slack gets an alert only** (title + counts, e.g. "3 critical, 14 warning, 0 info") — deliberately no per-finding detail, so a scheduled pipeline scanning several accounts never turns the channel into an unreadable wall of text; the webhook and email payloads include the top findings, since a machine consumer or a personal inbox can handle the extra detail without cluttering a shared channel.
+
+```sh
+cloudrift resource-security --notify-slack
+cloudrift analyze --notify-email team@example.com
+```
+
+Every credential (`SLACK_WEBHOOK_URL`, `CLOUDRIFT_WEBHOOK_URL`, `CLOUDRIFT_SMTP_HOST`/`PORT`/`USER`/`PASSWORD`/`FROM`) comes from the environment, never a flag — set it in your shell or as a CI secret, never in a committed file. See [docs/en/usage.md](https://github.com/elleVas/cloudrift/blob/main/docs/en/usage.md#history--local-scan-history) for the full reference.
+
+---
+
 ### Use it as an MCP server (`mcp`)
 
 Run cloudrift as a local [MCP](https://modelcontextprotocol.io) server over stdio, so an AI agent — Claude Code, Kiro, VS Code Copilot Chat (Agent mode) — can call `analyze_cloudrift`, `get_resource_types`, and `get_required_iam_permissions` directly instead of you running the CLI by hand. It inherits the same AWS credentials as every other command; see [ADR-0082](https://github.com/elleVas/cloudrift/blob/main/docs/adr/0082-mcp-server-second-input-adapter.md).

--- a/apps/cli/jest.config.cjs
+++ b/apps/cli/jest.config.cjs
@@ -24,6 +24,8 @@ module.exports = {
     '^shared-scan-coordination/(.*)$': '<rootDir>/../../libs/shared/scan-coordination/src/$1',
     '^shared-trend-store$': '<rootDir>/../../libs/shared/trend-store/src/index.ts',
     '^shared-trend-store/(.*)$': '<rootDir>/../../libs/shared/trend-store/src/$1',
+    '^shared-notifications$': '<rootDir>/../../libs/shared/notifications/src/index.ts',
+    '^shared-notifications/(.*)$': '<rootDir>/../../libs/shared/notifications/src/$1',
     '^cloud-cost-domain$': '<rootDir>/../../libs/cloud-cost/domain/src/index.ts',
     '^cloud-cost-domain/(.*)$': '<rootDir>/../../libs/cloud-cost/domain/src/$1',
     '^cloud-cost-pricing$': '<rootDir>/../../libs/shared/cloud-cost-pricing/src/index.ts',

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -216,12 +216,14 @@
     "dead-resources-domain": "workspace:*",
     "dead-resources-infrastructure-aws-adapter": "workspace:*",
     "mcp-server-application": "workspace:*",
+    "nodemailer": "^9.0.3",
     "pdfkit": "^0.19.1",
     "resource-security-application": "workspace:*",
     "resource-security-domain": "workspace:*",
     "resource-security-infrastructure-aws-adapter": "workspace:*",
     "shared-aws-infra-utils": "workspace:*",
     "shared-kernel": "workspace:*",
+    "shared-notifications": "workspace:*",
     "shared-trend-store": "workspace:*",
     "zod": "^4.4.3"
   }

--- a/apps/cli/src/commands/analyze-waste.command.ts
+++ b/apps/cli/src/commands/analyze-waste.command.ts
@@ -22,13 +22,15 @@ import { resolveMinAgeDays, resolveExplicitScanners, resolveRegions, resolveCred
 import { writeArtifacts, applyCostGate } from './post-analysis';
 import { reportCliError as fail } from './report-cli-error';
 import { persistTrendSnapshot } from 'shared-trend-store';
+import { shouldNotifyOnCost } from 'shared-notifications';
+import { dispatchNotifications, type NotifyFlags } from './notifications';
 
 export type { AnalyzeDeps };
 
 const DEFAULT_CLOUDWATCH_WINDOW_HOURS = 48;
 const DEFAULT_UTILIZATION_WINDOW_HOURS = 168;
 
-export interface AnalyzeWasteOptions {
+export interface AnalyzeWasteOptions extends NotifyFlags {
   regions: string[];
   accountId?: string;
   assumeRoleArn?: string;
@@ -204,5 +206,25 @@ export async function analyzeWasteCommand(
     generatedAt: meta.generatedAt.toISOString(),
     payload: formatWasteReportAsJson(result.value, meta),
   });
+
+  const emailBypassesGate = options.notifyEmail !== undefined && options.notifyEmailIgnoresGate === true;
+  if (shouldNotifyOnCost(result.value.totalWasteMonthlyUsd, config.costAlertThresholdUsd) || emailBypassesGate) {
+    const topWaste = [...result.value.findings]
+      .sort((a, b) => b.costEstimate.monthlyCostUsd - a.costEstimate.monthlyCostUsd)
+      .slice(0, 5)
+      .map((f) => `${f.kind}: ${f.wasteReason} ($${f.costEstimate.monthlyCostUsd.toFixed(2)}/mo)`);
+    await dispatchNotifications(
+      options,
+      {
+        title: `cloudrift analyze — $${result.value.totalWasteMonthlyUsd.toFixed(2)}/mo wasted (account ${accountId})`,
+        domain: 'cloud-cost',
+        accountId,
+        generatedAt: meta.generatedAt,
+        lines: topWaste,
+      },
+      info,
+    );
+  }
+
   applyCostGate(result.value, config);
 }

--- a/apps/cli/src/commands/dead-resources.command.ts
+++ b/apps/cli/src/commands/dead-resources.command.ts
@@ -15,10 +15,12 @@ import { reportCliError as fail } from './report-cli-error';
 import { OUTPUT_FORMATS, isOutputFormat } from '../output-format';
 import { resolveCredentials } from './resolve-options';
 import { persistTrendSnapshot } from 'shared-trend-store';
+import { shouldNotifyOnSeverity } from 'shared-notifications';
+import { dispatchNotifications, topFindingLines, type NotifyFlags } from './notifications';
 
 export type { DeadResourcesDeps };
 
-export interface DeadResourcesCommandOptions {
+export interface DeadResourcesCommandOptions extends NotifyFlags {
   regions: string[];
   accountId?: string;
   assumeRoleArn?: string;
@@ -164,4 +166,21 @@ export async function deadResourcesCommand(
     generatedAt: meta.generatedAt.toISOString(),
     payload: formatDeadResourcesReportAsJson(result.value, meta),
   });
+
+  const emailBypassesGate = options.notifyEmail !== undefined && options.notifyEmailIgnoresGate === true;
+  if (shouldNotifyOnSeverity(result.value.countBySeverity) || emailBypassesGate) {
+    const { critical, warning, info: infoCount } = result.value.countBySeverity;
+    await dispatchNotifications(
+      options,
+      {
+        title: `cloudrift dead-resources — ${critical} critical, ${warning} warning, ${infoCount} info (account ${accountId})`,
+        domain: 'dead-resources',
+        accountId,
+        generatedAt: meta.generatedAt,
+        countBySeverity: result.value.countBySeverity,
+        lines: topFindingLines(result.value.findings, (f) => f.hygieneReason),
+      },
+      info,
+    );
+  }
 }

--- a/apps/cli/src/commands/history.command.ts
+++ b/apps/cli/src/commands/history.command.ts
@@ -17,6 +17,8 @@ import { compareCloudCostSnapshots, compareHygieneSnapshots, type HistoryCompari
 import { isOutputFormat } from '../output-format';
 import { resolveCredentials } from './resolve-options';
 import { reportCliError as fail } from './report-cli-error';
+import { hasRegressed, type NotificationSummary } from 'shared-notifications';
+import { dispatchNotifications, type NotifyFlags } from './notifications';
 
 export const HISTORY_FORMATS = ['table', 'json'] as const;
 const HISTORY_DOMAINS = ['cloud-cost', 'dead-resources', 'resource-security'] as const;
@@ -39,7 +41,12 @@ function parseLimitOption(options: HistoryCommandOptions): ParsedOption {
 
 /** See `parseLimitOption` — same flattening reason. */
 function parseCompareOption(options: HistoryCommandOptions): ParsedOption {
-  if (options.compare === undefined) return { ok: true, value: undefined };
+  if (options.compare === undefined) {
+    if (options.notifySlack || options.notifyWebhook || options.notifyEmail) {
+      return { ok: false, message: '--notify-slack/--notify-webhook/--notify-email require --compare (they notify on a regression, which only a comparison can detect).' };
+    }
+    return { ok: true, value: undefined };
+  }
   if (options.domain === undefined || !isTrendDomain(options.domain)) {
     return { ok: false, message: '--compare requires --domain (cloud-cost, dead-resources, or resource-security) to know which report shape to compare.' };
   }
@@ -73,7 +80,35 @@ function buildComparison(domain: TrendDomain, older: TrendSnapshotRecord, newer:
   }
 }
 
-export interface HistoryCommandOptions {
+/**
+ * `undefined` when the comparison shows no regression — a still-present
+ * critical finding that hasn't gotten any worse isn't worth paging anyone
+ * every scheduled run, only an actual change for the worse is (see
+ * `hasRegressed`'s doc comment).
+ */
+function buildRegressionNotification(comparison: HistoryComparison, accountId: string): NotificationSummary | undefined {
+  if (comparison.domain === 'cloud-cost') {
+    if (!hasRegressed({ newFindingsCount: comparison.newFindings.length, deltaUsd: comparison.deltaUsd })) return undefined;
+    return {
+      title: `cloudrift history — spend increased by $${comparison.deltaUsd.toFixed(2)}/mo (account ${accountId})`,
+      domain: 'history',
+      accountId,
+      generatedAt: new Date(comparison.newerGeneratedAt),
+      lines: comparison.newFindings.map((f) => `new: ${f.kind} ($${f.monthlyCostUsd.toFixed(2)}/mo)`),
+    };
+  }
+
+  if (!hasRegressed({ newFindingsCount: comparison.newFindings.length })) return undefined;
+  return {
+    title: `cloudrift history (${comparison.domain}) — ${comparison.newFindings.length} new finding(s) since last run (account ${accountId})`,
+    domain: 'history',
+    accountId,
+    generatedAt: new Date(comparison.newerGeneratedAt),
+    lines: comparison.newFindings.map((f) => `new: ${f.kind} (${f.severity})`),
+  };
+}
+
+export interface HistoryCommandOptions extends NotifyFlags {
   accountId?: string;
   assumeRoleArn?: string;
   externalId?: string;
@@ -193,6 +228,11 @@ export async function historyCommand(
     }
     const comparison = buildComparison(domain, records[compareN], records[0]);
     console.log(format === 'json' ? formatHistoryComparisonAsJson(comparison) : formatHistoryComparisonAsTable(comparison));
+
+    const notification = buildRegressionNotification(comparison, accountId);
+    if (notification) {
+      await dispatchNotifications(options, notification, (msg) => console.error(msg));
+    }
   } else {
     const records = await deps.readSnapshots(accountId, {
       domain: options.domain as TrendDomain | undefined,

--- a/apps/cli/src/commands/notifications.spec.ts
+++ b/apps/cli/src/commands/notifications.spec.ts
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: Apache-2.0
+import { dispatchNotifications, topFindingLines } from './notifications';
+import type { NotificationSummary } from 'shared-notifications';
+import * as notifiers from 'shared-notifications';
+
+jest.mock('shared-notifications', () => ({
+  sendSlackNotification: jest.fn(),
+  sendWebhookNotification: jest.fn(),
+  sendEmailNotification: jest.fn(),
+}));
+
+const summary: NotificationSummary = {
+  title: 'cloudrift resource-security — 1 critical finding',
+  domain: 'resource-security',
+  accountId: '123456789012',
+  generatedAt: new Date('2026-07-31'),
+  countBySeverity: { critical: 1, warning: 0, info: 0 },
+  lines: ['S3 bucket "my-bucket" is public'],
+};
+
+const ENV_KEYS = ['SLACK_WEBHOOK_URL', 'CLOUDRIFT_WEBHOOK_URL', 'CLOUDRIFT_SMTP_HOST', 'CLOUDRIFT_SMTP_PORT', 'CLOUDRIFT_SMTP_USER', 'CLOUDRIFT_SMTP_PASSWORD', 'CLOUDRIFT_SMTP_FROM'];
+
+describe('dispatchNotifications', () => {
+  let info: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    info = jest.fn();
+    for (const key of ENV_KEYS) delete process.env[key];
+  });
+
+  it('does nothing when no flags are set', async () => {
+    await dispatchNotifications({}, summary, info);
+
+    expect(notifiers.sendSlackNotification).not.toHaveBeenCalled();
+    expect(notifiers.sendWebhookNotification).not.toHaveBeenCalled();
+    expect(notifiers.sendEmailNotification).not.toHaveBeenCalled();
+    expect(info).not.toHaveBeenCalled();
+  });
+
+  it('sends Slack when --notify-slack is set and SLACK_WEBHOOK_URL is present', async () => {
+    process.env.SLACK_WEBHOOK_URL = 'https://hooks.slack.com/x';
+    (notifiers.sendSlackNotification as jest.Mock).mockResolvedValueOnce({ ok: true, value: undefined });
+
+    await dispatchNotifications({ notifySlack: true }, summary, info);
+
+    expect(notifiers.sendSlackNotification).toHaveBeenCalledWith('https://hooks.slack.com/x', summary);
+    expect(info).toHaveBeenCalledWith(expect.stringContaining('sent'));
+  });
+
+  it('warns and skips Slack when --notify-slack is set but SLACK_WEBHOOK_URL is missing', async () => {
+    await dispatchNotifications({ notifySlack: true }, summary, info);
+
+    expect(notifiers.sendSlackNotification).not.toHaveBeenCalled();
+    expect(info).toHaveBeenCalledWith(expect.stringContaining('SLACK_WEBHOOK_URL'));
+  });
+
+  it('warns when the Slack send itself fails', async () => {
+    process.env.SLACK_WEBHOOK_URL = 'https://hooks.slack.com/x';
+    (notifiers.sendSlackNotification as jest.Mock).mockResolvedValueOnce({ ok: false, error: new Error('boom') });
+
+    await dispatchNotifications({ notifySlack: true }, summary, info);
+
+    expect(info).toHaveBeenCalledWith(expect.stringContaining('failed: boom'));
+  });
+
+  it('sends the generic webhook when --notify-webhook is set and CLOUDRIFT_WEBHOOK_URL is present', async () => {
+    process.env.CLOUDRIFT_WEBHOOK_URL = 'https://example.com/hook';
+    (notifiers.sendWebhookNotification as jest.Mock).mockResolvedValueOnce({ ok: true, value: undefined });
+
+    await dispatchNotifications({ notifyWebhook: true }, summary, info);
+
+    expect(notifiers.sendWebhookNotification).toHaveBeenCalledWith('https://example.com/hook', summary);
+  });
+
+  it('warns and skips the webhook when CLOUDRIFT_WEBHOOK_URL is missing', async () => {
+    await dispatchNotifications({ notifyWebhook: true }, summary, info);
+
+    expect(notifiers.sendWebhookNotification).not.toHaveBeenCalled();
+    expect(info).toHaveBeenCalledWith(expect.stringContaining('CLOUDRIFT_WEBHOOK_URL'));
+  });
+
+  it('sends email when --notify-email is set and every CLOUDRIFT_SMTP_* var is present', async () => {
+    process.env.CLOUDRIFT_SMTP_HOST = 'smtp.example.com';
+    process.env.CLOUDRIFT_SMTP_PORT = '587';
+    process.env.CLOUDRIFT_SMTP_USER = 'bot@example.com';
+    process.env.CLOUDRIFT_SMTP_PASSWORD = 'secret';
+    process.env.CLOUDRIFT_SMTP_FROM = 'cloudrift@example.com';
+    (notifiers.sendEmailNotification as jest.Mock).mockResolvedValueOnce({ ok: true, value: undefined });
+
+    await dispatchNotifications({ notifyEmail: 'team@example.com' }, summary, info);
+
+    expect(notifiers.sendEmailNotification).toHaveBeenCalledWith(
+      { host: 'smtp.example.com', port: 587, user: 'bot@example.com', password: 'secret', from: 'cloudrift@example.com' },
+      'team@example.com',
+      summary,
+    );
+  });
+
+  it('warns and skips email when any CLOUDRIFT_SMTP_* var is missing', async () => {
+    process.env.CLOUDRIFT_SMTP_HOST = 'smtp.example.com';
+    // port/user/password/from deliberately left unset
+
+    await dispatchNotifications({ notifyEmail: 'team@example.com' }, summary, info);
+
+    expect(notifiers.sendEmailNotification).not.toHaveBeenCalled();
+    expect(info).toHaveBeenCalledWith(expect.stringContaining('CLOUDRIFT_SMTP_HOST/PORT/USER/PASSWORD/FROM'));
+  });
+
+  it('fans out to multiple channels at once', async () => {
+    process.env.SLACK_WEBHOOK_URL = 'https://hooks.slack.com/x';
+    process.env.CLOUDRIFT_WEBHOOK_URL = 'https://example.com/hook';
+    (notifiers.sendSlackNotification as jest.Mock).mockResolvedValueOnce({ ok: true, value: undefined });
+    (notifiers.sendWebhookNotification as jest.Mock).mockResolvedValueOnce({ ok: true, value: undefined });
+
+    await dispatchNotifications({ notifySlack: true, notifyWebhook: true }, summary, info);
+
+    expect(notifiers.sendSlackNotification).toHaveBeenCalledTimes(1);
+    expect(notifiers.sendWebhookNotification).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('topFindingLines', () => {
+  const findings = [
+    { kind: 's3-bucket-public', severity: 'info', reason: 'no policy' },
+    { kind: 'iam-root-mfa-disabled', severity: 'critical', reason: 'no MFA' },
+    { kind: 'ec2-security-group-open-ingress', severity: 'warning', reason: 'port 22 open' },
+  ];
+
+  it('sorts critical first, then warning, then info', () => {
+    const lines = topFindingLines(findings, (f) => f.reason);
+
+    expect(lines[0]).toContain('iam-root-mfa-disabled');
+    expect(lines[1]).toContain('ec2-security-group-open-ingress');
+    expect(lines[2]).toContain('s3-bucket-public');
+  });
+
+  it('includes the kind, reason, and severity in each line', () => {
+    const lines = topFindingLines(findings, (f) => f.reason);
+
+    expect(lines[0]).toBe('iam-root-mfa-disabled: no MFA (critical)');
+  });
+
+  it('caps the number of lines to the given limit', () => {
+    const lines = topFindingLines(findings, (f) => f.reason, 2);
+
+    expect(lines).toHaveLength(2);
+  });
+
+  it('does not mutate the input array', () => {
+    const copy = [...findings];
+    topFindingLines(findings, (f) => f.reason);
+
+    expect(findings).toEqual(copy);
+  });
+});

--- a/apps/cli/src/commands/notifications.ts
+++ b/apps/cli/src/commands/notifications.ts
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: Apache-2.0
+import chalk from 'chalk';
+import type { NotificationSummary, SmtpConfig } from 'shared-notifications';
+import { sendSlackNotification, sendWebhookNotification, sendEmailNotification } from 'shared-notifications';
+
+export interface NotifyFlags {
+  notifySlack?: boolean;
+  notifyWebhook?: boolean;
+  notifyEmail?: string;
+  /**
+   * Set only by the interactive wizard: a human explicitly asked to email
+   * *this* report, the same "want a PDF too?" kind of one-off choice — not
+   * an automated alert, so it must fire regardless of the severity/cost/
+   * regression gate each command checks before calling `dispatchNotifications`.
+   * `--notify-email` from a flag (CI/scripts) has no way to set this and
+   * stays gated, same as `--notify-slack`/`--notify-webhook`.
+   */
+  notifyEmailIgnoresGate?: boolean;
+}
+
+const SEVERITY_RANK: Record<string, number> = { critical: 0, warning: 1, info: 2 };
+
+/** Most-severe-first, capped to `limit` — same shape as the PDF's "top findings" list, reused here for the notification body. */
+export function topFindingLines<T extends { kind: string; severity: string }>(
+  findings: readonly T[],
+  reasonFor: (finding: T) => string,
+  limit = 5,
+): string[] {
+  return [...findings]
+    .sort((a, b) => (SEVERITY_RANK[a.severity] ?? 99) - (SEVERITY_RANK[b.severity] ?? 99))
+    .slice(0, limit)
+    .map((finding) => `${finding.kind}: ${reasonFor(finding)} (${finding.severity})`);
+}
+
+/**
+ * Every channel's config comes from the environment, never from a CLI flag —
+ * a webhook URL or SMTP password would otherwise land in shell history and
+ * `ps aux`, the same reasoning that keeps AWS credentials out of flags too.
+ * Flags only turn a channel *on*; `--notify-email <address>` is the one
+ * exception because a recipient address isn't a secret.
+ */
+function resolveSmtpConfig(): SmtpConfig | undefined {
+  const host = process.env.CLOUDRIFT_SMTP_HOST;
+  const port = process.env.CLOUDRIFT_SMTP_PORT;
+  const user = process.env.CLOUDRIFT_SMTP_USER;
+  const password = process.env.CLOUDRIFT_SMTP_PASSWORD;
+  const from = process.env.CLOUDRIFT_SMTP_FROM;
+  if (!host || !port || !user || !password || !from) return undefined;
+  return { host, port: Number(port), user, password, from };
+}
+
+/**
+ * Fans out to every channel the caller turned on via `flags`, resolving each
+ * channel's config from the environment. Best-effort throughout: a missing
+ * env var or a failed send is logged via `info` (stderr in machine-readable
+ * modes, same as every other warning in this CLI) and never throws — a
+ * broken webhook must never fail the scan it's reporting on.
+ */
+export async function dispatchNotifications(flags: NotifyFlags, summary: NotificationSummary, info: (msg: string) => void): Promise<void> {
+  const tasks: Promise<void>[] = [];
+
+  if (flags.notifySlack) {
+    const url = process.env.SLACK_WEBHOOK_URL;
+    if (!url) {
+      info(chalk.yellow('  --notify-slack was set but SLACK_WEBHOOK_URL is not — skipping the Slack notification.'));
+    } else {
+      tasks.push(
+        sendSlackNotification(url, summary).then((result) => {
+          if (!result.ok) info(chalk.yellow(`  Slack notification failed: ${result.error.message}`));
+          else info(chalk.green('  Slack notification sent.'));
+        }),
+      );
+    }
+  }
+
+  if (flags.notifyWebhook) {
+    const url = process.env.CLOUDRIFT_WEBHOOK_URL;
+    if (!url) {
+      info(chalk.yellow('  --notify-webhook was set but CLOUDRIFT_WEBHOOK_URL is not — skipping the webhook notification.'));
+    } else {
+      tasks.push(
+        sendWebhookNotification(url, summary).then((result) => {
+          if (!result.ok) info(chalk.yellow(`  Webhook notification failed: ${result.error.message}`));
+          else info(chalk.green('  Webhook notification sent.'));
+        }),
+      );
+    }
+  }
+
+  if (flags.notifyEmail) {
+    const smtp = resolveSmtpConfig();
+    if (!smtp) {
+      info(chalk.yellow('  --notify-email was set but CLOUDRIFT_SMTP_HOST/PORT/USER/PASSWORD/FROM are not all set — skipping the email notification.'));
+    } else {
+      const to = flags.notifyEmail;
+      tasks.push(
+        sendEmailNotification(smtp, to, summary).then((result) => {
+          if (!result.ok) info(chalk.yellow(`  Email notification failed: ${result.error.message}`));
+          else info(chalk.green(`  Email notification sent to ${to}.`));
+        }),
+      );
+    }
+  }
+
+  await Promise.all(tasks);
+}

--- a/apps/cli/src/commands/resource-security.command.ts
+++ b/apps/cli/src/commands/resource-security.command.ts
@@ -15,10 +15,12 @@ import { reportCliError as fail } from './report-cli-error';
 import { OUTPUT_FORMATS, isOutputFormat } from '../output-format';
 import { resolveCredentials } from './resolve-options';
 import { persistTrendSnapshot } from 'shared-trend-store';
+import { shouldNotifyOnSeverity } from 'shared-notifications';
+import { dispatchNotifications, topFindingLines, type NotifyFlags } from './notifications';
 
 export type { ResourceSecurityDeps };
 
-export interface ResourceSecurityCommandOptions {
+export interface ResourceSecurityCommandOptions extends NotifyFlags {
   regions: string[];
   accountId?: string;
   assumeRoleArn?: string;
@@ -152,4 +154,21 @@ export async function resourceSecurityCommand(
     generatedAt: meta.generatedAt.toISOString(),
     payload: formatResourceSecurityReportAsJson(result.value, meta),
   });
+
+  const emailBypassesGate = options.notifyEmail !== undefined && options.notifyEmailIgnoresGate === true;
+  if (shouldNotifyOnSeverity(result.value.countBySeverity) || emailBypassesGate) {
+    const { critical, warning, info: infoCount } = result.value.countBySeverity;
+    await dispatchNotifications(
+      options,
+      {
+        title: `cloudrift resource-security — ${critical} critical, ${warning} warning, ${infoCount} info (account ${accountId})`,
+        domain: 'resource-security',
+        accountId,
+        generatedAt: meta.generatedAt,
+        countBySeverity: result.value.countBySeverity,
+        lines: topFindingLines(result.value.findings, (f) => f.riskReason),
+      },
+      info,
+    );
+  }
 }

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -87,6 +87,9 @@ program
     '--silent',
     'suppress all stdout output (banner, report, confirmations) — use with --pdf/--json/--csv for file-only output. Errors and the cost-gate alert still surface.',
   )
+  .option('--notify-slack', 'send a Slack notification if waste exceeds --config\'s costAlertThresholdUsd (or any waste, if unset); reads SLACK_WEBHOOK_URL from env')
+  .option('--notify-webhook', 'POST a JSON summary to a webhook under the same condition as --notify-slack; reads CLOUDRIFT_WEBHOOK_URL from env')
+  .option('--notify-email <address>', 'email a summary to this address under the same condition as --notify-slack; reads CLOUDRIFT_SMTP_HOST/PORT/USER/PASSWORD/FROM from env')
   .action((options) => analyzeWasteCommand(options));
 
 program
@@ -180,6 +183,9 @@ program
     'Also write a CSV report to disk (optional filename, defaults to reports/cloudrift-dead-resources-YYYY_MM_DD.csv)',
   )
   .option('--silent', 'suppress all stdout output (banner, report). Errors still surface.')
+  .option('--notify-slack', 'send a Slack notification if the scan has critical/warning findings; reads SLACK_WEBHOOK_URL from env')
+  .option('--notify-webhook', 'POST a JSON summary to a webhook under the same condition as --notify-slack; reads CLOUDRIFT_WEBHOOK_URL from env')
+  .option('--notify-email <address>', 'email a summary to this address under the same condition as --notify-slack; reads CLOUDRIFT_SMTP_HOST/PORT/USER/PASSWORD/FROM from env')
   .action((options) => deadResourcesCommand(options));
 
 program
@@ -214,6 +220,9 @@ program
     'Also write a CSV report to disk (optional filename, defaults to reports/cloudrift-resource-security-YYYY_MM_DD.csv)',
   )
   .option('--silent', 'suppress all stdout output (banner, report). Errors still surface.')
+  .option('--notify-slack', 'send a Slack notification if the scan has critical/warning findings; reads SLACK_WEBHOOK_URL from env')
+  .option('--notify-webhook', 'POST a JSON summary to a webhook under the same condition as --notify-slack; reads CLOUDRIFT_WEBHOOK_URL from env')
+  .option('--notify-email <address>', 'email a summary to this address under the same condition as --notify-slack; reads CLOUDRIFT_SMTP_HOST/PORT/USER/PASSWORD/FROM from env')
   .action((options) => resourceSecurityCommand(options));
 
 program
@@ -235,6 +244,9 @@ program
     'Also write a self-contained HTML report with a trend chart (optional filename, defaults to reports/cloudrift-history-<domain>-YYYY_MM_DD.html). Without --domain, charts all three domains stacked on one page instead of just one',
   )
   .option('--format <format>', 'stdout output format: table (default) or json', 'table')
+  .option('--notify-slack', 'with --compare, send a Slack notification if the comparison shows a regression (worse trend); reads SLACK_WEBHOOK_URL from env')
+  .option('--notify-webhook', 'with --compare, POST a JSON summary to a webhook under the same condition as --notify-slack; reads CLOUDRIFT_WEBHOOK_URL from env')
+  .option('--notify-email <address>', 'with --compare, email a summary to this address under the same condition as --notify-slack; reads CLOUDRIFT_SMTP_HOST/PORT/USER/PASSWORD/FROM from env')
   .action((options) => historyCommand(options));
 
 program

--- a/apps/cli/src/wizard/entry.wizard.ts
+++ b/apps/cli/src/wizard/entry.wizard.ts
@@ -23,6 +23,7 @@ import {
   playHandoffTransition,
   delegateToCloudriftIacDetector,
 } from './terraform-handoff.wizard';
+import { promptEmailNotification } from './notification.wizard';
 
 type Outro = (message?: string) => void;
 
@@ -76,6 +77,8 @@ async function runWasteMode(outro: Outro): Promise<void> {
   const output = await promptWasteOutput();
   if (output === undefined) return;
 
+  const notifyEmail = await promptEmailNotification();
+
   outro('Starting scan...');
   await analyzeWasteCommand({
     regions,
@@ -84,6 +87,8 @@ async function runWasteMode(outro: Outro): Promise<void> {
     pdf: output.savePdf ? true : undefined,
     json: output.saveJson ? true : undefined,
     csv: output.saveCsv ? true : undefined,
+    notifyEmail,
+    notifyEmailIgnoresGate: true,
   });
 }
 
@@ -97,6 +102,8 @@ async function runDeadResourcesMode(outro: Outro): Promise<void> {
   const output = await promptDeadResourcesOutput();
   if (output === undefined) return;
 
+  const notifyEmail = await promptEmailNotification();
+
   outro('Starting scan...');
   await deadResourcesCommand({
     regions,
@@ -104,6 +111,8 @@ async function runDeadResourcesMode(outro: Outro): Promise<void> {
     format: output.format,
     pdf: output.savePdf ? true : undefined,
     csv: output.saveCsv ? true : undefined,
+    notifyEmail,
+    notifyEmailIgnoresGate: true,
   });
 }
 
@@ -117,6 +126,8 @@ async function runResourceSecurityMode(outro: Outro): Promise<void> {
   const output = await promptResourceSecurityOutput();
   if (output === undefined) return;
 
+  const notifyEmail = await promptEmailNotification();
+
   outro('Starting scan...');
   await resourceSecurityCommand({
     regions,
@@ -124,6 +135,8 @@ async function runResourceSecurityMode(outro: Outro): Promise<void> {
     format: output.format,
     pdf: output.savePdf ? true : undefined,
     csv: output.saveCsv ? true : undefined,
+    notifyEmail,
+    notifyEmailIgnoresGate: true,
   });
 }
 

--- a/apps/cli/src/wizard/notification.wizard.ts
+++ b/apps/cli/src/wizard/notification.wizard.ts
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Whether every `CLOUDRIFT_SMTP_*` env var email sending needs is already
+ * set. Slack/webhook notifications are deliberately CI/script-only (see
+ * `dispatchNotifications`) and never prompted for here — a human running the
+ * interactive wizard is already looking at the report on their own screen;
+ * emailing it to someone else is the one channel worth offering in the
+ * moment, and only when SMTP is already configured (this wizard never walks
+ * anyone through setting it up).
+ */
+function isSmtpConfigured(): boolean {
+  return !!(
+    process.env.CLOUDRIFT_SMTP_HOST &&
+    process.env.CLOUDRIFT_SMTP_PORT &&
+    process.env.CLOUDRIFT_SMTP_USER &&
+    process.env.CLOUDRIFT_SMTP_PASSWORD &&
+    process.env.CLOUDRIFT_SMTP_FROM
+  );
+}
+
+/**
+ * Offers to email the report summary, only when SMTP is already configured.
+ * Returns the recipient address, or `undefined` if SMTP isn't configured,
+ * the user declines, or they cancel — none of which should abort the scan
+ * itself, unlike cancelling the regions/scanner/output prompts earlier in
+ * the same flow.
+ */
+export async function promptEmailNotification(): Promise<string | undefined> {
+  if (!isSmtpConfigured()) return undefined;
+
+  const { confirm, text, isCancel } = await import('@clack/prompts');
+
+  const wantsEmail = await confirm({ message: 'Email this report to someone?', initialValue: false });
+  if (isCancel(wantsEmail) || !wantsEmail) return undefined;
+
+  const address = await text({
+    message: 'Recipient email address:',
+    validate: (value) => (value?.includes('@') ? undefined : 'Enter a valid email address.'),
+  });
+  if (isCancel(address)) return undefined;
+
+  return address;
+}

--- a/apps/cli/tsconfig.app.json
+++ b/apps/cli/tsconfig.app.json
@@ -13,6 +13,9 @@
       "path": "../../libs/shared/trend-store/tsconfig.lib.json"
     },
     {
+      "path": "../../libs/shared/notifications/tsconfig.lib.json"
+    },
+    {
       "path": "../../libs/shared/kernel/tsconfig.lib.json"
     },
     {

--- a/docs/en/usage.md
+++ b/docs/en/usage.md
@@ -43,6 +43,9 @@ node apps/cli/dist/main.js analyze [options]
 | `--json [filename]`          | Also write a JSON report to disk (defaults to `cloudrift-reports/AWS_report_YYYY_MM_DD.json`)                            | —                  |
 | `--csv [filename]`           | Also write a CSV report to disk (defaults to `cloudrift-reports/AWS_report_YYYY_MM_DD.csv`)                              | —                  |
 | `--silent`                   | Suppress all stdout output (banner, report, confirmations) — use with `--pdf`/`--json`/`--csv` for file-only output | off                |
+| `--notify-slack`             | Send a Slack notification if waste exceeds `costAlertThresholdUsd` (or any waste, if unset). Reads `SLACK_WEBHOOK_URL` from env | off |
+| `--notify-webhook`           | POST a JSON summary to a webhook, same condition as `--notify-slack`. Reads `CLOUDRIFT_WEBHOOK_URL` from env  | off                |
+| `--notify-email <address>`   | Email a summary to this address, same condition as `--notify-slack`. Reads `CLOUDRIFT_SMTP_HOST`/`PORT`/`USER`/`PASSWORD`/`FROM` from env | off |
 | `-h, --help`                 | Show help                                                                                                      | —                  |
 
 > **stdout vs. file artifacts:** `--format` controls what goes to **stdout** (the report itself). `--json` / `--pdf` / `--csv` write **additional files** to disk and are independent of `--format` — by default the chosen `--format` still prints to stdout *in addition to* writing those files (so e.g. `--pdf` alone still shows the table by default). Add `--silent` for file-only output with nothing printed to the terminal. In machine-readable formats (`json`, `markdown`, `csv`) all human messages are routed to stderr, so stdout carries only the report — ideal for piping. Errors and the cost-gate alert always surface on stderr, even with `--silent`.
@@ -206,6 +209,9 @@ node apps/cli/dist/main.js dead-resources [options]
 | `--pdf [filename]`           | Also write a PDF report to disk (defaults to `cloudrift-reports/cloudrift-dead-resources-YYYY_MM_DD.pdf`)                | —                  |
 | `--csv [filename]`           | Also write a CSV report to disk (defaults to `cloudrift-reports/cloudrift-dead-resources-YYYY_MM_DD.csv`)                | —                  |
 | `--silent`                   | Suppress all stdout output (banner, report). Errors still surface.                                              | off                |
+| `--notify-slack`             | Send a Slack notification if the scan has critical/warning findings. Reads `SLACK_WEBHOOK_URL` from env        | off                |
+| `--notify-webhook`           | POST a JSON summary to a webhook, same condition as `--notify-slack`. Reads `CLOUDRIFT_WEBHOOK_URL` from env   | off                |
+| `--notify-email <address>`   | Email a summary to this address, same condition as `--notify-slack`. Reads `CLOUDRIFT_SMTP_HOST`/`PORT`/`USER`/`PASSWORD`/`FROM` from env | off |
 | `-h, --help`                 | Show help                                                                                                       | —                  |
 
 **Checks:**
@@ -274,6 +280,9 @@ node apps/cli/dist/main.js resource-security [options]
 | `--pdf [filename]`           | Also write a PDF report to disk (defaults to `cloudrift-reports/cloudrift-resource-security-YYYY_MM_DD.pdf`)             | —                  |
 | `--csv [filename]`           | Also write a CSV report to disk (defaults to `cloudrift-reports/cloudrift-resource-security-YYYY_MM_DD.csv`)             | —                  |
 | `--silent`                   | Suppress all stdout output (banner, report). Errors still surface.                                              | off                |
+| `--notify-slack`             | Send a Slack notification if the scan has critical/warning findings. Reads `SLACK_WEBHOOK_URL` from env        | off                |
+| `--notify-webhook`           | POST a JSON summary to a webhook, same condition as `--notify-slack`. Reads `CLOUDRIFT_WEBHOOK_URL` from env   | off                |
+| `--notify-email <address>`   | Email a summary to this address, same condition as `--notify-slack`. Reads `CLOUDRIFT_SMTP_HOST`/`PORT`/`USER`/`PASSWORD`/`FROM` from env | off |
 | `-h, --help`                 | Show help                                                                                                       | —                  |
 
 **Checks:**
@@ -361,7 +370,12 @@ node apps/cli/dist/main.js history [options]
 | `--compare <n>`           | Compare the latest run against the one `n` runs back instead of listing (requires `--domain`) | —               |
 | `--html [filename]`       | Also write a self-contained HTML report with a trend chart. With `--domain`, charts just that domain (defaults to `cloudrift-reports/cloudrift-history-<domain>-YYYY_MM_DD.html`); without it, stacks all three domains on one page (defaults to `cloudrift-reports/cloudrift-history-YYYY_MM_DD.html`) | —               |
 | `--format <format>`      | stdout output format: `table` or `json`                                            | `table`         |
+| `--notify-slack`          | With `--compare`, send a Slack notification if the comparison shows a regression (worse trend). Reads `SLACK_WEBHOOK_URL` from env | off |
+| `--notify-webhook`        | With `--compare`, POST a JSON summary to a webhook, same condition as `--notify-slack`. Reads `CLOUDRIFT_WEBHOOK_URL` from env | off |
+| `--notify-email <address>` | With `--compare`, email a summary to this address, same condition as `--notify-slack`. Reads `CLOUDRIFT_SMTP_HOST`/`PORT`/`USER`/`PASSWORD`/`FROM` from env | off |
 | `-h, --help`              | Show help                                                                          | —               |
+
+> **Notifications (`analyze`/`dead-resources`/`resource-security`/`history --compare`):** `--notify-slack`/`--notify-webhook`/`--notify-email` are best-effort and never fail the scan — a broken webhook or SMTP config logs a warning and moves on. Every credential (`SLACK_WEBHOOK_URL`, `CLOUDRIFT_WEBHOOK_URL`, `CLOUDRIFT_SMTP_*`) comes from the environment, never a flag, so it never lands in shell history or `ps aux` — set them in your shell profile or as CI secrets (e.g. GitHub Actions `secrets.*`), never in a committed file. The interactive wizard offers to email the report too (only when SMTP is already configured), but never asks about Slack/webhook — those are meant for CI/scripts, not a one-off terminal run.
 
 **Examples:**
 

--- a/docs/it/leggimi.md
+++ b/docs/it/leggimi.md
@@ -299,6 +299,19 @@ Vedi [ADR-0099](../adr/0099-local-trend-store.md)/[ADR-0100](../adr/0100-history
 
 ---
 
+### Notifiche (Slack / webhook / email)
+
+`analyze`, `dead-resources`, `resource-security` e `history --compare` possono inviare un riepilogo a Slack, un webhook generico o via email — `--notify-slack`, `--notify-webhook`, `--notify-email <indirizzo>`. Best-effort e mai bloccante: un webhook rotto logga un warning, lo scan resta inalterato. Scatta solo quando c'è qualcosa da segnalare (finding critical/warning, spreco sopra `costAlertThresholdUsd`, o un trend peggiorato su `history --compare`) — uno scan pulito resta silenzioso. **Su Slack arriva solo un alert** (titolo + conteggi, es. "3 critical, 14 warning, 0 info") — deliberatamente senza il dettaglio dei singoli finding, così una pipeline schedulata su più account non trasforma il canale in un muro di testo illeggibile; webhook ed email includono invece i finding principali, dato che un consumer automatico o una inbox personale possono gestire il dettaglio extra senza affollare un canale condiviso.
+
+```sh
+cloudrift resource-security --notify-slack
+cloudrift analyze --notify-email team@esempio.com
+```
+
+Ogni credenziale (`SLACK_WEBHOOK_URL`, `CLOUDRIFT_WEBHOOK_URL`, `CLOUDRIFT_SMTP_HOST`/`PORT`/`USER`/`PASSWORD`/`FROM`) viene letta dall'ambiente, mai da un flag — impostala nella tua shell o come secret di CI, mai in un file committato. Vedi [utilizzo.md](./utilizzo.md#history--storico-locale-delle-scansioni) per il riferimento completo.
+
+---
+
 ### Usalo come server MCP (`mcp`)
 
 Esegui cloudrift come server [MCP](https://modelcontextprotocol.io) locale via stdio, così un agente AI — Claude Code, Kiro, VS Code Copilot Chat (Agent mode) — può chiamare direttamente `analyze_cloudrift`, `get_resource_types` e `get_required_iam_permissions` invece che tu lanci la CLI a mano. Eredita le stesse credenziali AWS di ogni altro comando; vedi [ADR-0082](../adr/0082-mcp-server-second-input-adapter.md).

--- a/docs/it/utilizzo.md
+++ b/docs/it/utilizzo.md
@@ -43,6 +43,9 @@ node apps/cli/dist/main.js analyze [opzioni]
 | `--json [filename]`          | Scrive anche un report JSON su disco (default `cloudrift-reports/AWS_report_YYYY_MM_DD.json`)                                 | —                  |
 | `--csv [filename]`           | Scrive anche un report CSV su disco (default `cloudrift-reports/AWS_report_YYYY_MM_DD.csv`)                                   | —                  |
 | `--silent`                   | Sopprime tutto l'output su stdout (banner, report, conferme) — usalo con `--pdf`/`--json`/`--csv` per ottenere solo il file | off                |
+| `--notify-slack`             | Invia una notifica Slack se lo spreco supera `costAlertThresholdUsd` (o qualsiasi spreco, se non impostato). Legge `SLACK_WEBHOOK_URL` dall'env | off |
+| `--notify-webhook`           | Invia via POST un riepilogo JSON a un webhook, stessa condizione di `--notify-slack`. Legge `CLOUDRIFT_WEBHOOK_URL` dall'env | off |
+| `--notify-email <indirizzo>` | Invia via email un riepilogo a questo indirizzo, stessa condizione di `--notify-slack`. Legge `CLOUDRIFT_SMTP_HOST`/`PORT`/`USER`/`PASSWORD`/`FROM` dall'env | off |
 | `-h, --help`                 | Mostra l'help                                                                                                        | —                  |
 
 > **stdout vs. file:** `--format` controlla cosa va su **stdout** (il report). `--json` / `--pdf` / `--csv` scrivono **file aggiuntivi** su disco, indipendenti da `--format` — di default il `--format` scelto continua comunque a essere stampato su stdout *in aggiunta* alla scrittura di quei file (quindi es. `--pdf` da solo mostra comunque la tabella). Aggiungi `--silent` per ottenere solo il file, senza nulla stampato a terminale. Nei formati machine-readable (`json`, `markdown`, `csv`) tutti i messaggi umani vanno su stderr, così su stdout resta solo il report — ideale per il piping. Errori e l'alert della soglia di costo vanno sempre su stderr, anche con `--silent`.
@@ -221,6 +224,9 @@ node apps/cli/dist/main.js dead-resources [opzioni]
 | `--pdf [filename]`           | Scrive anche un report PDF su disco (default `cloudrift-reports/cloudrift-dead-resources-YYYY_MM_DD.pdf`)                | —                  |
 | `--csv [filename]`           | Scrive anche un report CSV su disco (default `cloudrift-reports/cloudrift-dead-resources-YYYY_MM_DD.csv`)                | —                  |
 | `--silent`                   | Sopprime tutto l'output su stdout (banner, report). Gli errori restano visibili.                                | off                |
+| `--notify-slack`             | Invia una notifica Slack se lo scan ha finding critical/warning. Legge `SLACK_WEBHOOK_URL` dall'env             | off                |
+| `--notify-webhook`           | Invia via POST un riepilogo JSON a un webhook, stessa condizione di `--notify-slack`. Legge `CLOUDRIFT_WEBHOOK_URL` dall'env | off |
+| `--notify-email <indirizzo>` | Invia via email un riepilogo a questo indirizzo, stessa condizione di `--notify-slack`. Legge `CLOUDRIFT_SMTP_HOST`/`PORT`/`USER`/`PASSWORD`/`FROM` dall'env | off |
 | `-h, --help`                 | Mostra l'help                                                                                                    | —                  |
 
 **Check:**
@@ -289,6 +295,9 @@ node apps/cli/dist/main.js resource-security [opzioni]
 | `--pdf [filename]`           | Scrive anche un report PDF su disco (default `cloudrift-reports/cloudrift-resource-security-YYYY_MM_DD.pdf`)             | —                  |
 | `--csv [filename]`           | Scrive anche un report CSV su disco (default `cloudrift-reports/cloudrift-resource-security-YYYY_MM_DD.csv`)             | —                  |
 | `--silent`                   | Sopprime tutto l'output stdout (banner, report). Gli errori restano visibili.                                   | off                |
+| `--notify-slack`             | Invia una notifica Slack se lo scan ha finding critical/warning. Legge `SLACK_WEBHOOK_URL` dall'env             | off                |
+| `--notify-webhook`           | Invia via POST un riepilogo JSON a un webhook, stessa condizione di `--notify-slack`. Legge `CLOUDRIFT_WEBHOOK_URL` dall'env | off |
+| `--notify-email <indirizzo>` | Invia via email un riepilogo a questo indirizzo, stessa condizione di `--notify-slack`. Legge `CLOUDRIFT_SMTP_HOST`/`PORT`/`USER`/`PASSWORD`/`FROM` dall'env | off |
 | `-h, --help`                 | Mostra l'help                                                                                                   | —                  |
 
 **Check:**
@@ -376,7 +385,12 @@ node apps/cli/dist/main.js history [options]
 | `--compare <n>`           | Confronta l'ultima esecuzione con quella di `n` esecuzioni fa invece di elencare (richiede `--domain`) | —               |
 | `--html [filename]`       | Scrive anche un report HTML autocontenuto con un grafico del trend. Con `--domain` grafica solo quel dominio (default `cloudrift-reports/cloudrift-history-<domain>-YYYY_MM_DD.html`); senza, impila tutti e tre i domini su un'unica pagina (default `cloudrift-reports/cloudrift-history-YYYY_MM_DD.html`) | —               |
 | `--format <format>`      | Formato di output su stdout: `table` o `json`                                       | `table`         |
+| `--notify-slack`          | Con `--compare`, invia una notifica Slack se il confronto mostra un peggioramento (trend peggiore). Legge `SLACK_WEBHOOK_URL` dall'env | off |
+| `--notify-webhook`        | Con `--compare`, invia via POST un riepilogo JSON a un webhook, stessa condizione di `--notify-slack`. Legge `CLOUDRIFT_WEBHOOK_URL` dall'env | off |
+| `--notify-email <indirizzo>` | Con `--compare`, invia via email un riepilogo a questo indirizzo, stessa condizione di `--notify-slack`. Legge `CLOUDRIFT_SMTP_HOST`/`PORT`/`USER`/`PASSWORD`/`FROM` dall'env | off |
 | `-h, --help`              | Mostra l'help                                                                       | —               |
+
+> **Notifiche (`analyze`/`dead-resources`/`resource-security`/`history --compare`):** `--notify-slack`/`--notify-webhook`/`--notify-email` sono best-effort e non fanno mai fallire lo scan — un webhook rotto o una config SMTP errata loggano un warning e proseguono. Ogni credenziale (`SLACK_WEBHOOK_URL`, `CLOUDRIFT_WEBHOOK_URL`, `CLOUDRIFT_SMTP_*`) viene letta dall'ambiente, mai da un flag, quindi non finisce mai nella shell history o in `ps aux` — impostale nel profilo della tua shell o come secret di CI (es. `secrets.*` di GitHub Actions), mai in un file committato. Il wizard interattivo offre anche di inviare il report via email (solo se l'SMTP è già configurato), ma non chiede mai di Slack/webhook — quelli sono pensati per CI/script, non per un'esecuzione interattiva occasionale.
 
 **Esempi:**
 

--- a/libs/shared/notifications/eslint.config.mjs
+++ b/libs/shared/notifications/eslint.config.mjs
@@ -1,0 +1,10 @@
+import baseConfig from '../../../eslint.config.mjs';
+
+export default [
+  ...baseConfig,
+  {
+    files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
+    // Override or add rules here
+    rules: {},
+  },
+];

--- a/libs/shared/notifications/jest.config.cjs
+++ b/libs/shared/notifications/jest.config.cjs
@@ -1,0 +1,23 @@
+/** @type {import('@jest/types').Config.InitialOptions} */
+module.exports = {
+  displayName: 'shared-notifications',
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      { tsconfig: '<rootDir>/tsconfig.spec.json', diagnostics: false },
+    ],
+  },
+  moduleFileExtensions: ['ts', 'js', 'json'],
+  testMatch: ['<rootDir>/src/**/*.spec.ts'],
+  collectCoverageFrom: ['<rootDir>/src/**/*.ts', '!<rootDir>/src/**/*.spec.ts', '!<rootDir>/src/index.ts'],
+  coverageThreshold: {
+    global: { statements: 60, branches: 60, functions: 60, lines: 60 },
+  },
+  moduleNameMapper: {
+    '^shared-kernel$': '<rootDir>/../kernel/src/index.ts',
+    '^shared-kernel/(.*)$': '<rootDir>/../kernel/src/$1',
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
+};

--- a/libs/shared/notifications/package.json
+++ b/libs/shared/notifications/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "shared-notifications",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "@cloudrift/source": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "nx": {
+    "tags": [
+      "scope:shared"
+    ],
+    "targets": {
+      "test": {
+        "executor": "@nx/jest:jest",
+        "outputs": [
+          "{workspaceRoot}/coverage/{projectRoot}"
+        ],
+        "options": {
+          "jestConfig": "libs/shared/notifications/jest.config.cjs",
+          "passWithNoTests": true
+        }
+      }
+    }
+  },
+  "dependencies": {
+    "nodemailer": "^9.0.3",
+    "shared-kernel": "workspace:*",
+    "tslib": "^2.8.1"
+  },
+  "devDependencies": {
+    "@types/nodemailer": "^8.0.1"
+  }
+}

--- a/libs/shared/notifications/src/email.notifier.spec.ts
+++ b/libs/shared/notifications/src/email.notifier.spec.ts
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+import { sendEmailNotification } from './email.notifier';
+import type { SmtpConfig } from './email.notifier';
+import type { NotificationSummary } from './types';
+
+const mockSendMail = jest.fn();
+const mockCreateTransport = jest.fn(() => ({ sendMail: mockSendMail }));
+
+jest.mock('nodemailer', () => ({
+  createTransport: (...args: unknown[]) => mockCreateTransport(...args),
+}));
+
+const config: SmtpConfig = { host: 'smtp.example.com', port: 587, user: 'bot@example.com', password: 'secret', from: 'cloudrift@example.com' };
+
+const summary: NotificationSummary = {
+  title: 'cloudrift dead-resources — 5 findings',
+  domain: 'dead-resources',
+  accountId: '123456789012',
+  generatedAt: new Date('2026-07-31'),
+  countBySeverity: { critical: 0, warning: 5, info: 0 },
+  lines: ['Unused IAM role "S3ReadOnly"'],
+};
+
+describe('sendEmailNotification', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('sends a plain-text email built from the summary', async () => {
+    mockSendMail.mockResolvedValueOnce({ messageId: 'abc' });
+
+    const result = await sendEmailNotification(config, 'team@example.com', summary);
+
+    expect(result.ok).toBe(true);
+    expect(mockCreateTransport).toHaveBeenCalledWith(
+      expect.objectContaining({ host: 'smtp.example.com', port: 587, auth: { user: 'bot@example.com', pass: 'secret' } }),
+    );
+    expect(mockSendMail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        from: 'cloudrift@example.com',
+        to: 'team@example.com',
+        subject: summary.title,
+      }),
+    );
+    const { text } = mockSendMail.mock.calls[0][0];
+    expect(text).toContain('0 critical, 5 warning, 0 info');
+    expect(text).toContain('Unused IAM role "S3ReadOnly"');
+  });
+
+  it('uses secure:true for port 465', async () => {
+    mockSendMail.mockResolvedValueOnce({});
+
+    await sendEmailNotification({ ...config, port: 465 }, 'team@example.com', summary);
+
+    expect(mockCreateTransport).toHaveBeenCalledWith(expect.objectContaining({ secure: true }));
+  });
+
+  it('returns Result.fail instead of throwing when sendMail rejects', async () => {
+    mockSendMail.mockRejectedValueOnce(new Error('SMTP auth failed'));
+
+    const result = await sendEmailNotification(config, 'team@example.com', summary);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toBe('SMTP auth failed');
+  });
+});

--- a/libs/shared/notifications/src/email.notifier.ts
+++ b/libs/shared/notifications/src/email.notifier.ts
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+import { Result } from 'shared-kernel';
+import type { NotificationSummary } from './types';
+
+export interface SmtpConfig {
+  host: string;
+  port: number;
+  user: string;
+  password: string;
+  from: string;
+}
+
+function buildEmailBody(summary: NotificationSummary): string {
+  const lines = [summary.title, ''];
+  if (summary.countBySeverity) {
+    const { critical, warning, info } = summary.countBySeverity;
+    lines.push(`${critical} critical, ${warning} warning, ${info} info — account ${summary.accountId}`, '');
+  } else {
+    lines.push(`Account: ${summary.accountId}`, '');
+  }
+  lines.push(...summary.lines.map((line) => `- ${line}`));
+  return lines.join('\n');
+}
+
+/**
+ * Sends a plain-text summary email via SMTP (`nodemailer`). Same
+ * never-throws, best-effort contract as the other notifiers — a broken SMTP
+ * config shouldn't fail the scan it's reporting on.
+ */
+export async function sendEmailNotification(config: SmtpConfig, to: string, summary: NotificationSummary): Promise<Result<void>> {
+  try {
+    const { createTransport } = await import('nodemailer');
+    const transport = createTransport({
+      host: config.host,
+      port: config.port,
+      secure: config.port === 465,
+      auth: { user: config.user, pass: config.password },
+    });
+    await transport.sendMail({
+      from: config.from,
+      to,
+      subject: summary.title,
+      text: buildEmailBody(summary),
+    });
+    return Result.ok(undefined);
+  } catch (err) {
+    return Result.fail(err instanceof Error ? err : new Error(String(err)));
+  }
+}

--- a/libs/shared/notifications/src/generic-webhook.notifier.spec.ts
+++ b/libs/shared/notifications/src/generic-webhook.notifier.spec.ts
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+import { sendWebhookNotification } from './generic-webhook.notifier';
+import type { NotificationSummary } from './types';
+
+const summary: NotificationSummary = {
+  title: 'cloudrift analyze — $42.10/month wasted',
+  domain: 'cloud-cost',
+  accountId: '123456789012',
+  generatedAt: new Date('2026-07-31'),
+  lines: ['3 unattached EBS volumes'],
+};
+
+describe('sendWebhookNotification', () => {
+  const mockFetch = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = mockFetch;
+  });
+
+  it('POSTs the full summary as JSON', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true, status: 200, statusText: 'OK' });
+
+    const result = await sendWebhookNotification('https://example.com/hook', summary);
+
+    expect(result.ok).toBe(true);
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://example.com/hook',
+      expect.objectContaining({ method: 'POST', headers: { 'Content-Type': 'application/json' } }),
+    );
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.title).toBe(summary.title);
+    expect(body.domain).toBe('cloud-cost');
+  });
+
+  it('returns Result.fail on a non-2xx response', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 500, statusText: 'Internal Server Error' });
+
+    const result = await sendWebhookNotification('https://example.com/hook', summary);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toContain('500');
+  });
+
+  it('returns Result.fail instead of throwing on a network error', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+
+    const result = await sendWebhookNotification('https://example.com/hook', summary);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toBe('ECONNREFUSED');
+  });
+});

--- a/libs/shared/notifications/src/generic-webhook.notifier.ts
+++ b/libs/shared/notifications/src/generic-webhook.notifier.ts
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+import { Result } from 'shared-kernel';
+import type { NotificationSummary } from './types';
+
+/**
+ * Posts the full `NotificationSummary` as JSON to an arbitrary URL — the
+ * "bring your own integration" escape hatch for services cloudrift doesn't
+ * have a dedicated notifier for (Teams, Discord, an internal ops endpoint,
+ * ...). Same never-throws contract as the Slack notifier.
+ */
+export async function sendWebhookNotification(url: string, summary: NotificationSummary): Promise<Result<void>> {
+  try {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(summary),
+    });
+    if (!response.ok) {
+      return Result.fail(new Error(`Webhook returned ${response.status} ${response.statusText}`));
+    }
+    return Result.ok(undefined);
+  } catch (err) {
+    return Result.fail(err instanceof Error ? err : new Error(String(err)));
+  }
+}

--- a/libs/shared/notifications/src/index.ts
+++ b/libs/shared/notifications/src/index.ts
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0
+export type { NotificationSummary } from './types';
+export { shouldNotifyOnSeverity, hasRegressed, shouldNotifyOnCost } from './should-notify';
+export { sendSlackNotification } from './slack-webhook.notifier';
+export { sendWebhookNotification } from './generic-webhook.notifier';
+export { sendEmailNotification } from './email.notifier';
+export type { SmtpConfig } from './email.notifier';

--- a/libs/shared/notifications/src/should-notify.spec.ts
+++ b/libs/shared/notifications/src/should-notify.spec.ts
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+import { shouldNotifyOnSeverity, hasRegressed, shouldNotifyOnCost } from './should-notify';
+
+describe('shouldNotifyOnSeverity', () => {
+  it('is false when there are no critical or warning findings', () => {
+    expect(shouldNotifyOnSeverity({ critical: 0, warning: 0 })).toBe(false);
+  });
+
+  it('is true when there is at least one critical finding', () => {
+    expect(shouldNotifyOnSeverity({ critical: 1, warning: 0 })).toBe(true);
+  });
+
+  it('is true when there is at least one warning finding', () => {
+    expect(shouldNotifyOnSeverity({ critical: 0, warning: 1 })).toBe(true);
+  });
+});
+
+describe('hasRegressed', () => {
+  it('is false when nothing new and no cost delta', () => {
+    expect(hasRegressed({ newFindingsCount: 0 })).toBe(false);
+    expect(hasRegressed({ newFindingsCount: 0, deltaUsd: 0 })).toBe(false);
+  });
+
+  it('is true when there are new findings', () => {
+    expect(hasRegressed({ newFindingsCount: 1 })).toBe(true);
+  });
+
+  it('is true when the cost delta is positive', () => {
+    expect(hasRegressed({ newFindingsCount: 0, deltaUsd: 12.5 })).toBe(true);
+  });
+
+  it('is false when the cost delta is negative (spend went down)', () => {
+    expect(hasRegressed({ newFindingsCount: 0, deltaUsd: -12.5 })).toBe(false);
+  });
+});
+
+describe('shouldNotifyOnCost', () => {
+  it('is false when there is no waste and no threshold configured', () => {
+    expect(shouldNotifyOnCost(0)).toBe(false);
+  });
+
+  it('is true when there is any waste and no threshold configured', () => {
+    expect(shouldNotifyOnCost(0.01)).toBe(true);
+  });
+
+  it('is false when waste is under the configured threshold', () => {
+    expect(shouldNotifyOnCost(50, 100)).toBe(false);
+  });
+
+  it('is true when waste exceeds the configured threshold', () => {
+    expect(shouldNotifyOnCost(150, 100)).toBe(true);
+  });
+
+  it('is false when waste equals the threshold exactly', () => {
+    expect(shouldNotifyOnCost(100, 100)).toBe(false);
+  });
+});

--- a/libs/shared/notifications/src/should-notify.ts
+++ b/libs/shared/notifications/src/should-notify.ts
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * A scan-domain report is worth notifying about only once it has at least
+ * one `critical` or `warning` finding — a clean run (or one with only
+ * `info`-level noise) doesn't page anyone. Not applicable to `history`
+ * comparisons, which use `hasRegressed` below instead (a comparison can
+ * still be "worth notifying" on a worsening trend even if the absolute
+ * counts aren't new).
+ */
+export function shouldNotifyOnSeverity(countBySeverity: { critical: number; warning: number }): boolean {
+  return countBySeverity.critical > 0 || countBySeverity.warning > 0;
+}
+
+/**
+ * A `history --compare` run is worth notifying about only when something got
+ * worse since the previous snapshot — not merely "there's still a critical
+ * finding," which would fire every single scheduled run for as long as that
+ * finding stays unresolved. `newFindingsCount` covers `dead-resources`/
+ * `resource-security` (any newly-appeared finding is a regression); `deltaUsd`
+ * covers `cloud-cost` (spend went up).
+ */
+export function hasRegressed(delta: { newFindingsCount: number; deltaUsd?: number }): boolean {
+  return delta.newFindingsCount > 0 || (delta.deltaUsd ?? 0) > 0;
+}
+
+/**
+ * `analyze` (cost-waste) has no severity concept (ADR: dollar total + category
+ * split, not info/warning/critical) — reuses the existing cost-alert-threshold
+ * config instead: notify once waste exceeds it, same threshold `applyCostGate`
+ * already gates CI exit codes on. With no threshold configured, any waste at
+ * all is worth a notification (there's no other signal to gate on).
+ */
+export function shouldNotifyOnCost(totalWasteMonthlyUsd: number, costAlertThresholdUsd?: number): boolean {
+  return costAlertThresholdUsd !== undefined ? totalWasteMonthlyUsd > costAlertThresholdUsd : totalWasteMonthlyUsd > 0;
+}

--- a/libs/shared/notifications/src/slack-webhook.notifier.spec.ts
+++ b/libs/shared/notifications/src/slack-webhook.notifier.spec.ts
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+import { sendSlackNotification } from './slack-webhook.notifier';
+import type { NotificationSummary } from './types';
+
+const summary: NotificationSummary = {
+  title: 'cloudrift resource-security — 2 critical, 1 warning, 0 info (account 123456789012)',
+  domain: 'resource-security',
+  accountId: '123456789012',
+  generatedAt: new Date('2026-07-31'),
+  countBySeverity: { critical: 2, warning: 1, info: 0 },
+  lines: ['S3 bucket "my-bucket" is public', 'Root account has no MFA'],
+};
+
+async function postedAttachment(mockFetch: jest.Mock) {
+  const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+  return body.attachments[0];
+}
+
+describe('sendSlackNotification', () => {
+  const mockFetch = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = mockFetch;
+    mockFetch.mockResolvedValue({ ok: true, status: 200, statusText: 'OK' });
+  });
+
+  it('posts the title, bolded, as a single colored attachment — no per-finding detail', async () => {
+    const result = await sendSlackNotification('https://hooks.slack.com/services/x', summary);
+
+    expect(result.ok).toBe(true);
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://hooks.slack.com/services/x',
+      expect.objectContaining({ method: 'POST', headers: { 'Content-Type': 'application/json' } }),
+    );
+    const attachment = await postedAttachment(mockFetch);
+    expect(attachment.text).toBe(`*${summary.title}*`);
+    expect(attachment.mrkdwn_in).toEqual(['text']);
+  });
+
+  it('never leaks summary.lines into the Slack message, regardless of content', async () => {
+    const wildcardSummary: NotificationSummary = {
+      ...summary,
+      lines: ['iam-user-policy-wildcard: grants Action: "*", Resource: "*" (critical)'],
+    };
+
+    await sendSlackNotification('https://hooks.slack.com/services/x', wildcardSummary);
+
+    const attachment = await postedAttachment(mockFetch);
+    expect(attachment.text).toBe(`*${wildcardSummary.title}*`);
+    expect(attachment.text).not.toContain('iam-user-policy-wildcard');
+  });
+
+  it('colors the attachment red when there is at least one critical finding', async () => {
+    await sendSlackNotification('https://hooks.slack.com/services/x', { ...summary, countBySeverity: { critical: 1, warning: 5, info: 0 } });
+
+    expect((await postedAttachment(mockFetch)).color).toBe('#d03b3b');
+  });
+
+  it('colors the attachment amber when there are warnings but no criticals', async () => {
+    await sendSlackNotification('https://hooks.slack.com/services/x', { ...summary, countBySeverity: { critical: 0, warning: 3, info: 0 } });
+
+    expect((await postedAttachment(mockFetch)).color).toBe('#fab219');
+  });
+
+  it('colors the attachment muted grey when only info findings are present', async () => {
+    await sendSlackNotification('https://hooks.slack.com/services/x', { ...summary, countBySeverity: { critical: 0, warning: 0, info: 2 } });
+
+    expect((await postedAttachment(mockFetch)).color).toBe('#898781');
+  });
+
+  it('defaults to the amber color for summaries with no severity concept (e.g. cost-waste)', async () => {
+    await sendSlackNotification('https://hooks.slack.com/services/x', { ...summary, countBySeverity: undefined });
+
+    expect((await postedAttachment(mockFetch)).color).toBe('#fab219');
+  });
+
+  it('returns Result.fail when Slack responds with a non-2xx status', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 404, statusText: 'Not Found' });
+
+    const result = await sendSlackNotification('https://hooks.slack.com/services/x', summary);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toContain('404');
+  });
+
+  it('returns Result.fail instead of throwing on a network error', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('ENOTFOUND'));
+
+    const result = await sendSlackNotification('https://hooks.slack.com/services/x', summary);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toBe('ENOTFOUND');
+  });
+});

--- a/libs/shared/notifications/src/slack-webhook.notifier.ts
+++ b/libs/shared/notifications/src/slack-webhook.notifier.ts
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+import { Result } from 'shared-kernel';
+import type { NotificationSummary } from './types';
+
+/**
+ * Same fixed status palette as `history-report.html-formatter.ts`'s
+ * `--severity-critical`/`--severity-warning`/info-as-muted — never themed,
+ * kept identical across every surface that shows a severity so a "critical"
+ * finding looks the same shade of red everywhere in cloudrift.
+ */
+const SEVERITY_COLOR = { critical: '#d03b3b', warning: '#fab219', info: '#898781' } as const;
+
+/** No severity concept for cost-waste/regression alerts (`analyze`, cost-based `history --compare`) — treat as "worth a second look," same weight as `warning`. */
+const DEFAULT_COLOR = SEVERITY_COLOR.warning;
+
+function pickColor(countBySeverity: NotificationSummary['countBySeverity']): string {
+  if (!countBySeverity) return DEFAULT_COLOR;
+  if (countBySeverity.critical > 0) return SEVERITY_COLOR.critical;
+  if (countBySeverity.warning > 0) return SEVERITY_COLOR.warning;
+  return SEVERITY_COLOR.info;
+}
+
+/**
+ * Posts to a Slack "Incoming Webhook" URL using a colored "attachment" (the
+ * classic mechanism Slack integrations have used for status-colored alerts
+ * for years — a vertical bar in `color`, alongside `text`) rather than the
+ * bare top-level `text` field. Deliberately just `summary.title` in bold —
+ * every command builds it to already carry domain, counts/amount, and
+ * account (see e.g. `resource-security.command.ts`), so nothing else is
+ * needed. Earlier versions also rendered `summary.lines` (the top findings)
+ * here, but that treated Slack as a mini-report instead of an alert: fine
+ * for a single manual run, but on a scheduled pipeline scanning several
+ * accounts/regions it turns into an unbounded wall of text per run.
+ * `lines` is still populated and sent as-is to the generic webhook and
+ * email notifiers, where a machine consumer or a personal inbox can handle
+ * the extra detail without cluttering a shared channel — only Slack's own
+ * rendering dropped it. Bold markdown is safe here specifically because the
+ * title is a fixed format string built from numbers/enum-like domain
+ * names — never free-text from a finding, which is what made `*`/`_`/`~`
+ * inside `summary.lines` dangerous (Slack's mrkdwn parser eats a `*...*`
+ * pair as bold; confirmed live against a real webhook that this happened
+ * with an IAM wildcard policy's `Action: "*"`, and that neither `mrkdwn:
+ * false` nor fullwidth-Unicode substitution reliably prevented it). Never
+ * throws: network/HTTP failures are returned as `Result.fail` so callers
+ * can log-and-continue (this channel is always best-effort, never allowed
+ * to fail the scan itself).
+ */
+export async function sendSlackNotification(webhookUrl: string, summary: NotificationSummary): Promise<Result<void>> {
+  try {
+    const response = await fetch(webhookUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        attachments: [{ color: pickColor(summary.countBySeverity), text: `*${summary.title}*`, mrkdwn_in: ['text'] }],
+      }),
+    });
+    if (!response.ok) {
+      return Result.fail(new Error(`Slack webhook returned ${response.status} ${response.statusText}`));
+    }
+    return Result.ok(undefined);
+  } catch (err) {
+    return Result.fail(err instanceof Error ? err : new Error(String(err)));
+  }
+}

--- a/libs/shared/notifications/src/types.ts
+++ b/libs/shared/notifications/src/types.ts
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Domain-agnostic summary a caller builds from its own report DTO before
+ * handing it to a notifier. Deliberately flat and free of any
+ * domain-specific type (`WasteReportDto`, `SecurityFinding`, ...) so this
+ * package never depends on `cloud-cost-*`/`dead-resources-*`/
+ * `resource-security-*` — same "boundary DTO" reasoning as `SecurityFinding`
+ * itself (ADR-0078 lineage), one level further out.
+ */
+export interface NotificationSummary {
+  /** e.g. "cloudrift resource-security — 3 critical findings". */
+  title: string;
+  domain: 'cloud-cost' | 'dead-resources' | 'resource-security' | 'history';
+  accountId: string;
+  generatedAt: Date;
+  /** Present for the three scan domains; omitted for `history` comparisons, which have their own delta framing in `lines`. */
+  countBySeverity?: { critical: number; warning: number; info: number };
+  /** Short, already-formatted lines — e.g. top findings, or a comparison delta. Rendered as-is (one per line/bullet) by each notifier. */
+  lines: string[];
+}

--- a/libs/shared/notifications/tsconfig.json
+++ b/libs/shared/notifications/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/libs/shared/notifications/tsconfig.lib.json
+++ b/libs/shared/notifications/tsconfig.lib.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "dist/tsconfig.lib.tsbuildinfo",
+    "emitDeclarationOnly": false,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"],
+  "references": [
+    {
+      "path": "../kernel/tsconfig.lib.json"
+    }
+  ]
+}

--- a/libs/shared/notifications/tsconfig.spec.json
+++ b/libs/shared/notifications/tsconfig.spec.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "outDir": "./dist/test",
+    "types": ["jest", "node"],
+    "strict": true,
+    "esModuleInterop": true
+  },
+  "include": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -296,6 +296,9 @@ importers:
       mcp-server-application:
         specifier: workspace:*
         version: link:../../libs/mcp-server/application
+      nodemailer:
+        specifier: ^9.0.3
+        version: 9.0.3
       pdfkit:
         specifier: ^0.19.1
         version: 0.19.1
@@ -314,6 +317,9 @@ importers:
       shared-kernel:
         specifier: workspace:*
         version: link:../../libs/shared/kernel
+      shared-notifications:
+        specifier: workspace:*
+        version: link:../../libs/shared/notifications
       shared-trend-store:
         specifier: workspace:*
         version: link:../../libs/shared/trend-store
@@ -758,6 +764,22 @@ importers:
       tslib:
         specifier: ^2.8.1
         version: 2.8.1
+
+  libs/shared/notifications:
+    dependencies:
+      nodemailer:
+        specifier: ^9.0.3
+        version: 9.0.3
+      shared-kernel:
+        specifier: workspace:*
+        version: link:../kernel
+      tslib:
+        specifier: ^2.8.1
+        version: 2.8.1
+    devDependencies:
+      '@types/nodemailer':
+        specifier: ^8.0.1
+        version: 8.0.1
 
   libs/shared/scan-coordination:
     dependencies:
@@ -2869,6 +2891,9 @@ packages:
   '@types/node@22.20.1':
     resolution: {integrity: sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==}
 
+  '@types/nodemailer@8.0.1':
+    resolution: {integrity: sha512-PxpaInm8V1JQDd4j0ds5HfvWQk8JupS1C0Picb96QJsrrRDjBH+DlK7L4ZdNSqNULhiZRQHc40nLVShaGxXAMw==}
+
   '@types/parse-json@4.0.2':
     resolution: {integrity: sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==}
 
@@ -4565,6 +4590,10 @@ packages:
   node-releases@2.0.51:
     resolution: {integrity: sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==}
     engines: {node: '>=18'}
+
+  nodemailer@9.0.3:
+    resolution: {integrity: sha512-n+YP+NKwR5zRWa60k3GiQ6Q3B4KXCoAw40dAKeCtYn020iNN74aWK2liXIC3ZEATeGql7we3tE3t8QwhY0eskw==}
+    engines: {node: '>=6.0.0'}
 
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
@@ -8562,6 +8591,10 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/nodemailer@8.0.1':
+    dependencies:
+      '@types/node': 22.20.1
+
   '@types/parse-json@4.0.2': {}
 
   '@types/pdfkit@0.13.9':
@@ -10669,6 +10702,8 @@ snapshots:
   node-int64@0.4.0: {}
 
   node-releases@2.0.51: {}
+
+  nodemailer@9.0.3: {}
 
   normalize-path@3.0.0: {}
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -59,6 +59,9 @@
     },
     {
       "path": "./libs/shared/trend-store"
+    },
+    {
+      "path": "./libs/shared/notifications"
     }
   ]
 }


### PR DESCRIPTION
New shared-notifications lib (Slack, generic webhook, email via nodemailer) wired into analyze/dead-resources/resource-security/history --compare via --notify-slack/--notify-webhook/--notify-email. Fires only when there's something worth reporting (critical/warning findings, waste over the configured threshold, or a worsening trend); best-effort, never blocks the scan. All channel secrets come from env vars, never a flag. The interactive wizard offers to email the report (only when SMTP is already configured); Slack/webhook stay flag-only for CI.

Slack rendering was refined against a real workspace: an IAM wildcard policy's literal "*" was silently eaten by Slack's mrkdwn bold parser, and per-finding detail didn't scale across multi-account pipelines — Slack now gets a single color-coded (critical/warning/info) alert with just the title, while the webhook/email payloads keep the full finding detail.