### PR TITLE
chore(release): bump @cloudrift/cli to 0.9.1

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudrift/cli",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Detect and report wasted AWS cloud resources — built to run in CI/CD and fail pipelines over a cost threshold.",
   "keywords": [
     "aws",


### PR DESCRIPTION
## Summary

- Version bump only: `apps/cli/package.json` 0.9.0 → 0.9.1, for the fixes in #103 (real price differences replacing heuristic estimates, 14-day idle window).
- No other changes.

## Test plan

- [x] Trivial single-field change, covered by the existing green suite on `main`