### PR TITLE
PR comment on budget overrun via new GitHub notifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,16 +289,17 @@ See [ADR-0099](https://github.com/elleVas/cloudrift/blob/main/docs/adr/0099-loca
 
 ---
 
-### Notifications (Slack / webhook / email)
+### Notifications (Slack / webhook / email / GitHub PR comment)
 
-`analyze`, `dead-resources`, `resource-security`, and `history --compare` can send a summary to Slack, a generic webhook, or email — `--notify-slack`, `--notify-webhook`, `--notify-email <address>`. Best-effort and never blocking: a broken webhook logs a warning, the scan itself is unaffected. Fires only when there's something worth reporting (critical/warning findings, waste over `costAlertThresholdUsd`, or a worsening trend on `history --compare`) — a clean run stays quiet. **Slack gets an alert only** (title + counts, e.g. "3 critical, 14 warning, 0 info") — deliberately no per-finding detail, so a scheduled pipeline scanning several accounts never turns the channel into an unreadable wall of text; the webhook and email payloads include the top findings, since a machine consumer or a personal inbox can handle the extra detail without cluttering a shared channel.
+`analyze`, `dead-resources`, `resource-security`, and `history --compare` can send a summary to Slack, a generic webhook, email, or a GitHub PR comment — `--notify-slack`, `--notify-webhook`, `--notify-email <address>`, `--notify-github-comment`. Best-effort and never blocking: a broken webhook logs a warning, the scan itself is unaffected. Fires only when there's something worth reporting (critical/warning findings, waste over `costAlertThresholdUsd`, or a worsening trend on `history --compare`) — a clean run stays quiet. **Slack gets an alert only** (title + counts, e.g. "3 critical, 14 warning, 0 info") — deliberately no per-finding detail, so a scheduled pipeline scanning several accounts never turns the channel into an unreadable wall of text; the webhook, email, and PR comment payloads include the top findings, since a machine consumer, a personal inbox, or a PR reviewer can handle the extra detail without cluttering a shared channel.
 
 ```sh
 cloudrift resource-security --notify-slack
 cloudrift analyze --notify-email team@example.com
+cloudrift analyze --notify-github-comment
 ```
 
-Every credential (`SLACK_WEBHOOK_URL`, `CLOUDRIFT_WEBHOOK_URL`, `CLOUDRIFT_SMTP_HOST`/`PORT`/`USER`/`PASSWORD`/`FROM`) comes from the environment, never a flag — set it in your shell or as a CI secret, never in a committed file. See [docs/en/usage.md](https://github.com/elleVas/cloudrift/blob/main/docs/en/usage.md#history--local-scan-history) for the full reference.
+Every credential (`SLACK_WEBHOOK_URL`, `CLOUDRIFT_WEBHOOK_URL`, `CLOUDRIFT_SMTP_HOST`/`PORT`/`USER`/`PASSWORD`/`FROM`, `GITHUB_TOKEN`) comes from the environment, never a flag — set it in your shell or as a CI secret, never in a committed file. `--notify-github-comment` also needs `GITHUB_REPOSITORY`/`GITHUB_EVENT_PATH` (set automatically by GitHub Actions) and only posts on a `pull_request` trigger; see the [`action.yml`](./action.yml) `pr-comment` input for the one-flag way to enable it from the reusable Action. See [docs/en/usage.md](https://github.com/elleVas/cloudrift/blob/main/docs/en/usage.md#history--local-scan-history) for the full reference.
 
 ---
 

--- a/action.yml
+++ b/action.yml
@@ -43,6 +43,10 @@ inputs:
     description: 'Append the report to $GITHUB_STEP_SUMMARY when format is markdown'
     required: false
     default: 'true'
+  pr-comment:
+    description: 'Post the report as a PR comment when waste exceeds costAlertThresholdUsd (requires the job to grant `permissions: pull-requests: write` and to run on a pull_request trigger)'
+    required: false
+    default: 'false'
   version:
     description: 'Version (or dist-tag) of @cloudrift/cli to install'
     required: false
@@ -78,6 +82,11 @@ runs:
         CLOUDRIFT_PDF: ${{ inputs.pdf }}
         CLOUDRIFT_JSON: ${{ inputs.json }}
         CLOUDRIFT_STEP_SUMMARY: ${{ inputs.step-summary }}
+        CLOUDRIFT_PR_COMMENT: ${{ inputs.pr-comment }}
+        # Only forwarded when pr-comment is requested: Actions does not export
+        # GITHUB_TOKEN to shell steps by default (unlike GITHUB_REPOSITORY/
+        # GITHUB_EVENT_PATH, which always are), so it has to be set explicitly.
+        GITHUB_TOKEN: ${{ inputs.pr-comment == 'true' && github.token || '' }}
       run: |
         set +e
         args=(--regions $CLOUDRIFT_REGIONS --format "$CLOUDRIFT_FORMAT")
@@ -89,6 +98,7 @@ runs:
         [ -n "$CLOUDRIFT_IGNORE_TAG" ] && args+=(--ignore-tag "$CLOUDRIFT_IGNORE_TAG")
         [ -n "$CLOUDRIFT_PDF" ] && args+=(--pdf "$CLOUDRIFT_PDF")
         [ -n "$CLOUDRIFT_JSON" ] && args+=(--json "$CLOUDRIFT_JSON")
+        [ "$CLOUDRIFT_PR_COMMENT" = "true" ] && args+=(--notify-github-comment)
 
         output="$(cloudrift analyze "${args[@]}")"
         code=$?

--- a/apps/cli/src/commands/history.command.ts
+++ b/apps/cli/src/commands/history.command.ts
@@ -43,8 +43,8 @@ function parseLimitOption(options: HistoryCommandOptions): ParsedOption {
 /** See `parseLimitOption` — same flattening reason. */
 function parseCompareOption(options: HistoryCommandOptions): ParsedOption {
   if (options.compare === undefined) {
-    if (options.notifySlack || options.notifyWebhook || options.notifyEmail) {
-      return { ok: false, message: '--notify-slack/--notify-webhook/--notify-email require --compare (they notify on a regression, which only a comparison can detect).' };
+    if (options.notifySlack || options.notifyWebhook || options.notifyEmail || options.notifyGithubComment) {
+      return { ok: false, message: '--notify-slack/--notify-webhook/--notify-email/--notify-github-comment require --compare (they notify on a regression, which only a comparison can detect).' };
     }
     return { ok: true, value: undefined };
   }

--- a/apps/cli/src/commands/notifications.spec.ts
+++ b/apps/cli/src/commands/notifications.spec.ts
@@ -1,4 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
+import { writeFileSync, mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { dispatchNotifications, topFindingLines } from './notifications';
 import type { NotificationSummary } from 'shared-notifications';
 import * as notifiers from 'shared-notifications';
@@ -7,6 +10,7 @@ jest.mock('shared-notifications', () => ({
   sendSlackNotification: jest.fn(),
   sendWebhookNotification: jest.fn(),
   sendEmailNotification: jest.fn(),
+  sendGithubPrComment: jest.fn(),
 }));
 
 const summary: NotificationSummary = {
@@ -18,7 +22,24 @@ const summary: NotificationSummary = {
   lines: ['S3 bucket "my-bucket" is public'],
 };
 
-const ENV_KEYS = ['SLACK_WEBHOOK_URL', 'CLOUDRIFT_WEBHOOK_URL', 'CLOUDRIFT_SMTP_HOST', 'CLOUDRIFT_SMTP_PORT', 'CLOUDRIFT_SMTP_USER', 'CLOUDRIFT_SMTP_PASSWORD', 'CLOUDRIFT_SMTP_FROM'];
+const ENV_KEYS = [
+  'SLACK_WEBHOOK_URL',
+  'CLOUDRIFT_WEBHOOK_URL',
+  'CLOUDRIFT_SMTP_HOST',
+  'CLOUDRIFT_SMTP_PORT',
+  'CLOUDRIFT_SMTP_USER',
+  'CLOUDRIFT_SMTP_PASSWORD',
+  'CLOUDRIFT_SMTP_FROM',
+  'GITHUB_TOKEN',
+  'GITHUB_REPOSITORY',
+  'GITHUB_EVENT_PATH',
+];
+
+function writePullRequestEvent(prNumber: number): string {
+  const path = join(mkdtempSync(join(tmpdir(), 'cloudrift-notify-')), 'event.json');
+  writeFileSync(path, JSON.stringify({ pull_request: { number: prNumber } }));
+  return path;
+}
 
 describe('dispatchNotifications', () => {
   let info: jest.Mock;
@@ -105,6 +126,48 @@ describe('dispatchNotifications', () => {
 
     expect(notifiers.sendEmailNotification).not.toHaveBeenCalled();
     expect(info).toHaveBeenCalledWith(expect.stringContaining('CLOUDRIFT_SMTP_HOST/PORT/USER/PASSWORD/FROM'));
+  });
+
+  it('posts a GitHub PR comment when --notify-github-comment is set and the event is a pull_request', async () => {
+    process.env.GITHUB_TOKEN = 'ghs_x';
+    process.env.GITHUB_REPOSITORY = 'elleVas/cloudrift';
+    process.env.GITHUB_EVENT_PATH = writePullRequestEvent(42);
+    (notifiers.sendGithubPrComment as jest.Mock).mockResolvedValueOnce({ ok: true, value: undefined });
+
+    await dispatchNotifications({ notifyGithubComment: true }, summary, info);
+
+    expect(notifiers.sendGithubPrComment).toHaveBeenCalledWith({ token: 'ghs_x', owner: 'elleVas', repo: 'cloudrift', prNumber: 42 }, summary);
+    expect(info).toHaveBeenCalledWith(expect.stringContaining('posted'));
+  });
+
+  it('warns and skips the PR comment when GITHUB_TOKEN/GITHUB_REPOSITORY/GITHUB_EVENT_PATH are missing', async () => {
+    await dispatchNotifications({ notifyGithubComment: true }, summary, info);
+
+    expect(notifiers.sendGithubPrComment).not.toHaveBeenCalled();
+    expect(info).toHaveBeenCalledWith(expect.stringContaining('GITHUB_TOKEN'));
+  });
+
+  it('warns and skips the PR comment when the triggering event has no pull_request (e.g. a push/cron run)', async () => {
+    process.env.GITHUB_TOKEN = 'ghs_x';
+    process.env.GITHUB_REPOSITORY = 'elleVas/cloudrift';
+    const path = join(mkdtempSync(join(tmpdir(), 'cloudrift-notify-')), 'event.json');
+    writeFileSync(path, JSON.stringify({ ref: 'refs/heads/main' }));
+    process.env.GITHUB_EVENT_PATH = path;
+
+    await dispatchNotifications({ notifyGithubComment: true }, summary, info);
+
+    expect(notifiers.sendGithubPrComment).not.toHaveBeenCalled();
+  });
+
+  it('warns when the PR comment send itself fails', async () => {
+    process.env.GITHUB_TOKEN = 'ghs_x';
+    process.env.GITHUB_REPOSITORY = 'elleVas/cloudrift';
+    process.env.GITHUB_EVENT_PATH = writePullRequestEvent(42);
+    (notifiers.sendGithubPrComment as jest.Mock).mockResolvedValueOnce({ ok: false, error: new Error('boom') });
+
+    await dispatchNotifications({ notifyGithubComment: true }, summary, info);
+
+    expect(info).toHaveBeenCalledWith(expect.stringContaining('failed: boom'));
   });
 
   it('fans out to multiple channels at once', async () => {

--- a/apps/cli/src/commands/notifications.ts
+++ b/apps/cli/src/commands/notifications.ts
@@ -1,12 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 import chalk from 'chalk';
-import type { NotificationSummary, SmtpConfig } from 'shared-notifications';
-import { sendSlackNotification, sendWebhookNotification, sendEmailNotification } from 'shared-notifications';
+import { readFileSync } from 'node:fs';
+import type { GithubPrContext, NotificationSummary, SmtpConfig } from 'shared-notifications';
+import { sendSlackNotification, sendWebhookNotification, sendEmailNotification, sendGithubPrComment } from 'shared-notifications';
 
 export interface NotifyFlags {
   notifySlack?: boolean;
   notifyWebhook?: boolean;
   notifyEmail?: string;
+  notifyGithubComment?: boolean;
   /**
    * Set only by the interactive wizard: a human explicitly asked to email
    * *this* report, the same "want a PDF too?" kind of one-off choice — not
@@ -47,6 +49,37 @@ function resolveSmtpConfig(): SmtpConfig | undefined {
   const from = process.env.CLOUDRIFT_SMTP_FROM;
   if (!host || !port || !user || !password || !from) return undefined;
   return { host, port: Number(port), user, password, from };
+}
+
+/**
+ * `GITHUB_TOKEN`/`GITHUB_REPOSITORY` are only two of three needed pieces:
+ * unlike a Slack/webhook URL, the PR number isn't a static secret to put in
+ * an env var — it's read from the triggering event's own payload
+ * (`GITHUB_EVENT_PATH`, `pull_request.number`), the documented, stable
+ * source (as opposed to parsing `GITHUB_REF`'s `refs/pull/<n>/merge`, which
+ * happens to work but isn't the contract). Also `GITHUB_TOKEN` — unlike
+ * `GITHUB_REPOSITORY`/`GITHUB_EVENT_PATH` — is not exported by Actions by
+ * default; the workflow must forward it explicitly (`env: GITHUB_TOKEN:
+ * ${{ github.token }}`), so its absence commonly just means the user hasn't
+ * wired that up yet, not a broken environment.
+ */
+function resolveGithubPrContext(): GithubPrContext | undefined {
+  const token = process.env.GITHUB_TOKEN;
+  const repository = process.env.GITHUB_REPOSITORY;
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  if (!token || !repository || !eventPath) return undefined;
+
+  const [owner, repo] = repository.split('/');
+  if (!owner || !repo) return undefined;
+
+  try {
+    const event = JSON.parse(readFileSync(eventPath, 'utf8'));
+    const prNumber = event.pull_request?.number;
+    if (typeof prNumber !== 'number') return undefined;
+    return { token, owner, repo, prNumber };
+  } catch {
+    return undefined;
+  }
 }
 
 /**
@@ -97,6 +130,24 @@ export async function dispatchNotifications(flags: NotifyFlags, summary: Notific
         sendEmailNotification(smtp, to, summary).then((result) => {
           if (!result.ok) info(chalk.yellow(`  Email notification failed: ${result.error.message}`));
           else info(chalk.green(`  Email notification sent to ${to}.`));
+        }),
+      );
+    }
+  }
+
+  if (flags.notifyGithubComment) {
+    const context = resolveGithubPrContext();
+    if (!context) {
+      info(
+        chalk.yellow(
+          '  --notify-github-comment was set but GITHUB_TOKEN/GITHUB_REPOSITORY/GITHUB_EVENT_PATH are not all set, or this run is not a pull_request event — skipping the PR comment.',
+        ),
+      );
+    } else {
+      tasks.push(
+        sendGithubPrComment(context, summary).then((result) => {
+          if (!result.ok) info(chalk.yellow(`  GitHub PR comment failed: ${result.error.message}`));
+          else info(chalk.green('  GitHub PR comment posted.'));
         }),
       );
     }

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -90,6 +90,7 @@ program
   .option('--notify-slack', 'send a Slack notification if waste exceeds --config\'s costAlertThresholdUsd (or any waste, if unset); reads SLACK_WEBHOOK_URL from env')
   .option('--notify-webhook', 'POST a JSON summary to a webhook under the same condition as --notify-slack; reads CLOUDRIFT_WEBHOOK_URL from env')
   .option('--notify-email <address>', 'email a summary to this address under the same condition as --notify-slack; reads CLOUDRIFT_SMTP_HOST/PORT/USER/PASSWORD/FROM from env')
+  .option('--notify-github-comment', 'post a PR comment under the same condition as --notify-slack; requires GITHUB_TOKEN/GITHUB_REPOSITORY/GITHUB_EVENT_PATH (set by GitHub Actions on a pull_request trigger)')
   .action((options) => analyzeWasteCommand(options));
 
 program
@@ -186,6 +187,7 @@ program
   .option('--notify-slack', 'send a Slack notification if the scan has critical/warning findings; reads SLACK_WEBHOOK_URL from env')
   .option('--notify-webhook', 'POST a JSON summary to a webhook under the same condition as --notify-slack; reads CLOUDRIFT_WEBHOOK_URL from env')
   .option('--notify-email <address>', 'email a summary to this address under the same condition as --notify-slack; reads CLOUDRIFT_SMTP_HOST/PORT/USER/PASSWORD/FROM from env')
+  .option('--notify-github-comment', 'post a PR comment under the same condition as --notify-slack; requires GITHUB_TOKEN/GITHUB_REPOSITORY/GITHUB_EVENT_PATH (set by GitHub Actions on a pull_request trigger)')
   .action((options) => deadResourcesCommand(options));
 
 program
@@ -223,6 +225,7 @@ program
   .option('--notify-slack', 'send a Slack notification if the scan has critical/warning findings; reads SLACK_WEBHOOK_URL from env')
   .option('--notify-webhook', 'POST a JSON summary to a webhook under the same condition as --notify-slack; reads CLOUDRIFT_WEBHOOK_URL from env')
   .option('--notify-email <address>', 'email a summary to this address under the same condition as --notify-slack; reads CLOUDRIFT_SMTP_HOST/PORT/USER/PASSWORD/FROM from env')
+  .option('--notify-github-comment', 'post a PR comment under the same condition as --notify-slack; requires GITHUB_TOKEN/GITHUB_REPOSITORY/GITHUB_EVENT_PATH (set by GitHub Actions on a pull_request trigger)')
   .action((options) => resourceSecurityCommand(options));
 
 program
@@ -247,6 +250,7 @@ program
   .option('--notify-slack', 'with --compare, send a Slack notification if the comparison shows a regression (worse trend); reads SLACK_WEBHOOK_URL from env')
   .option('--notify-webhook', 'with --compare, POST a JSON summary to a webhook under the same condition as --notify-slack; reads CLOUDRIFT_WEBHOOK_URL from env')
   .option('--notify-email <address>', 'with --compare, email a summary to this address under the same condition as --notify-slack; reads CLOUDRIFT_SMTP_HOST/PORT/USER/PASSWORD/FROM from env')
+  .option('--notify-github-comment', 'with --compare, post a PR comment under the same condition as --notify-slack; requires GITHUB_TOKEN/GITHUB_REPOSITORY/GITHUB_EVENT_PATH (set by GitHub Actions on a pull_request trigger)')
   .action((options) => historyCommand(options));
 
 program

--- a/docs/adr/0103-github-pr-comment-notifier.md
+++ b/docs/adr/0103-github-pr-comment-notifier.md
@@ -1,0 +1,67 @@
+# ADR-0103: GitHub PR comment as a fifth notification channel
+
+- **Status:** Accepted (2026-08-21)
+
+## Context
+
+`analyze`/`dead-resources`/`resource-security`/`history --compare` already fan out to Slack, a generic webhook,
+and email via `dispatchNotifications()` (`apps/cli/src/commands/notifications.ts`), each channel a small
+"notifier" function in `libs/shared/notifications` (`sendSlackNotification`, `sendWebhookNotification`,
+`sendEmailNotification`) taking a domain-agnostic `NotificationSummary`. `action.yml` already surfaces the
+markdown report in `$GITHUB_STEP_SUMMARY`, but that only reaches someone who opens the Checks tab — it's easy
+to miss on a PR with several other checks. External feedback (an AWS Ambassador-sourced review of cloudrift)
+named the CI/budget-gate integration as the project's main differentiator over native AWS cost tooling; a PR
+comment that surfaces the same information directly in the PR conversation was identified as the highest-value,
+lowest-effort gap to close.
+
+## Decision
+
+Add a fifth notifier, `sendGithubPrComment` (`libs/shared/notifications/src/github-comment.notifier.ts`), posting
+to `POST /repos/{owner}/{repo}/issues/{pr}/comments` via the plain GitHub REST API (`fetch`, no `@octokit`/
+`@actions/github` dependency — same style as the Slack/generic-webhook notifiers). Wired into `dispatchNotifications`
+as a new `--notify-github-comment` flag, added identically to `--notify-slack`/`--notify-webhook`/`--notify-email`
+on all four commands, and gated by the exact same "worth reporting" condition each command already computes for
+those three channels (`shouldNotifyOnCost`/`shouldNotifyOnSeverity`/`hasRegressed`) — no bespoke "did the CI gate
+fail" check, to avoid a fifth channel behaving differently from the other four for no functional reason.
+
+Context (`owner`, `repo`, `prNumber`, `token`) is resolved from the environment inside the CLI layer
+(`resolveGithubPrContext()`), mirroring `resolveSmtpConfig()`:
+
+- `GITHUB_REPOSITORY` and `GITHUB_EVENT_PATH` are exported by every Actions run automatically.
+- `GITHUB_TOKEN` is not — the workflow (or `action.yml`) must forward it explicitly via `env:`.
+- The PR number comes from the triggering event's own JSON payload (`GITHUB_EVENT_PATH` → `pull_request.number`),
+  not by parsing `GITHUB_REF`'s `refs/pull/<n>/merge` — the payload is the documented, stable source, and this
+  also means a non-`pull_request` trigger (push, cron) cleanly resolves to "skip," not a wrong PR number.
+
+`action.yml` gained a `pr-comment` input (default `false`) that sets `--notify-github-comment` and forwards
+`GITHUB_TOKEN: ${{ github.token }}` only when the input is on, documented as requiring the job to grant
+`permissions: pull-requests: write` — a new, opt-in scope beyond the read-only-AWS story the Action otherwise
+tells.
+
+**Alternatives considered:**
+
+- **A plain YAML step** (`actions/github-script` or `peter-evans/create-or-update-comment`) posting
+  `steps.analyze.outputs.report` directly, no CLI code change. Rejected as the primary path: it would special-case
+  GitHub as a workflow-only integration while every other channel (Slack, webhook, email) lives in the CLI's own
+  Ports & Adapters-flavored notifier layer — inconsistent with the architecture, and untested by the CLI's own
+  Jest suite. (Still available to anyone who'd rather not grant `pull-requests: write` to the composite action
+  and wire their own step instead — `--format markdown` plus any comment-posting action works without this
+  feature at all.)
+- **Firing only on the literal CI-gate exit code (2)**, independent of `shouldNotifyOnCost`. Rejected: `analyze`
+  is the only command with a real exit-code gate today (`applyCostGate`); `dead-resources`/`resource-security`
+  have no equivalent, so a gate-exit-code condition couldn't generalize to all four commands the other channels
+  already support. Reusing the existing notify condition keeps one mental model ("this channel fires exactly
+  when Slack would") instead of a sixth new set of semantics.
+
+## Consequences
+
+Comment body is markdown, includes the full `summary.lines` (unlike Slack's deliberately title-only alert —
+a PR comment isn't a shared ambient channel a busy pipeline could flood, so the "wall of text" concern that
+shaped `slack-webhook.notifier.ts` doesn't apply here).
+
+Best-effort, never-throws, same contract as every other notifier: a missing token, a closed PR, or a GitHub API
+error logs a warning and never fails the scan.
+
+New tests: `github-comment.notifier.spec.ts` (7 cases) and `notifications.spec.ts` additions (4 cases covering
+the dispatch/skip/failure paths). Verified: `shared-notifications` and `cli` typecheck, lint, and full test
+suites green.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -133,6 +133,12 @@ Each entry follows: Context → Decision → Alternatives Considered → Consequ
 | [0092](0092-csv-output-format.md) | `csv` output format, flat DTO schema, `OUTPUT_FORMATS` consolidated | Accepted |
 | [0093](0093-quick-wins-effort-and-category-bar-chart.md) | Quick-wins ranked by savings/effort, category bar chart in the waste PDF | Accepted |
 
+## Notifications
+
+| ADR | Title | Status |
+|---|---|---|
+| [0103](0103-github-pr-comment-notifier.md) | GitHub PR comment as a fifth notification channel | Accepted |
+
 ## Testing
 
 | ADR | Title | Status |

--- a/docs/en/ci-cd.md
+++ b/docs/en/ci-cd.md
@@ -39,6 +39,31 @@ jobs:
 
 With a `cloudrift.config.json` committed (`{"costAlertThresholdUsd": 500}`), the action fails the check automatically when waste exceeds the budget — the pipeline blocks when newly created resources push it over the threshold. See `action.yml` for every input (`live-pricing`, `scanners`, `min-age-days`, `ignore-tag`, `pdf`, `json`, `format`, `version`, …) and the `report`/`exit-code` outputs.
 
+**PR comment on budget overrun.** Set `pr-comment: true` to also post the report as a comment on the pull request, in addition to the job summary — the same condition that would fail the job (waste over `costAlertThresholdUsd`). Requires the job to grant `permissions: pull-requests: write` and to actually run on a `pull_request` trigger; it's a no-op (with a logged warning, never a failure) on a push/cron run.
+
+```yaml
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  cloudrift:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - uses: elleVas/cloudrift@v0.5.1
+        with:
+          regions: us-east-1 eu-west-1
+          config: cloudrift.config.json
+          pr-comment: true
+```
+
 **GitHub Actions — building from source:** an alternative if you'd rather pin to an unreleased commit instead of a published version.
 
 ```yaml

--- a/docs/en/usage.md
+++ b/docs/en/usage.md
@@ -46,6 +46,7 @@ node apps/cli/dist/main.js analyze [options]
 | `--notify-slack`             | Send a Slack notification if waste exceeds `costAlertThresholdUsd` (or any waste, if unset). Reads `SLACK_WEBHOOK_URL` from env | off |
 | `--notify-webhook`           | POST a JSON summary to a webhook, same condition as `--notify-slack`. Reads `CLOUDRIFT_WEBHOOK_URL` from env  | off                |
 | `--notify-email <address>`   | Email a summary to this address, same condition as `--notify-slack`. Reads `CLOUDRIFT_SMTP_HOST`/`PORT`/`USER`/`PASSWORD`/`FROM` from env | off |
+| `--notify-github-comment`   | Post a PR comment, same condition as `--notify-slack`. Requires `GITHUB_TOKEN`/`GITHUB_REPOSITORY`/`GITHUB_EVENT_PATH` (set by GitHub Actions on a `pull_request` trigger) | off |
 | `-h, --help`                 | Show help                                                                                                      | —                  |
 
 > **stdout vs. file artifacts:** `--format` controls what goes to **stdout** (the report itself). `--json` / `--pdf` / `--csv` write **additional files** to disk and are independent of `--format` — by default the chosen `--format` still prints to stdout *in addition to* writing those files (so e.g. `--pdf` alone still shows the table by default). Add `--silent` for file-only output with nothing printed to the terminal. In machine-readable formats (`json`, `markdown`, `csv`) all human messages are routed to stderr, so stdout carries only the report — ideal for piping. Errors and the cost-gate alert always surface on stderr, even with `--silent`.
@@ -212,6 +213,7 @@ node apps/cli/dist/main.js dead-resources [options]
 | `--notify-slack`             | Send a Slack notification if the scan has critical/warning findings. Reads `SLACK_WEBHOOK_URL` from env        | off                |
 | `--notify-webhook`           | POST a JSON summary to a webhook, same condition as `--notify-slack`. Reads `CLOUDRIFT_WEBHOOK_URL` from env   | off                |
 | `--notify-email <address>`   | Email a summary to this address, same condition as `--notify-slack`. Reads `CLOUDRIFT_SMTP_HOST`/`PORT`/`USER`/`PASSWORD`/`FROM` from env | off |
+| `--notify-github-comment`    | Post a PR comment, same condition as `--notify-slack`. Requires `GITHUB_TOKEN`/`GITHUB_REPOSITORY`/`GITHUB_EVENT_PATH` (set by GitHub Actions on a `pull_request` trigger) | off |
 | `-h, --help`                 | Show help                                                                                                       | —                  |
 
 **Checks:**
@@ -283,6 +285,7 @@ node apps/cli/dist/main.js resource-security [options]
 | `--notify-slack`             | Send a Slack notification if the scan has critical/warning findings. Reads `SLACK_WEBHOOK_URL` from env        | off                |
 | `--notify-webhook`           | POST a JSON summary to a webhook, same condition as `--notify-slack`. Reads `CLOUDRIFT_WEBHOOK_URL` from env   | off                |
 | `--notify-email <address>`   | Email a summary to this address, same condition as `--notify-slack`. Reads `CLOUDRIFT_SMTP_HOST`/`PORT`/`USER`/`PASSWORD`/`FROM` from env | off |
+| `--notify-github-comment`    | Post a PR comment, same condition as `--notify-slack`. Requires `GITHUB_TOKEN`/`GITHUB_REPOSITORY`/`GITHUB_EVENT_PATH` (set by GitHub Actions on a `pull_request` trigger) | off |
 | `-h, --help`                 | Show help                                                                                                       | —                  |
 
 **Checks:**
@@ -373,9 +376,10 @@ node apps/cli/dist/main.js history [options]
 | `--notify-slack`          | With `--compare`, send a Slack notification if the comparison shows a regression (worse trend). Reads `SLACK_WEBHOOK_URL` from env | off |
 | `--notify-webhook`        | With `--compare`, POST a JSON summary to a webhook, same condition as `--notify-slack`. Reads `CLOUDRIFT_WEBHOOK_URL` from env | off |
 | `--notify-email <address>` | With `--compare`, email a summary to this address, same condition as `--notify-slack`. Reads `CLOUDRIFT_SMTP_HOST`/`PORT`/`USER`/`PASSWORD`/`FROM` from env | off |
+| `--notify-github-comment` | With `--compare`, post a PR comment, same condition as `--notify-slack`. Requires `GITHUB_TOKEN`/`GITHUB_REPOSITORY`/`GITHUB_EVENT_PATH` (set by GitHub Actions on a `pull_request` trigger) | off |
 | `-h, --help`              | Show help                                                                          | —               |
 
-> **Notifications (`analyze`/`dead-resources`/`resource-security`/`history --compare`):** `--notify-slack`/`--notify-webhook`/`--notify-email` are best-effort and never fail the scan — a broken webhook or SMTP config logs a warning and moves on. Every credential (`SLACK_WEBHOOK_URL`, `CLOUDRIFT_WEBHOOK_URL`, `CLOUDRIFT_SMTP_*`) comes from the environment, never a flag, so it never lands in shell history or `ps aux` — set them in your shell profile or as CI secrets (e.g. GitHub Actions `secrets.*`), never in a committed file. The interactive wizard offers to email the report too (only when SMTP is already configured), but never asks about Slack/webhook — those are meant for CI/scripts, not a one-off terminal run.
+> **Notifications (`analyze`/`dead-resources`/`resource-security`/`history --compare`):** `--notify-slack`/`--notify-webhook`/`--notify-email`/`--notify-github-comment` are best-effort and never fail the scan — a broken webhook, SMTP config, or GitHub token logs a warning and moves on. Every credential (`SLACK_WEBHOOK_URL`, `CLOUDRIFT_WEBHOOK_URL`, `CLOUDRIFT_SMTP_*`, `GITHUB_TOKEN`) comes from the environment, never a flag, so it never lands in shell history or `ps aux` — set them in your shell profile or as CI secrets (e.g. GitHub Actions `secrets.*`), never in a committed file. `--notify-github-comment` additionally needs `GITHUB_REPOSITORY`/`GITHUB_EVENT_PATH` (exported automatically by GitHub Actions) and only posts on a `pull_request` trigger — it silently skips on a push/cron run, and the job needs `permissions: pull-requests: write`. The interactive wizard offers to email the report too (only when SMTP is already configured), but never asks about Slack/webhook/GitHub comment — those are meant for CI/scripts, not a one-off terminal run.
 
 **Examples:**
 

--- a/docs/it/ci-cd.md
+++ b/docs/it/ci-cd.md
@@ -39,6 +39,31 @@ jobs:
 
 Con un `cloudrift.config.json` committato (`{"costAlertThresholdUsd": 500}`), l'azione fa fallire il check automaticamente quando lo spreco supera il budget — la pipeline si blocca quando nuove risorse lo spingono oltre la soglia. Vedi `action.yml` per tutti gli input (`live-pricing`, `scanners`, `min-age-days`, `ignore-tag`, `pdf`, `json`, `format`, `version`, …) e gli output `report`/`exit-code`.
 
+**Commento sulla PR quando si sfora il budget.** Imposta `pr-comment: true` per pubblicare il report anche come commento sulla pull request, oltre che nel job summary — stessa condizione che farebbe fallire il job (spreco oltre `costAlertThresholdUsd`). Richiede che il job conceda `permissions: pull-requests: write` e che giri effettivamente su un trigger `pull_request`; su un run push/cron è un no-op (con un warning loggato, mai un fallimento).
+
+```yaml
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  cloudrift:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - uses: elleVas/cloudrift@v0.5.1
+        with:
+          regions: us-east-1 eu-west-1
+          config: cloudrift.config.json
+          pr-comment: true
+```
+
 **GitHub Actions — compilando dai sorgenti:** alternativa se preferisci puntare a un commit non ancora rilasciato invece che a una versione pubblicata.
 
 ```yaml

--- a/docs/it/leggimi.md
+++ b/docs/it/leggimi.md
@@ -299,16 +299,17 @@ Vedi [ADR-0099](../adr/0099-local-trend-store.md)/[ADR-0100](../adr/0100-history
 
 ---
 
-### Notifiche (Slack / webhook / email)
+### Notifiche (Slack / webhook / email / commento PR GitHub)
 
-`analyze`, `dead-resources`, `resource-security` e `history --compare` possono inviare un riepilogo a Slack, un webhook generico o via email — `--notify-slack`, `--notify-webhook`, `--notify-email <indirizzo>`. Best-effort e mai bloccante: un webhook rotto logga un warning, lo scan resta inalterato. Scatta solo quando c'è qualcosa da segnalare (finding critical/warning, spreco sopra `costAlertThresholdUsd`, o un trend peggiorato su `history --compare`) — uno scan pulito resta silenzioso. **Su Slack arriva solo un alert** (titolo + conteggi, es. "3 critical, 14 warning, 0 info") — deliberatamente senza il dettaglio dei singoli finding, così una pipeline schedulata su più account non trasforma il canale in un muro di testo illeggibile; webhook ed email includono invece i finding principali, dato che un consumer automatico o una inbox personale possono gestire il dettaglio extra senza affollare un canale condiviso.
+`analyze`, `dead-resources`, `resource-security` e `history --compare` possono inviare un riepilogo a Slack, un webhook generico, via email o come commento su una PR GitHub — `--notify-slack`, `--notify-webhook`, `--notify-email <indirizzo>`, `--notify-github-comment`. Best-effort e mai bloccante: un webhook rotto logga un warning, lo scan resta inalterato. Scatta solo quando c'è qualcosa da segnalare (finding critical/warning, spreco sopra `costAlertThresholdUsd`, o un trend peggiorato su `history --compare`) — uno scan pulito resta silenzioso. **Su Slack arriva solo un alert** (titolo + conteggi, es. "3 critical, 14 warning, 0 info") — deliberatamente senza il dettaglio dei singoli finding, così una pipeline schedulata su più account non trasforma il canale in un muro di testo illeggibile; webhook, email e commento PR includono invece i finding principali, dato che un consumer automatico, una inbox personale o chi revisiona la PR possono gestire il dettaglio extra senza affollare un canale condiviso.
 
 ```sh
 cloudrift resource-security --notify-slack
 cloudrift analyze --notify-email team@esempio.com
+cloudrift analyze --notify-github-comment
 ```
 
-Ogni credenziale (`SLACK_WEBHOOK_URL`, `CLOUDRIFT_WEBHOOK_URL`, `CLOUDRIFT_SMTP_HOST`/`PORT`/`USER`/`PASSWORD`/`FROM`) viene letta dall'ambiente, mai da un flag — impostala nella tua shell o come secret di CI, mai in un file committato. Vedi [utilizzo.md](./utilizzo.md#history--storico-locale-delle-scansioni) per il riferimento completo.
+Ogni credenziale (`SLACK_WEBHOOK_URL`, `CLOUDRIFT_WEBHOOK_URL`, `CLOUDRIFT_SMTP_HOST`/`PORT`/`USER`/`PASSWORD`/`FROM`, `GITHUB_TOKEN`) viene letta dall'ambiente, mai da un flag — impostala nella tua shell o come secret di CI, mai in un file committato. `--notify-github-comment` richiede anche `GITHUB_REPOSITORY`/`GITHUB_EVENT_PATH` (impostate automaticamente da GitHub Actions) e posta solo su un trigger `pull_request`; vedi l'input `pr-comment` di [`action.yml`](../../action.yml) per il modo più rapido di attivarlo dalla Action riutilizzabile. Vedi [utilizzo.md](./utilizzo.md#history--storico-locale-delle-scansioni) per il riferimento completo.
 
 ---
 

--- a/docs/it/utilizzo.md
+++ b/docs/it/utilizzo.md
@@ -46,6 +46,7 @@ node apps/cli/dist/main.js analyze [opzioni]
 | `--notify-slack`             | Invia una notifica Slack se lo spreco supera `costAlertThresholdUsd` (o qualsiasi spreco, se non impostato). Legge `SLACK_WEBHOOK_URL` dall'env | off |
 | `--notify-webhook`           | Invia via POST un riepilogo JSON a un webhook, stessa condizione di `--notify-slack`. Legge `CLOUDRIFT_WEBHOOK_URL` dall'env | off |
 | `--notify-email <indirizzo>` | Invia via email un riepilogo a questo indirizzo, stessa condizione di `--notify-slack`. Legge `CLOUDRIFT_SMTP_HOST`/`PORT`/`USER`/`PASSWORD`/`FROM` dall'env | off |
+| `--notify-github-comment`    | Posta un commento sulla PR, stessa condizione di `--notify-slack`. Richiede `GITHUB_TOKEN`/`GITHUB_REPOSITORY`/`GITHUB_EVENT_PATH` (impostate da GitHub Actions su un trigger `pull_request`) | off |
 | `-h, --help`                 | Mostra l'help                                                                                                        | —                  |
 
 > **stdout vs. file:** `--format` controlla cosa va su **stdout** (il report). `--json` / `--pdf` / `--csv` scrivono **file aggiuntivi** su disco, indipendenti da `--format` — di default il `--format` scelto continua comunque a essere stampato su stdout *in aggiunta* alla scrittura di quei file (quindi es. `--pdf` da solo mostra comunque la tabella). Aggiungi `--silent` per ottenere solo il file, senza nulla stampato a terminale. Nei formati machine-readable (`json`, `markdown`, `csv`) tutti i messaggi umani vanno su stderr, così su stdout resta solo il report — ideale per il piping. Errori e l'alert della soglia di costo vanno sempre su stderr, anche con `--silent`.
@@ -227,6 +228,7 @@ node apps/cli/dist/main.js dead-resources [opzioni]
 | `--notify-slack`             | Invia una notifica Slack se lo scan ha finding critical/warning. Legge `SLACK_WEBHOOK_URL` dall'env             | off                |
 | `--notify-webhook`           | Invia via POST un riepilogo JSON a un webhook, stessa condizione di `--notify-slack`. Legge `CLOUDRIFT_WEBHOOK_URL` dall'env | off |
 | `--notify-email <indirizzo>` | Invia via email un riepilogo a questo indirizzo, stessa condizione di `--notify-slack`. Legge `CLOUDRIFT_SMTP_HOST`/`PORT`/`USER`/`PASSWORD`/`FROM` dall'env | off |
+| `--notify-github-comment`    | Posta un commento sulla PR, stessa condizione di `--notify-slack`. Richiede `GITHUB_TOKEN`/`GITHUB_REPOSITORY`/`GITHUB_EVENT_PATH` (impostate da GitHub Actions su un trigger `pull_request`) | off |
 | `-h, --help`                 | Mostra l'help                                                                                                    | —                  |
 
 **Check:**
@@ -298,6 +300,7 @@ node apps/cli/dist/main.js resource-security [opzioni]
 | `--notify-slack`             | Invia una notifica Slack se lo scan ha finding critical/warning. Legge `SLACK_WEBHOOK_URL` dall'env             | off                |
 | `--notify-webhook`           | Invia via POST un riepilogo JSON a un webhook, stessa condizione di `--notify-slack`. Legge `CLOUDRIFT_WEBHOOK_URL` dall'env | off |
 | `--notify-email <indirizzo>` | Invia via email un riepilogo a questo indirizzo, stessa condizione di `--notify-slack`. Legge `CLOUDRIFT_SMTP_HOST`/`PORT`/`USER`/`PASSWORD`/`FROM` dall'env | off |
+| `--notify-github-comment`    | Posta un commento sulla PR, stessa condizione di `--notify-slack`. Richiede `GITHUB_TOKEN`/`GITHUB_REPOSITORY`/`GITHUB_EVENT_PATH` (impostate da GitHub Actions su un trigger `pull_request`) | off |
 | `-h, --help`                 | Mostra l'help                                                                                                   | —                  |
 
 **Check:**
@@ -388,9 +391,10 @@ node apps/cli/dist/main.js history [options]
 | `--notify-slack`          | Con `--compare`, invia una notifica Slack se il confronto mostra un peggioramento (trend peggiore). Legge `SLACK_WEBHOOK_URL` dall'env | off |
 | `--notify-webhook`        | Con `--compare`, invia via POST un riepilogo JSON a un webhook, stessa condizione di `--notify-slack`. Legge `CLOUDRIFT_WEBHOOK_URL` dall'env | off |
 | `--notify-email <indirizzo>` | Con `--compare`, invia via email un riepilogo a questo indirizzo, stessa condizione di `--notify-slack`. Legge `CLOUDRIFT_SMTP_HOST`/`PORT`/`USER`/`PASSWORD`/`FROM` dall'env | off |
+| `--notify-github-comment` | Con `--compare`, posta un commento sulla PR, stessa condizione di `--notify-slack`. Richiede `GITHUB_TOKEN`/`GITHUB_REPOSITORY`/`GITHUB_EVENT_PATH` (impostate da GitHub Actions su un trigger `pull_request`) | off |
 | `-h, --help`              | Mostra l'help                                                                       | —               |
 
-> **Notifiche (`analyze`/`dead-resources`/`resource-security`/`history --compare`):** `--notify-slack`/`--notify-webhook`/`--notify-email` sono best-effort e non fanno mai fallire lo scan — un webhook rotto o una config SMTP errata loggano un warning e proseguono. Ogni credenziale (`SLACK_WEBHOOK_URL`, `CLOUDRIFT_WEBHOOK_URL`, `CLOUDRIFT_SMTP_*`) viene letta dall'ambiente, mai da un flag, quindi non finisce mai nella shell history o in `ps aux` — impostale nel profilo della tua shell o come secret di CI (es. `secrets.*` di GitHub Actions), mai in un file committato. Il wizard interattivo offre anche di inviare il report via email (solo se l'SMTP è già configurato), ma non chiede mai di Slack/webhook — quelli sono pensati per CI/script, non per un'esecuzione interattiva occasionale.
+> **Notifiche (`analyze`/`dead-resources`/`resource-security`/`history --compare`):** `--notify-slack`/`--notify-webhook`/`--notify-email`/`--notify-github-comment` sono best-effort e non fanno mai fallire lo scan — un webhook rotto, una config SMTP errata o un token GitHub mancante loggano un warning e proseguono. Ogni credenziale (`SLACK_WEBHOOK_URL`, `CLOUDRIFT_WEBHOOK_URL`, `CLOUDRIFT_SMTP_*`, `GITHUB_TOKEN`) viene letta dall'ambiente, mai da un flag, quindi non finisce mai nella shell history o in `ps aux` — impostale nel profilo della tua shell o come secret di CI (es. `secrets.*` di GitHub Actions), mai in un file committato. `--notify-github-comment` richiede anche `GITHUB_REPOSITORY`/`GITHUB_EVENT_PATH` (esportate automaticamente da GitHub Actions) e posta solo su un trigger `pull_request` — su un run push/cron viene saltato silenziosamente, e il job necessita di `permissions: pull-requests: write`. Il wizard interattivo offre anche di inviare il report via email (solo se l'SMTP è già configurato), ma non chiede mai di Slack/webhook/commento GitHub — quelli sono pensati per CI/script, non per un'esecuzione interattiva occasionale.
 
 **Esempi:**
 

--- a/libs/shared/notifications/src/github-comment.notifier.spec.ts
+++ b/libs/shared/notifications/src/github-comment.notifier.spec.ts
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+import { sendGithubPrComment } from './github-comment.notifier';
+import type { NotificationSummary } from './types';
+
+const summary: NotificationSummary = {
+  title: 'cloudrift analyze — $123.45/mo wasted (account 123456789012)',
+  domain: 'cloud-cost',
+  accountId: '123456789012',
+  generatedAt: new Date('2026-08-21'),
+  lines: ['ec2-instance-stopped: stopped for 45 days ($30.00/mo)', 'ebs-volume-unattached: unattached ($5.00/mo)'],
+};
+
+const context = { token: 'ghs_x', owner: 'elleVas', repo: 'cloudrift', prNumber: 42 };
+
+function postedBody(mockFetch: jest.Mock) {
+  return JSON.parse(mockFetch.mock.calls[0][1].body).body as string;
+}
+
+describe('sendGithubPrComment', () => {
+  const mockFetch = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = mockFetch;
+    mockFetch.mockResolvedValue({ ok: true, status: 201, statusText: 'Created' });
+  });
+
+  it('posts to the issues/comments endpoint for the given owner/repo/PR', async () => {
+    const result = await sendGithubPrComment(context, summary);
+
+    expect(result.ok).toBe(true);
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://api.github.com/repos/elleVas/cloudrift/issues/42/comments',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer ghs_x',
+          Accept: 'application/vnd.github+json',
+          'User-Agent': 'cloudrift-cli',
+        }),
+      }),
+    );
+  });
+
+  it('includes the title (bolded) and every line, unlike the Slack notifier', async () => {
+    await sendGithubPrComment(context, summary);
+
+    const body = postedBody(mockFetch);
+    expect(body).toContain(`**${summary.title}**`);
+    expect(body).toContain('ec2-instance-stopped: stopped for 45 days ($30.00/mo)');
+    expect(body).toContain('ebs-volume-unattached: unattached ($5.00/mo)');
+  });
+
+  it('renders severity counts when present', async () => {
+    await sendGithubPrComment(context, { ...summary, domain: 'resource-security', countBySeverity: { critical: 2, warning: 1, info: 0 } });
+
+    expect(postedBody(mockFetch)).toContain('2 critical, 1 warning, 0 info — account `123456789012`');
+  });
+
+  it('falls back to a plain account line when there is no severity concept', async () => {
+    await sendGithubPrComment(context, summary);
+
+    expect(postedBody(mockFetch)).toContain('Account: `123456789012`');
+  });
+
+  it('returns Result.fail when the GitHub API responds with a non-2xx status', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 404, statusText: 'Not Found' });
+
+    const result = await sendGithubPrComment(context, summary);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toContain('404');
+  });
+
+  it('returns Result.fail instead of throwing on a network error', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('ENOTFOUND'));
+
+    const result = await sendGithubPrComment(context, summary);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toBe('ENOTFOUND');
+  });
+});

--- a/libs/shared/notifications/src/github-comment.notifier.ts
+++ b/libs/shared/notifications/src/github-comment.notifier.ts
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+import { Result } from 'shared-kernel';
+import type { NotificationSummary } from './types';
+
+export interface GithubPrContext {
+  token: string;
+  owner: string;
+  repo: string;
+  prNumber: number;
+}
+
+/**
+ * Markdown, not the plain text `email.notifier.ts` builds — this lands verbatim
+ * in a PR's comment thread, which renders `**`/`-` natively. Includes
+ * `summary.lines` in full: unlike Slack (`slack-webhook.notifier.ts`), a PR
+ * comment isn't a shared ambient channel that a busy pipeline could flood, so
+ * the same "wall of text" concern that keeps Slack to a title-only alert
+ * doesn't apply here — the reviewer opened this PR and wants the detail.
+ */
+function buildCommentBody(summary: NotificationSummary): string {
+  const lines = [`**${summary.title}**`, ''];
+  if (summary.countBySeverity) {
+    const { critical, warning, info } = summary.countBySeverity;
+    lines.push(`${critical} critical, ${warning} warning, ${info} info — account \`${summary.accountId}\``, '');
+  } else {
+    lines.push(`Account: \`${summary.accountId}\``, '');
+  }
+  lines.push(...summary.lines.map((line) => `- ${line}`));
+  return lines.join('\n');
+}
+
+/**
+ * Posts a comment to the pull request identified by `context`, via the plain
+ * GitHub REST API (no `@octokit`/`@actions/github` dependency, same
+ * fetch-only style as the Slack/generic-webhook notifiers). `User-Agent` is
+ * required by GitHub's API for non-browser clients; omitting it is a 403, not
+ * a helpful error. Same never-throws, best-effort contract as every other
+ * notifier here — a broken token or a deleted PR must never fail the scan.
+ */
+export async function sendGithubPrComment(context: GithubPrContext, summary: NotificationSummary): Promise<Result<void>> {
+  try {
+    const response = await fetch(`https://api.github.com/repos/${context.owner}/${context.repo}/issues/${context.prNumber}/comments`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${context.token}`,
+        Accept: 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+        'Content-Type': 'application/json',
+        'User-Agent': 'cloudrift-cli',
+      },
+      body: JSON.stringify({ body: buildCommentBody(summary) }),
+    });
+    if (!response.ok) {
+      return Result.fail(new Error(`GitHub API returned ${response.status} ${response.statusText}`));
+    }
+    return Result.ok(undefined);
+  } catch (err) {
+    return Result.fail(err instanceof Error ? err : new Error(String(err)));
+  }
+}

--- a/libs/shared/notifications/src/index.ts
+++ b/libs/shared/notifications/src/index.ts
@@ -5,3 +5,5 @@ export { sendSlackNotification } from './slack-webhook.notifier';
 export { sendWebhookNotification } from './generic-webhook.notifier';
 export { sendEmailNotification } from './email.notifier';
 export type { SmtpConfig } from './email.notifier';
+export { sendGithubPrComment } from './github-comment.notifier';
+export type { GithubPrContext } from './github-comment.notifier';


### PR DESCRIPTION
## Summary
- Adds a fifth notification channel, `--notify-github-comment`, posting the report as a PR comment under the same condition as `--notify-slack`/`--notify-webhook`/`--notify-email`
- New `action.yml` input `pr-comment: true` wires it into the reusable Action (requires `permissions: pull-requests: write`)
- Docs updated (README, usage/ci-cd guides EN+IT), ADR-0103 documents the design and rejected alternatives

## Test plan
- [x] `nx test shared-notifications` — 32/32 passing (7 new)
- [x] `nx test cli` — 311/311 passing (4 new)
- [x] `nx typecheck`/`nx lint` clean on both projects