### PR TITLE
feat(cli): add PDF bookmarks/outline for long reports

### DIFF
--- a/apps/cli/src/formatters/severity-report.formatter.spec.ts
+++ b/apps/cli/src/formatters/severity-report.formatter.spec.ts
@@ -174,6 +174,12 @@ describe('SeverityReportFormatter.toPdf', () => {
     );
     expect(written.subarray(0, 5).toString('latin1')).toBe('%PDF-');
     expect(written.length).toBeGreaterThan(1000);
+
+    const asText = written.toString('latin1');
+    expect(asText).toContain('/Outlines');
+    expect(asText).toContain('(Summary)');
+    expect(asText).toContain('(Alpha Section)');
+    expect(asText).toContain('(Beta Section)');
   });
 
   it('writes a valid PDF when there are no findings', async () => {

--- a/apps/cli/src/formatters/severity-report.formatter.ts
+++ b/apps/cli/src/formatters/severity-report.formatter.ts
@@ -160,6 +160,7 @@ export abstract class SeverityReportFormatter<
       const contentBottom = PAGE_H - MARGIN - footerReservedHeight(disclaimerH);
       doc.on('pageAdded', () => drawFooter(doc, this.disclaimer, disclaimerH));
       doc.addPage();
+      doc.outline.addItem('Summary');
 
       this.drawSummaryPage(doc, summary, meta, contentBottom);
       this.drawDetailPages(doc, summary, contentBottom);
@@ -240,6 +241,7 @@ export abstract class SeverityReportFormatter<
 
       const presenter = this.presenterFor(kind);
       doc.addPage();
+      doc.outline.addItem(presenter.title);
       const y = this.sectionHeader(doc, presenter.title);
       const links = findings.map((finding) =>
         buildConsoleUrl({ kind: finding.kind, id: finding.id, region: finding.region?.code }),

--- a/apps/cli/src/formatters/waste-report.pdf-formatter.spec.ts
+++ b/apps/cli/src/formatters/waste-report.pdf-formatter.spec.ts
@@ -126,6 +126,16 @@ describe('generateWasteReportPdf', () => {
       const written = await readFile(file);
       expect(written.subarray(0, 5).toString('latin1')).toBe('%PDF-');
       expect(written.length).toBeGreaterThan(1000);
+
+      // Section titles contain an em dash, so PDFKit encodes them as
+      // UTF-16BE — only the plain-ASCII "Summary" bookmark survives a
+      // latin1 substring match; the per-section count below covers the rest.
+      const asText = written.toString('latin1');
+      expect(asText).toContain('/Outlines');
+      expect(asText).toContain('/PageMode /UseOutlines');
+      expect(asText).toContain('(Summary)');
+      const distinctKinds = new Set(findings.map((f) => f.kind)).size;
+      expect(asText.match(/\/Title \(/g)?.length).toBe(1 + distinctKinds);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/apps/cli/src/formatters/waste-report.pdf-formatter.ts
+++ b/apps/cli/src/formatters/waste-report.pdf-formatter.ts
@@ -59,6 +59,7 @@ export async function generateWasteReportPdf(
     // its footer drawn here, right when it's created — see drawFooter above.
     doc.on('pageAdded', () => drawFooter(doc, REPORT_DISCLAIMER, disclaimerH));
     doc.addPage();
+    doc.outline.addItem('Summary');
 
     drawSummaryPage(doc, summary, meta, contentBottom);
     drawDetailPages(doc, summary, contentBottom);
@@ -207,6 +208,7 @@ function drawDetailPages(
 
     const presenter = presenterFor(kind);
     doc.addPage();
+    doc.outline.addItem(presenter.title);
     const y = sectionHeader(doc, presenter.title);
     const links = findings.map((finding) =>
       buildConsoleUrl({ kind: finding.kind, id: finding.id, region: finding.region.code }),


### PR DESCRIPTION
## Summary
- Add a "Summary" bookmark plus one per resource-kind section to every PDF report (waste, resource-security, dead-resources), via PDFKit's `doc.outline.addItem`, so long reports can be navigated from the viewer's bookmark sidebar instead of scrolling.
- Applied to `waste-report.pdf-formatter.ts` and the shared `severity-report.formatter.ts` base class (covers resource-security and dead-resources).

## Test plan
- [x] `nx run-many --target=lint,test,build --projects=cli` all green (299 tests)
- [x] Unit tests assert the outline dictionary and section titles are present in the generated PDF bytes
- [ ] Manual visual check of the bookmark sidebar in a PDF viewer